### PR TITLE
Style/#22 tag 컴포넌트 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooFilledTag.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooFilledTag.swift
@@ -1,0 +1,81 @@
+//
+//  ByeBoo.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/4/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+enum ByeBooFilledTagType {
+    case purple
+    case gray
+    
+    var backgroundColor: UIColor {
+        switch self {
+        case .purple:
+            return .primary300
+        case .gray:
+            return .white10
+        }
+    }
+    
+    var textColor: UIColor {
+        switch self {
+        case .purple:
+            return .white
+        case .gray:
+            return .grayscale300
+        }
+    }
+}
+
+final class ByeBooFilledTag: BaseView {
+    private let textLabel =  UILabel()
+    private var tagType: ByeBooFilledTagType
+    
+    init(tagType: ByeBooFilledTagType, text: String) {
+        self.tagType = tagType
+        super.init(frame: .zero)
+        self.textLabel.text = text
+        
+        setStyle()
+        setUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setStyle() {
+        self.do {
+            $0.backgroundColor = tagType.backgroundColor
+            $0.layer.cornerRadius = 12
+            $0.clipsToBounds = true
+        }
+        
+        textLabel.do {
+            $0.font = FontManager.cap1M12.font
+            $0.textColor = tagType.textColor
+        }
+    }
+    
+    override func setUI() {
+        addSubview(textLabel)
+    }
+    
+    override func setLayout() {
+        self.snp.makeConstraints {
+            $0.height.equalTo(24)
+        }
+        
+        textLabel.snp.makeConstraints {
+            //TODO: - 기기대응 extension 적용
+            $0.leading.trailing.equalToSuperview().inset(17.5)
+            $0.top.bottom.equalToSuperview().inset(3)
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooFilledTag.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooFilledTag.swift
@@ -69,13 +69,12 @@ final class ByeBooFilledTag: BaseView {
     
     override func setLayout() {
         self.snp.makeConstraints {
-            $0.height.equalTo(24)
+            $0.height.equalTo(24.adjustedH)
         }
         
         textLabel.snp.makeConstraints {
-            //TODO: - 기기대응 extension 적용
-            $0.leading.trailing.equalToSuperview().inset(17.5)
-            $0.top.bottom.equalToSuperview().inset(3)
+            $0.leading.trailing.equalToSuperview().inset(17.5.adjustedW)
+            $0.top.bottom.equalToSuperview().inset(3.adjustedH)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooYellowTag.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooYellowTag.swift
@@ -1,0 +1,24 @@
+//
+//  ByeBooTag.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/4/25.
+//
+
+import UIKit
+
+import SnapKit
+
+final class ByeBooYellowTag: UILabel {
+    init(text: String) {
+        super.init(frame: .zero)
+        self.text = text
+        self.font = FontManager.cap1M12.font
+        self.textColor = .secondary300
+        self.textAlignment = .left
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #22

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 태그 컴포넌트 UI 구현했습니다 

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| PNG | <img src ="https://github.com/user-attachments/assets/7d59db21-20c9-4600-9962-dcd7643883db" width ="250"> | <img src = "https://github.com/user-attachments/assets/e2c18523-bb4a-4899-8925-d40f0ba73207" width ="250"> |


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
태그 컴포넌트가 뷰에 잘 뜨는지 
- 시나리오 진행에 필요한 값
N/A
- 시나리오 진행에 필요한 조건
뷰컨트롤러에 태그 컴포넌트를 선언해서 테스트했습니다
- 시나리오 완료 시 보장하는 결과
태그컴포넌트가 잘 보여요

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`ByeBooTagFilledTag`
- 보라색, 회색 백그라운드가 있는 태그입니다
- 초기화 시 tagType(purple & gray), 텍스트가 필요합니다
```swift
enum ByeBooFilledTagType {
    case purple
    case gray
    
    var backgroundColor: UIColor {
        switch self {
        case .purple:
            return .primary300
        case .gray:
            return .white10
        }
    }
    
    var textColor: UIColor {
        switch self {
        case .purple:
            return .white
        case .gray:
            return .grayscale300
        }
    }
}
```

`ByeBooTagYellowTag`
- 노란색 텍스트만 있는 태그입니다. 
- 초기화 시 텍스트가 필요합니다 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

- [x] 주리님의 버튼 pr 머지 후에 develop 리베이스해서 기기대응 코드 추가하고 머지할 예정입니다 
