### PR TITLE
Style/#34 top navigation bar

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Base/BaseViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Base/BaseViewController.swift
@@ -45,3 +45,16 @@ class BaseViewController: UIViewController {
 
     func setDelegate() {}
 }
+
+extension BaseViewController {
+    
+    @objc
+    func back() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    @objc
+    func close() {
+        self.dismiss(animated: true, completion: nil)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Base/BaseViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Base/BaseViewController.swift
@@ -45,16 +45,3 @@ class BaseViewController: UIViewController {
 
     func setDelegate() {}
 }
-
-extension BaseViewController {
-    
-    @objc
-    func back() {
-        self.navigationController?.popViewController(animated: true)
-    }
-    
-    @objc
-    func close() {
-        self.dismiss(animated: true, completion: nil)
-    }
-}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNavigationBar.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNavigationBar.swift
@@ -21,7 +21,8 @@ final class ByeBooNavigationBar {
     static func makeNavigationBar(
         navigationItem: UINavigationItem,
         navigationController: UINavigationController?,
-        type: NavigationBarType
+        type: NavigationBarType,
+        action: Selector? = nil
     ) -> UINavigationBarAppearance {
         
         let barAppearance = UINavigationBarAppearance()
@@ -34,11 +35,16 @@ final class ByeBooNavigationBar {
             ]
         }
         
+        guard let topViewController = navigationController?.topViewController as? BaseViewController else {
+            return barAppearance
+        }
+        
         switch type {
         case .back:
             let backButtonItem = makeBarButtonItem(
                 image: .left.withTintColor(.white),
-                target: navigationController?.topViewController
+                target: navigationController?.topViewController,
+                action: #selector(topViewController.back)
             )
             navigationItem.leftBarButtonItem = backButtonItem
             
@@ -49,14 +55,16 @@ final class ByeBooNavigationBar {
             makeCloseButtonItem(
                 image: .xicon,
                 target: navigationController?.topViewController,
-                navigationItem: navigationItem
+                navigationItem: navigationItem,
+                action: action
             )
             
         case .titleAndClose(let string):
             makeCloseButtonItem(
                 image: .xicon,
                 target: navigationController?.topViewController,
-                navigationItem: navigationItem
+                navigationItem: navigationItem,
+                action: action
             )
             navigationItem.title = string
         }
@@ -69,21 +77,26 @@ final class ByeBooNavigationBar {
         return barAppearance
     }
     
-    private static func makeBarButtonItem(image: UIImage, target: UIViewController?) -> UIBarButtonItem {
+    private static func makeBarButtonItem(
+        image: UIImage,
+        target: UIViewController?,
+        action: Selector?
+    ) -> UIBarButtonItem {
         return UIBarButtonItem(
             image: image.withTintColor(.white).withRenderingMode(.alwaysOriginal),
             style: .plain,
             target: target,
-            action: nil
+            action: action
         )
     }
     
     private static func makeCloseButtonItem(
         image: UIImage,
         target: UIViewController?,
-        navigationItem: UINavigationItem
+        navigationItem: UINavigationItem,
+        action: Selector?
     ) {
-        let closeButtonItem = makeBarButtonItem(image: image, target: target)
+        let closeButtonItem = makeBarButtonItem(image: image, target: target, action: action)
         navigationItem.rightBarButtonItem = closeButtonItem
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNavigationBar.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNavigationBar.swift
@@ -1,0 +1,89 @@
+//
+//  ByeBooNavigationbar.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/5/25.
+//
+
+import UIKit
+
+import SnapKit
+
+enum NavigationBarType {
+    case back
+    case title(String)
+    case close
+    case titleAndClose(String)
+}
+
+final class ByeBooNavigationBar {
+    
+    static func makeNavigationBar(
+        navigationItem: UINavigationItem,
+        navigationController: UINavigationController?,
+        type: NavigationBarType
+    ) -> UINavigationBarAppearance {
+        
+        let barAppearance = UINavigationBarAppearance()
+        barAppearance.do {
+            $0.backgroundColor = .black
+            $0.shadowColor = .clear
+            $0.titleTextAttributes = [
+                .font: FontManager.sub1Sb20.font,
+                .foregroundColor: UIColor.white
+            ]
+        }
+        
+        switch type {
+        case .back:
+            let backButtonItem = makeBarButtonItem(
+                image: .left.withTintColor(.white),
+                target: navigationController?.topViewController
+            )
+            navigationItem.leftBarButtonItem = backButtonItem
+            
+        case .title(let string):
+            navigationItem.title = string
+            
+        case .close:
+            makeCloseButtonItem(
+                image: .xicon,
+                target: navigationController?.topViewController,
+                navigationItem: navigationItem
+            )
+            
+        case .titleAndClose(let string):
+            makeCloseButtonItem(
+                image: .xicon,
+                target: navigationController?.topViewController,
+                navigationItem: navigationItem
+            )
+            navigationItem.title = string
+        }
+        
+        navigationController?.navigationBar.do {
+            $0.standardAppearance = barAppearance
+            $0.scrollEdgeAppearance = barAppearance
+        }
+        
+        return barAppearance
+    }
+    
+    private static func makeBarButtonItem(image: UIImage, target: UIViewController?) -> UIBarButtonItem {
+        return UIBarButtonItem(
+            image: image.withTintColor(.white).withRenderingMode(.alwaysOriginal),
+            style: .plain,
+            target: target,
+            action: nil
+        )
+    }
+    
+    private static func makeCloseButtonItem(
+        image: UIImage,
+        target: UIViewController?,
+        navigationItem: UINavigationItem
+    ) {
+        let closeButtonItem = makeBarButtonItem(image: image, target: target)
+        navigationItem.rightBarButtonItem = closeButtonItem
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNavigationBar.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNavigationBar.swift
@@ -16,7 +16,7 @@ enum NavigationBarType {
     case titleAndClose(String)
 }
 
-final class ByeBooNavigationBar {
+struct ByeBooNavigationBar {
     
     static func makeNavigationBar(
         navigationItem: UINavigationItem,
@@ -44,7 +44,7 @@ final class ByeBooNavigationBar {
             let backButtonItem = makeBarButtonItem(
                 image: .left.withTintColor(.white),
                 target: navigationController?.topViewController,
-                action: #selector(topViewController.back)
+                action: action
             )
             navigationItem.leftBarButtonItem = backButtonItem
             

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
@@ -28,12 +28,12 @@ final class ByeBooNicknameTextField: BaseView {
     override func setStyle() {
         nicknameField.do {
             $0.backgroundColor = .grayscale700
-            $0.layer.cornerRadius = 12
+            $0.layer.cornerRadius = 12.adjustedW
             $0.attributedPlaceholder = NSAttributedString(
                 string: "닉네임을 입력해주세요",
                 attributes: [NSAttributedString.Key.foregroundColor : UIColor.grayscale300]
             )
-            $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 0))
+            $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 24.adjustedW, height: 0))
             $0.leftViewMode = .always
             $0.textColor = .grayscale300
         }
@@ -41,7 +41,7 @@ final class ByeBooNicknameTextField: BaseView {
         errorIcon.do {
             $0.image = .errorRed
             $0.clipsToBounds = true
-            $0.layer.cornerRadius = 9
+            $0.layer.cornerRadius = 9.adjustedW
             $0.tintColor = .grayscale600
         }
     }
@@ -53,8 +53,8 @@ final class ByeBooNicknameTextField: BaseView {
     
     override func setLayout() {
         self.snp.makeConstraints {
-            $0.width.equalTo(312)
-            $0.height.equalTo(57)
+            $0.width.equalTo(312.adjustedW)
+            $0.height.equalTo(57.adjustedH)
         }
         
         nicknameField.snp.makeConstraints {
@@ -63,9 +63,10 @@ final class ByeBooNicknameTextField: BaseView {
         }
         
         errorIcon.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(-24)
+            $0.trailing.equalToSuperview().inset(-24.adjustedW)
             $0.centerY.equalToSuperview()
-            $0.width.height.equalTo(18)
+            $0.width.equalTo(18.adjustedW)
+            $0.height.equalTo(18.adjustedH)
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
@@ -14,6 +14,7 @@ final class ByeBooNicknameTextField: BaseView {
     
     let nicknameField = UITextField()
     let errorIcon = UIImageView()
+    var onTextChange: ((String) -> Void)?
     
     init(_ type: NicknameFieldType) {
         super.init(frame: .zero)
@@ -63,7 +64,7 @@ final class ByeBooNicknameTextField: BaseView {
         }
         
         errorIcon.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(-24.adjustedW)
+            $0.trailing.equalToSuperview().inset(24.adjustedW)
             $0.centerY.equalToSuperview()
             $0.width.equalTo(18.adjustedW)
             $0.height.equalTo(18.adjustedH)
@@ -92,6 +93,8 @@ final class ByeBooNicknameTextField: BaseView {
     @objc
     private func nicknameFieldDidChange() {
         guard let text = nicknameField.text else { return }
+        
+        onTextChange?(text)
         
         if text.isEmpty {
             self.setTextFieldStyle(.onBeginEditing)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/BackNavigable.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/BackNavigable.swift
@@ -1,0 +1,13 @@
+//
+//  Dismissible.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/6/25.
+//
+
+import Foundation
+
+@objc
+protocol BackNavigable {
+    func back()
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/Dismissible.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/Dismissible.swift
@@ -1,0 +1,13 @@
+//
+//  Dismissible.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/6/25.
+//
+
+import Foundation
+
+@objc
+protocol Dismissible {
+    func close()
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #34 

## 📄 작업 내용
- 탑 내비게이션 바를 구현했습니다

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| 백 버튼 | <img src = "https://github.com/user-attachments/assets/522b2e95-39a0-4186-b930-4ea331b14eb2" width ="250"> | <img src = "https://github.com/user-attachments/assets/da368420-fea7-4351-a3e8-0832dcf1e99f" width ="250"> |
| 닫기 버튼 | <img src = "https://github.com/user-attachments/assets/cf3e1c24-fbf1-4f15-a2a4-4817f361028d" width ="250"> | <img src = "https://github.com/user-attachments/assets/2a8db265-1633-4c40-b09a-38b3c4042182" width ="250"> |
| 제목 | <img src = "https://github.com/user-attachments/assets/9c19d2cc-3d3a-4c3c-9037-ab7616e42b07" width ="250"> | <img src = "https://github.com/user-attachments/assets/a99c050a-0b6c-444f-84c3-c9a5b1d9bbda" width ="250"> |
| 제목 + 닫기 버튼 | <img src = "https://github.com/user-attachments/assets/94e49f6f-3872-4f50-ad27-2b4eb1988466" width ="250"> | <img src = "https://github.com/user-attachments/assets/f8755424-884a-4218-b735-afb7ab34b816" width ="250"> |


## ✅ Testing
- 테스트 목적과 상황
   서로 다른 타입의 탑 내비게이션 바를 호출했을 때 화면에 잘 뜨는지 확인
- 시나리오 진행에 필요한 값
   주요 코드 참고
- 시나리오 완료 시 보장하는 결과
   원하는 타입에 따라 탑 내비게이션 바 사용 가능

## 💻 주요 코드 설명
`ByeBooNavigationBar`
- UINavigationBarAppearance을 활용하여 내비게이션 바 커스텀
- UIBarButtonItem을 생성하는 함수를 분리해서 코드 중복을 줄이고자 했어요
- **내비게이션 바 타입 4가지 : 백 버튼, 클로즈 버튼, 제목, 제목 + 클로즈 버튼**
```swift
enum NavigationBarType {
    // 제목이 있는 경우(title, titleAndClose)에는 제목명을 함께 써주어야 합니다
    case back
    case title(String)
    case close
    case titleAndClose(String)
}
```

`Dismissible / BackNavigable`
- 🚨BaseViewController 확장 -> 프로토콜 채택으로 변경
- 🚨백 버튼 상단 내비게이션바를 사용할 때는 뷰컨트롤러에서 **BackNavigable을 채택해주세요**
    - 채택 후, **back 메서드 내부에 self.navigationController?.popViewController(animated: true)**를 적어주시면 됩니다
- 🚨닫기 버튼 상단 내비게이션바를 사용할 때는 뷰컨트롤러에서 **Dismissible을 채택해주세요**
    - 채택 후, **close 메서드 내부에 닫기 버튼을 눌렀을 때 로직**을 구현해주시면 됩니다
```swift
import Foundation

@objc
protocol Dismissible {
    func close()
}
```

```swift
import Foundation

@objc
protocol BackNavigable {
    func back()
}
```

`사용 방법`
- BaseViewController를 상속한 뷰 컨트롤러에서 static 메서드를 호출
```swift
class ViewController: BaseViewController {
    
    override func viewDidLoad() {
        super.viewDidLoad()
        view.backgroundColor = .black

        // 호출
        // 1. 백 버튼만 있는 경우 (백 버튼만 있을 때는 action이 popViewController로 설정되어있어 action 파라미터 안 써도 됨)
        // ViewController에 BackNavigable 채택
        ByeBooNavigationBar.makeNavigationBar(
            navigationItem: self.navigationItem,
            navigationController: self.navigationController,
            type: .back,
            action: #selector(back)
        )

        // 2. 닫기 버튼만 있는 경우
        // ViewController에 Dismissible 채택
        ByeBooNavigationBar.makeNavigationBar(
            navigationItem: self.navigationItem,
            navigationController: self.navigationController,
            type: .close,
            action: #selector(close)
        )

        // 3. 제목만 있는 경우
        ByeBooNavigationBar.makeNavigationBar(
            navigationItem: self.navigationItem,
            navigationController: self.navigationController,
            type: .title("퀘스트 작성 TIP")
        )

        // 4. 제목 + 닫기 버튼
        ByeBooNavigationBar.makeNavigationBar(
            navigationItem: self.navigationItem,
            navigationController: self.navigationController,
            type: .titleAndClose("퀘스트 작성 TIP"),
            action: #selector(close)
        )
    }
}
```