### PR TITLE
Setting/#5 dicontainer 세팅

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/App/DIContainer+.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/DIContainer+.swift
@@ -1,0 +1,16 @@
+//
+//  DependencyInjection.swift
+//  ByeBoo-iOS
+//
+//  Created by 최주리 on 6/30/25.
+//
+
+extension DIContainer {
+    /// assemble 하는 순서는 data의 repository -> domain의 useCase -> presentation의 viewmodel
+    func dependencyInject() {
+        let dataAssembler = DataDependencyAssembler()
+        let domainAssembler = DomainDependencyAssembler(preAssembler: dataAssembler)
+        let presentationAssembler = PresentationDependencyAssembler(preAssembler: domainAssembler)
+        presentationAssembler.assemble()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
@@ -18,6 +18,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
+        DIContainer.shared.dependencyInject()
+        guard let testViewModel = DIContainer.shared.resolve(type: TestViewModel.self) else {
+            // TODO: Logger로 대체하기
+            print("❌ DI 실패")
+            return
+        }
+//        let testViewController = TestViewController(viewModel: testViewModel)
+        
         let viewController = ViewController()
         let navigationController = UINavigationController(rootViewController: viewController)
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Core/DIContainer.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/DIContainer.swift
@@ -1,0 +1,30 @@
+//
+//  DIContainer.swift
+//  ByeBoo-iOS
+//
+//  Created by 최주리 on 6/30/25.
+//
+
+final class DIContainer {
+    static let shared = DIContainer()
+    // container에 등록된 의존성 객체를 꺼내서 등록해야하니까 DIContainer를 필요로 함
+    private var storage: [String: (DIContainer) -> Any] = [:]
+    
+    private init() { }
+    
+    /// 의존성을 클로저 형태로 딕셔너리에 저장
+    /// type: 프로토콜의 타입
+    /// clousure:  실제 의존성 객체 return
+    func register<T>(type: T.Type, closure: @escaping (DIContainer) -> Any) {
+        storage["\(type)"] = closure
+    }
+    
+    /// 실제 사용할 때 클로저로 저장된 의존성을 객체화
+    func resolve<T>(type: T.Type) -> T? {
+        guard let dependency = storage["\(type)"]?(self) as? T else {
+            return nil
+        }
+        
+        return dependency
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Core/DIContainer.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/DIContainer.swift
@@ -4,6 +4,11 @@
 //
 //  Created by 최주리 on 6/30/25.
 //
+import Foundation
+
+protocol DependencyAssembler {
+    func assemble()
+}
 
 final class DIContainer {
     static let shared = DIContainer()

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
@@ -1,0 +1,22 @@
+//
+//  DataDependencyAssembler.swift
+//  ByeBoo-iOS
+//
+//  Created by 최주리 on 6/30/25.
+//
+
+import Foundation
+
+struct DataDependencyAssembler: DependencyAssembler {
+    private let networkService: NetworkService = DefaultNetworkService()
+    private let keychainService: KeychainService = DefaultKeychainService()
+    private let userDefaultService: UserDefaultService = DefaultUserDefaultService()
+    
+    func assemble() {
+        DIContainer.shared.register(type: TestInterface.self) { _ in
+            return DefaultTestRepository(network: networkService, keychain: keychainService)
+        }
+        
+        // repository dependency 추가 여기서...
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -1,0 +1,26 @@
+//
+//  DomainDependencyAssembler.swift
+//  ByeBoo-iOS
+//
+//  Created by 최주리 on 6/30/25.
+//
+
+import Foundation
+
+struct DomainDependencyAssembler: DependencyAssembler {
+    private let preAssembler: DependencyAssembler
+    
+    init(preAssembler: DependencyAssembler) {
+        self.preAssembler = preAssembler
+    }
+    
+    func assemble() {
+        preAssembler.assemble()
+        
+        guard let testRepository = DIContainer.shared.resolve(type: TestInterface.self) else { return }
+        
+        DIContainer.shared.register(type: TestUseCase.self) { container in
+            return DefaultTestUseCase(testRepository: testRepository)
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/TestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/TestViewController.swift
@@ -5,3 +5,22 @@
 //  Created by 최주리 on 6/28/25.
 //
 
+import UIKit
+
+class TestViewController: UIViewController {
+    
+    private let viewModel: TestViewModel
+    
+    init(viewModel: TestViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -1,0 +1,26 @@
+//
+//  PresentationDependencyAssembler.swift
+//  ByeBoo-iOS
+//
+//  Created by 최주리 on 6/30/25.
+//
+
+import Foundation
+
+struct PresentationDependencyAssembler: DependencyAssembler {
+    private let preAssembler: DependencyAssembler
+    
+    init(preAssembler: DependencyAssembler) {
+        self.preAssembler = preAssembler
+    }
+    
+    func assemble() {
+        preAssembler.assemble()
+        
+        DIContainer.shared.register(type: TestViewModel.self) { container in
+            guard let testUseCase = container.resolve(type: TestUseCase.self) else { return }
+            
+            return TestViewModel(testUseCase: testUseCase)
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #5 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- DIContainer 구현
- Assembler 구현

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`DIContainer`
- `register`에서는 딕셔너리에 클로저를 저장합니다! (아직 객체 생성 전)
- `resolve`에서는 딕셔너리에 저장된 클로저를 실행하여 객체를 생성합니다.
- `dependencyInject`에서는 순서에 맞게 의존성을 조립합니다.
```swift
final class DIContainer {
    static let shared = DIContainer()
    // container에 등록된 의존성 객체를 꺼내서 등록해야하니까 DIContainer를 필요로 함
    private var storage: [String: (DIContainer) -> Any] = [:]
    
    private init() { }
    
    /// 의존성을 클로저 형태로 딕셔너리에 저장
    /// type: 프로토콜의 타입
    /// clousure:  실제 의존성 객체 return
    func register<T>(type: T.Type, closure: @escaping (DIContainer) -> Any) {
        storage["\(type)"] = closure
    }
    
    /// 실제 사용할 때 클로저로 저장된 의존성을 객체화
    func resolve<T>(type: T.Type) -> T? {
        guard let dependency = storage["\(type)"]?(self) as? T else {
            return nil
        }
        
        return dependency
    }
}

extension DIContainer {
    /// assemble 하는 순서는 data의 repository -> domain의 useCase -> presentation의 viewmodel
    func dependencyInject() {
        let dataAssembler = DataDependencyAssembler()
        let domainAssembler = DomainDependencyAssembler(preAssembler: dataAssembler)
        let presentationAssembler = PresentationDependencyAssembler(preAssembler: domainAssembler)
        presentationAssembler.assemble()
    }
}

```

`SceneDelegate`
- ViewController를 생성할 때 ViewModel이 필요한데, 이 때 ViewModel을 resolve(객체 생성)하여 ViewController에 주입합니다.
```
        guard let windowScene = (scene as? UIWindowScene) else { return }
        
        DIContainer.shared.dependencyInject()
        guard let testViewModel = DIContainer.shared.resolve(type: TestViewModel.self) else {
            // TODO: Logger로 대체하기
            print("❌ DI 실패")
            return
        }
        let testViewController = TestViewController(viewModel: testViewModel)
```

`DomainDependencyAssembler`
- `assemble()`: 필요한 의존성을 register (의존성을 register하기 위한 다른 의존성을 resolve하기도 함)
- `preAssembler`: domain의 usecase를 생성하기 위해 필요한 repository 의존성을 등록한 것을 받아옴
```
struct DomainDependencyAssembler: DependencyAssembler {
    private let preAssembler: DependencyAssembler
    
    init(preAssembler: DependencyAssembler) {
        self.preAssembler = preAssembler
    }
    
    func assemble() {
        preAssembler.assemble()
        
        guard let testRepository = DIContainer.shared.resolve(type: TestInterface.self) else { return }
        
        DIContainer.shared.register(type: TestUseCase.self) { container in
            return DefaultTestUseCase(testRepository: testRepository)
        }
    }
}

```
- 해당 코드에서  `DIContainer.shared.register(type: TestUseCase.self)`뒤에 적힌 클로저가 DIContainer의 딕셔너리에 저장되는 클로저 입니다!

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 어렵네요... 저도 100프로 이해하지 못해서 질문하고 답변하면서 부족한 부분 채워나가요 ! 
