### PR TITLE
Setting/#8 Combine 및 MVVM 세팅

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		18A8172D2E154F3D00F68F9F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 18A8172C2E154F3D00F68F9F /* Alamofire */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		CB41808B2E0925D2001E7BCB /* ByeBoo-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ByeBoo-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -36,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18A8172D2E154F3D00F68F9F /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +83,7 @@
 			);
 			name = "ByeBoo-iOS";
 			packageProductDependencies = (
+				18A8172C2E154F3D00F68F9F /* Alamofire */,
 			);
 			productName = "ByeBoo-iOS";
 			productReference = CB41808B2E0925D2001E7BCB /* ByeBoo-iOS.app */;
@@ -107,6 +113,9 @@
 			);
 			mainGroup = CB4180822E0925D2001E7BCB;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				18A8172B2E154F3D00F68F9F /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CB41808C2E0925D2001E7BCB /* Products */;
 			projectDirPath = "";
@@ -341,6 +350,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		18A8172B2E154F3D00F68F9F /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		18A8172C2E154F3D00F68F9F /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 18A8172B2E154F3D00F68F9F /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CB4180832E0925D2001E7BCB /* Project object */;
 }

--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e8f130fe30ac6cdc940ef06ee1e8535e9f46ffee6aeead1722b9525562f6ce08",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 final class CombineTestViewController: UIViewController {
     
     private let viewModel: CombineTestViewModel
-    private let input = PassthroughSubject<CombineTestViewModel.InputAction, Never>()
+    //private let input = PassthroughSubject<CombineTestViewModel.InputAction, Never>()
     private var cancellables = Set<AnyCancellable>()
     
     init(viewModel: CombineTestViewModel) {
@@ -22,9 +22,7 @@ final class CombineTestViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         dataBind()
-        // 테스트용으로 명시한 것으로, 실제 앱에서는 input은 버튼 클릭 등 사용자 액션에서 전달됩니다.
-        input.send(.first)
-        input.send(.second)
+        viewModel.action(.first)
     }
     
     required init?(coder: NSCoder) {
@@ -32,11 +30,7 @@ final class CombineTestViewController: UIViewController {
     }
     
     func dataBind() {
-        let output = viewModel.transform(
-            input: CombineTestViewModel.Input(event: input.eraseToAnyPublisher())
-        )
-        
-        output.result
+        viewModel.result
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 switch result {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
@@ -36,7 +36,7 @@ final class CombineTestViewController: UIViewController {
                 case .success(let entity):
                     self?.updateUI(from: entity)
                 case .failure(let error):
-                    ByeBooLogger.network(error)
+                    ByeBooLogger.error(error)
                 }
             }
             .store(in: &cancellables)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 final class CombineTestViewController: UIViewController {
     
     private let viewModel: CombineTestViewModel
-    //private let input = PassthroughSubject<CombineTestViewModel.InputAction, Never>()
     private var cancellables = Set<AnyCancellable>()
     
     init(viewModel: CombineTestViewModel) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 final class CombineTestViewController: UIViewController {
     
     private let viewModel: CombineTestViewModel
-    private let input = PassthroughSubject<Void, Never>()
+    private let input = PassthroughSubject<CombineTestViewModel.InputAction, Never>()
     private var cancellables = Set<AnyCancellable>()
     
     init(viewModel: CombineTestViewModel) {
@@ -22,6 +22,9 @@ final class CombineTestViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         dataBind()
+        // 테스트용으로 명시한 것으로, 실제 앱에서는 input은 버튼 클릭 등 사용자 액션에서 전달됩니다.
+        input.send(.first)
+        input.send(.second)
     }
     
     required init?(coder: NSCoder) {
@@ -30,15 +33,15 @@ final class CombineTestViewController: UIViewController {
     
     func dataBind() {
         let output = viewModel.transform(
-            input: CombineTestViewModel.Input(publisher: input.eraseToAnyPublisher())
+            input: CombineTestViewModel.Input(event: input.eraseToAnyPublisher())
         )
         
         output.result
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 switch result {
-                case .success(let model):
-                    self?.updateUI(model: model)
+                case .success(let entity):
+                    self?.updateUI(from: entity)
                 case .failure(let error):
                     ByeBooLogger.network(error)
                 }
@@ -46,7 +49,7 @@ final class CombineTestViewController: UIViewController {
             .store(in: &cancellables)
     }
     
-    func updateUI(model: TestViewModel) {
+    func updateUI(from entity: TestEntity) {
         
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
@@ -21,6 +21,7 @@ final class CombineTestViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        dataBind()
     }
     
     required init?(coder: NSCoder) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/CombineTestViewController.swift
@@ -1,0 +1,51 @@
+//
+//  CombineTestViewController.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/1/25.
+//
+
+import Combine
+import UIKit
+
+final class CombineTestViewController: UIViewController {
+    
+    private let viewModel: CombineTestViewModel
+    private let input = PassthroughSubject<Void, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: CombineTestViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func dataBind() {
+        let output = viewModel.transform(
+            input: CombineTestViewModel.Input(publisher: input.eraseToAnyPublisher())
+        )
+        
+        output.result
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let model):
+                    self?.updateUI(model: model)
+                case .failure(let error):
+                    ByeBooLogger.network(error)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    func updateUI(model: TestViewModel) {
+        
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  CombineTestViewModel.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/1/25.
+//
+
+import Combine
+import UIKit
+
+final class CombineTestViewModel: ViewModelType {
+    
+    struct Input {
+        let publisher: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let result: AnyPublisher<Result<TestViewModel, ByeBooError>, Never>
+    }
+    
+    private var output: PassthroughSubject<Result<TestViewModel, ByeBooError>, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
+    
+    private let testuseCase: TestUseCase
+    
+    init(testUseCase: TestUseCase) {
+        self.testuseCase = testUseCase
+    }
+    
+    func transform(input: Input) -> Output {
+        input.publisher
+            .sink { [weak self] _ in
+                self?.fetchTestModel()
+            }
+            .store(in: &cancellables)
+        return Output(result: output.eraseToAnyPublisher())
+    }
+    
+    private func fetchTestModel() {
+//        testuseCase.testFetchModel()
+//            .sink(receiveCompletion: { [weak self] completion in
+//                if case .failure(let error) = completion {
+//                    self?.output.send(.failure(error))
+//                }
+//            }, receiveValue: { [weak self] model in
+//                self?.output.send(.success(model))
+//            })
+//            .store(in: &cancellables)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
@@ -10,41 +10,53 @@ import UIKit
 
 final class CombineTestViewModel: ViewModelType {
     
+    enum InputAction {
+        case first
+        case second
+    }
+    
     struct Input {
-        let publisher: AnyPublisher<Void, Never>
+        let event: AnyPublisher<InputAction, Never>
     }
     
     struct Output {
-        let result: AnyPublisher<Result<TestViewModel, ByeBooError>, Never>
+        let result: AnyPublisher<Result<TestEntity, ByeBooError>, Never>
     }
     
-    private var output: PassthroughSubject<Result<TestViewModel, ByeBooError>, Never> = .init()
+    private var output: PassthroughSubject<Result<TestEntity, ByeBooError>, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     
-    private let testuseCase: TestUseCase
+    private let testUseCase: TestUseCase
     
     init(testUseCase: TestUseCase) {
-        self.testuseCase = testUseCase
+        self.testUseCase = testUseCase
     }
     
     func transform(input: Input) -> Output {
-        input.publisher
-            .sink { [weak self] _ in
-                self?.fetchTestModel()
+        input.event
+            .sink { [weak self] action in
+                switch action {
+                case .first:
+                    self?.fetchTestModel()
+                case .second:
+                    self?.fetchTestModel()
+                }
             }
             .store(in: &cancellables)
         return Output(result: output.eraseToAnyPublisher())
     }
     
     private func fetchTestModel() {
-//        testuseCase.testFetchModel()
-//            .sink(receiveCompletion: { [weak self] completion in
-//                if case .failure(let error) = completion {
-//                    self?.output.send(.failure(error))
-//                }
-//            }, receiveValue: { [weak self] model in
-//                self?.output.send(.success(model))
-//            })
-//            .store(in: &cancellables)
+        Task { [weak self] in
+            guard let self else { return }
+            
+            do {
+                let name = try await testUseCase.testFetchUserName()
+                output.send(.success(TestEntity(name: name, birth: "")))
+            } catch {
+                guard let error = error as? ByeBooError else { return }
+                output.send(.failure(error))
+            }
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
@@ -15,10 +15,6 @@ final class CombineTestViewModel: ViewModelType {
         case second
     }
     
-    struct Input {
-        let event: AnyPublisher<InputAction, Never>
-    }
-    
     struct Output {
         let result: AnyPublisher<Result<TestEntity, ByeBooError>, Never>
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/CombineTestViewModel.swift
@@ -23,7 +23,10 @@ final class CombineTestViewModel: ViewModelType {
         let result: AnyPublisher<Result<TestEntity, ByeBooError>, Never>
     }
     
-    private var output: PassthroughSubject<Result<TestEntity, ByeBooError>, Never> = .init()
+    private var resultSubject: PassthroughSubject<Result<TestEntity, ByeBooError>, Never> = .init()
+    var result: AnyPublisher<Result<TestEntity, ByeBooError>, Never> {
+        resultSubject.eraseToAnyPublisher()
+    }
     private var cancellables = Set<AnyCancellable>()
     
     private let testUseCase: TestUseCase
@@ -32,18 +35,11 @@ final class CombineTestViewModel: ViewModelType {
         self.testUseCase = testUseCase
     }
     
-    func transform(input: Input) -> Output {
-        input.event
-            .sink { [weak self] action in
-                switch action {
-                case .first:
-                    self?.fetchTestModel()
-                case .second:
-                    self?.fetchTestModel()
-                }
-            }
-            .store(in: &cancellables)
-        return Output(result: output.eraseToAnyPublisher())
+    func action(_ trigger: InputAction) {
+        switch trigger {
+        case .first, .second:
+            fetchTestModel()
+        }
     }
     
     private func fetchTestModel() {
@@ -52,10 +48,10 @@ final class CombineTestViewModel: ViewModelType {
             
             do {
                 let name = try await testUseCase.testFetchUserName()
-                output.send(.success(TestEntity(name: name, birth: "")))
+                resultSubject.send(.success(TestEntity(name: name, birth: "")))
             } catch {
                 guard let error = error as? ByeBooError else { return }
-                output.send(.failure(error))
+                resultSubject.send(.failure(error))
             }
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
@@ -1,0 +1,13 @@
+//
+//  ViewModelType.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/1/25.
+//
+
+protocol ViewModelType {
+    associatedtype Input
+    associatedtype Output
+    
+    func transform(input: Input) -> Output
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
@@ -6,5 +6,8 @@
 //
 
 protocol ViewModelType {
-    associatedtype Output    
+    associatedtype Input
+    associatedtype Output
+    
+    func action(_ trigger: Input)
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
@@ -6,6 +6,5 @@
 //
 
 protocol ViewModelType {
-    associatedtype Input
     associatedtype Output    
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ViewModelType.swift
@@ -7,7 +7,5 @@
 
 protocol ViewModelType {
     associatedtype Input
-    associatedtype Output
-    
-    func transform(input: Input) -> Output
+    associatedtype Output    
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #8

## 📄 작업 내용
- Combine을 적용한 MVVM(by Input-Output 패턴) 기초 세팅 


## 💻 주요 코드 설명
`VieModelType`
- ViewModelType 프로토콜을 Presentation/Protocol 폴더에 구현했습니다. Protocol 폴더를 새로 만들었는데 이에 대한 의견 궁금합니다!
- 🚨뷰컨트롤러에서 트리거를 뷰모델에 전달하는 방식으로 바꾸면서 transform 메서드를 삭제했습니다.
```swift
protocol ViewModelType {
    associatedtype Input
    associatedtype Output
}
```

<br>

`CombineTestViewModel`
### Combine에 대한 사전 지식
#### Publisher
✅ **Publisher :** 비동기적으로 데이터를 전달하는 객체. 하나/여러 개 값을 연속적으로 보내고, 완료 또는 에러로 종료
1. Combine에서는 모든 데이터 흐름을 Publisher로 모델링합니다

✅ **AnyPublisher:** Publisher 타입을 추상화한 것
1. AnyPublisher<Output, Failure>
- Output : Publisher가 발행하는 데이터 타입. Input-Output 패턴의 Output과 다른 의미입니다.
- Failure : Publisher가 발행할 수 있는 에러 타입 (우리는 ByeBooError를 쓰면 되겠죠?)

#### Subject
✅ **Subject :** 양방향 통신 객체, 값을 보내는 쪽과 받는 쪽의 중간 다리 역할을 합니다.

✅ **자주 쓰이는 Subject의 종류**
1. PassthroughSubject
- 외부에서 값을 수동으로 전달합니다.
- 주로 버튼 탭과 같은 이벤트를 전달하는 데 사용합니다.

2. CurrentValueSubject
- 가장 최신 값을 전달하여 전달합니다.
- 주로 로딩 상태(로딩 중/로딩 완료)를 전달하는 데 사용합니다.

#### Cancellable
✅ **Cancellable :** Combine의 구독을 보관하고 관리하는 객체입니다.
1. 여러 구독을 관리하게 위해서 Set<AnyCancellable>을 정의합니다.
2. 이를 통해 메모리 누수 없이 구독을 관리할 수 있습니다.

#### 메서드
✅ **sink :** publisher를 구독하는 메서드입니다. 클로저에 publisher가 보낸 값을 어떻게 처리할지 정의합니다.
✅ **store :** 구독을 Set<AnyCancellable>에 저장합니다.
✅ **assign :** publisher가 보낸 값을 특정 객체의 속성에 할당합니다.
✅ **eraseToAnyPublisher :** publisher 타입을 AnyPublisher로 추상화합니다. 실제 publisher 타입은 복잡해서 유지보수가 힘듭니다.


`CombineTestViewModel`
- 🚨Input 타입이 여러 개일 수 있기 때문에 InputAction enum을 추가했습니다
- 🚨action 메서드를 구현해서, 어떤 인풋 타입인지에 따라 다른 output 처리 함수를 호출하도록 변경했습니다
```swift
import Combine
import UIKit

final class CombineTestViewModel: ViewModelType {
    
    // InputAction 추가
    enum InputAction {
        case first
        case second
    }
    
    struct Input {
        // AnyPublisher의 Output 타입도 InputAction으로 변경했습니다
        let event: AnyPublisher<InputAction, Never>
    }
    
    struct Output {
        let result: AnyPublisher<Result<TestEntity, ByeBooError>, Never>
    }
    
    private var resultSubject: PassthroughSubject<Result<TestEntity, ByeBooError>, Never> = .init()
    // output을 AnyPublisher 타입으로 변경해주는 변수를 따로 선언했습니다
    var result: AnyPublisher<Result<TestEntity, ByeBooError>, Never> {
        resultSubject.eraseToAnyPublisher()
    }
    private var cancellables = Set<AnyCancellable>()
    
    private let testUseCase: TestUseCase
    
    init(testUseCase: TestUseCase) {
        self.testUseCase = testUseCase
    }
    
    // 여기서는 first, second 두 케이스 모두 fetchTestModel을 호출하지만, 실제로는 각 케이스마다 output을 받아오기 위한 서로 다른 함수를 호출하게 될겁니다
    func action(_ trigger: InputAction) {
        switch trigger {
        case .first, .second:
            fetchTestModel()
        }
    }
    
    // testFetchUserName()은 문자열을 반환하는 함수이지만, async/await을 활용하기로 했기 때문에 비동기 함수인 척 해보았습니다
    private func fetchTestModel() {
        Task { [weak self] in
            guard let self else { return }
            
            do {
                let name = try await testUseCase.testFetchUserName()
                resultSubject.send(.success(TestEntity(name: name, birth: "")))
            } catch {
                guard let error = error as? ByeBooError else { return }
                resultSubject.send(.failure(error))
            }
        }
    }
}
```

`CombineTestViewController`
- 🚨뷰 컨트롤러에서 뷰 모델로 트리거를 전달하는 방식으로 변경했습니다. 코드 주석을 봐주세요!
```swift
import Combine
import UIKit

final class CombineTestViewController: UIViewController {
    
    private let viewModel: CombineTestViewModel
    private var cancellables = Set<AnyCancellable>()
    
    init(viewModel: CombineTestViewModel) {
        self.viewModel = viewModel
        super.init(nibName: nil, bundle: nil)
    }
    
    override func viewDidLoad() {
        super.viewDidLoad()
        dataBind()
        // 뷰 모델에 정의한 action 메서드를 호출했습니다
        // 여기서는 임의로 viewDidLoad에서 호출했지만, 실제로는 버튼 탭이나 텍스트필드 입력 등 이벤트 처리할 때 호출합니다
        viewModel.action(.first)
    }
    
    required init?(coder: NSCoder) {
        fatalError("init(coder:) has not been implemented")
    }
    
    func dataBind() {
        // transform을 이용하지 않고 뷰 모델에 정의한 result를 이용합니다 (ViewModel 코드 참고)
        viewModel.result
            .receive(on: DispatchQueue.main)
            .sink { [weak self] result in
                switch result {
                case .success(let entity):
                    self?.updateUI(from: entity)
                case .failure(let error):
                    ByeBooLogger.network(error)
                }
            }
            .store(in: &cancellables)
    }
    
    // 받아온 데이터를 뷰에 업데이트하는 메서드 (내부 구현 X)
    func updateUI(from entity: TestEntity) {
        
    }
}
```

## 📚 참고자료
https://medium.com/daily-monster/uikit-mvvm-with-combine-적용기-ft-error-handling-a5f59389f8b7

## 👀 기타 더 이야기해볼 점
첫 Combine 사용이라 미숙한 부분이 있을 수 있습니다. 많은 피드백 부탁드립니다!