### PR TITLE
style/#33 quit modal 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
@@ -11,8 +11,6 @@ import SnapKit
 import Then
 
 final class ByeBooQuitModal: BaseView, ModalProtocol {
-//    var cancelButton: ByeBooButton?
-    
     
     private let titleLabel = UILabel()
     private let secondDescriptionLabel = UILabel()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
@@ -1,0 +1,90 @@
+//
+//  ByeBooQuitModal.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/6/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ByeBooQuitModal: BaseView, ModalProtocol {
+    
+    private let titleLabel = UILabel()
+    private let secondDescriptionLabel = UILabel()
+    private let buttonStackView = UIStackView()
+    let confirmButton = ByeBooButton(titleText: "머무르기", type: .enabled)
+    lazy var quitButton = ByeBooButton(titleText: "나가기", type: .outline)
+    
+    override func setUI() {
+        addSubviews(
+            titleLabel,
+            secondDescriptionLabel,
+            buttonStackView
+        )
+        
+        [confirmButton, quitButton].forEach {
+            buttonStackView.addArrangedSubview($0)
+        }
+        
+        setAddTarget()
+    }
+    
+    override func setStyle() {
+        titleLabel.do {
+            $0.text = "작성을 중단하시겠어요?"
+            $0.font = FontManager.sub2Sb18.font
+            $0.textColor = .grayscale50
+            $0.textAlignment = .center
+        }
+        
+        secondDescriptionLabel.do {
+            $0.text = "작성하시던 내용은 저장되지 않아요."
+            $0.font = FontManager.body2M16.font
+            $0.textColor = .grayscale400
+            $0.textAlignment = .center
+        }
+        
+        buttonStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 16
+        }
+    }
+    
+    override func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(24)
+            $0.centerX.equalToSuperview()
+        }
+        
+        secondDescriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+        }
+        
+        buttonStackView.snp.makeConstraints {
+            $0.top.equalTo(secondDescriptionLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().inset(24)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.width.equalTo(107.adjustedW)
+            $0.height.equalTo(53.adjustedH)
+            $0.leading.equalToSuperview()
+        }
+        
+        quitButton.snp.makeConstraints {
+            $0.width.equalTo(107.adjustedW)
+            $0.height.equalTo(53.adjustedH)
+            $0.trailing.equalToSuperview()
+        }
+    }
+    
+    private func setAddTarget() {
+        confirmButton.addTarget(target, action: #selector(CustomModalController.confirmButtonTapped), for: .touchUpInside)
+        quitButton.addTarget(target, action: #selector(CustomModalController.cancleButtonTapped), for: .touchUpInside)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
@@ -11,12 +11,14 @@ import SnapKit
 import Then
 
 final class ByeBooQuitModal: BaseView, ModalProtocol {
+//    var cancelButton: ByeBooButton?
+    
     
     private let titleLabel = UILabel()
     private let secondDescriptionLabel = UILabel()
     private let buttonStackView = UIStackView()
-    let confirmButton = ByeBooButton(titleText: "머무르기", type: .enabled)
-    lazy var quitButton = ByeBooButton(titleText: "나가기", type: .outline)
+    let actionButton = ByeBooButton(titleText: "머무르기", type: .enabled)
+    let dismissButton: ByeBooButton? = ByeBooButton(titleText: "나가기", type: .outline)
     
     override func setUI() {
         backgroundColor = .grayscale90080
@@ -28,11 +30,11 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
             buttonStackView
         )
         
-        [confirmButton, quitButton].forEach {
-            buttonStackView.addArrangedSubview($0)
+        if let cancelButton = dismissButton {
+            [actionButton, cancelButton].forEach {
+                buttonStackView.addArrangedSubview($0)
+            }
         }
-        
-        setAddTarget()
     }
     
     override func setStyle() {
@@ -73,21 +75,18 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
             $0.bottom.equalToSuperview().inset(24)
         }
         
-        confirmButton.snp.makeConstraints {
+        actionButton.snp.makeConstraints {
             $0.width.equalTo(107.adjustedW)
             $0.height.equalTo(53.adjustedH)
             $0.leading.equalToSuperview()
         }
         
-        quitButton.snp.makeConstraints {
-            $0.width.equalTo(107.adjustedW)
-            $0.height.equalTo(53.adjustedH)
-            $0.trailing.equalToSuperview()
+        if let cancelButton = dismissButton {
+            cancelButton.snp.makeConstraints {
+                $0.width.equalTo(107.adjustedW)
+                $0.height.equalTo(53.adjustedH)
+                $0.trailing.equalToSuperview()
+            }
         }
-    }
-    
-    private func setAddTarget() {
-        quitButton.addTarget(target, action: #selector(CustomModalController.confirmButtonTapped), for: .touchUpInside) //TODO: - VC 이동
-        confirmButton.addTarget(target, action: #selector(CustomModalController.cancleButtonTapped), for: .touchUpInside)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooQuitModal.swift
@@ -19,6 +19,9 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
     lazy var quitButton = ByeBooButton(titleText: "나가기", type: .outline)
     
     override func setUI() {
+        backgroundColor = .grayscale90080
+        layer.cornerRadius = 12
+        
         addSubviews(
             titleLabel,
             secondDescriptionLabel,
@@ -66,7 +69,7 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
         
         buttonStackView.snp.makeConstraints {
             $0.top.equalTo(secondDescriptionLabel.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.centerX.equalToSuperview()
             $0.bottom.equalToSuperview().inset(24)
         }
         
@@ -84,7 +87,7 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
     }
     
     private func setAddTarget() {
-        confirmButton.addTarget(target, action: #selector(CustomModalController.confirmButtonTapped), for: .touchUpInside)
-        quitButton.addTarget(target, action: #selector(CustomModalController.cancleButtonTapped), for: .touchUpInside)
+        quitButton.addTarget(target, action: #selector(CustomModalController.confirmButtonTapped), for: .touchUpInside) //TODO: - VC 이동
+        confirmButton.addTarget(target, action: #selector(CustomModalController.cancleButtonTapped), for: .touchUpInside)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/CongrateModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/CongrateModalView.swift
@@ -11,7 +11,9 @@ import SnapKit
 import Then
 
 final class CongrateModalView: BaseView, ModalProtocol {
-    let confirmButton: ByeBooButton = ByeBooButton(titleText: "바로가기", type: .enabled)
+    
+    let actionButton: ByeBooButton = ByeBooButton(titleText: "바로가기", type: .enabled)
+    let dismissButton: ByeBooButton? = nil
     
     private let descriptionLabel = UILabel()
     private let titleLabel = UILabel()
@@ -53,7 +55,7 @@ final class CongrateModalView: BaseView, ModalProtocol {
             titleLabel,
             imageView,
             secondDescriptionLabel,
-            confirmButton
+            actionButton
         )
     }
     
@@ -79,7 +81,7 @@ final class CongrateModalView: BaseView, ModalProtocol {
             $0.centerX.equalToSuperview()
         }
         
-        confirmButton.snp.makeConstraints {
+        actionButton.snp.makeConstraints {
             $0.top.equalTo(secondDescriptionLabel.snp.bottom).offset(16)
             $0.bottom.equalToSuperview().inset(24)
             $0.horizontalEdges.equalToSuperview().inset(24)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/CustomModalController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/CustomModalController.swift
@@ -39,20 +39,25 @@ final class CustomModalController: BaseViewController {
     override func setAddTarget() {
         guard let modalView = modalView as? ModalProtocol else { return }
         
-        modalView.confirmButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+        modalView.actionButton.addTarget(self, action: #selector(actionButtonDidTapped), for: .touchUpInside)
+        guard let cancelButton = modalView.dismissButton else { return }
+        cancelButton.addTarget(self, action: #selector(dismissButtonDidTapped), for: .touchUpInside)
     }
 }
 
 extension CustomModalController {
     @objc
-    func confirmButtonTapped() {
+    func actionButtonDidTapped() {
         if let action {
+            ByeBooLogger.debug("action button 터치")
             action()
+            dismiss(animated: false)
         }
     }
     
     @objc
-    func cancleButtonTapped() {
+    func dismissButtonDidTapped() {
+        ByeBooLogger.debug("dismiss button 터치")
         dismiss(animated: false)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuitModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuitModalView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class ByeBooQuitModal: BaseView, ModalProtocol {
+final class QuitModalView: BaseView, ModalProtocol {
     
     private let titleLabel = UILabel()
     private let secondDescriptionLabel = UILabel()
@@ -28,10 +28,8 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
             buttonStackView
         )
         
-        if let cancelButton = dismissButton {
-            [actionButton, cancelButton].forEach {
-                buttonStackView.addArrangedSubview($0)
-            }
+        if let dismissButton = dismissButton {
+            buttonStackView.addArrangedSubviews(actionButton, dismissButton)
         }
     }
     
@@ -58,19 +56,19 @@ final class ByeBooQuitModal: BaseView, ModalProtocol {
     
     override func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24)
+            $0.top.equalToSuperview().inset(24.adjustedH)
             $0.centerX.equalToSuperview()
         }
         
         secondDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
             $0.centerX.equalToSuperview()
         }
         
         buttonStackView.snp.makeConstraints {
-            $0.top.equalTo(secondDescriptionLabel.snp.bottom).offset(16)
+            $0.top.equalTo(secondDescriptionLabel.snp.bottom).offset(16.adjustedH)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().inset(24.adjustedH)
         }
         
         actionButton.snp.makeConstraints {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ModalProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ModalProtocol.swift
@@ -8,5 +8,6 @@
 import UIKit
 
 protocol ModalProtocol {
-    var confirmButton: ByeBooButton { get }
+    var actionButton: ByeBooButton { get }
+    var dismissButton: ByeBooButton? { get }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #33

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- quit 모달 작업했습니다 

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src ="https://github.com/user-attachments/assets/ae238121-0f07-4623-8ecc-42d1386a6d78" width ="250"> | <img src ="https://github.com/user-attachments/assets/ebaef65d-da04-4a2f-a2fb-0160af6766ff" width ="250"> |


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
모달이 잘 뜨는지, 머무르기를 눌렀을 때 모달이 사라짐 
- 시나리오 진행에 필요한 값
N/A
- 시나리오 진행에 필요한 조건

- 시나리오 완료 시 보장하는 결과

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`ModalProtocl`
- 뷰에서 addTarget하는게 별로인것 같다는 의견을 따라서 프로토콜에 dismiss button을 옵셔널로 추가했습니다
- 그래서 congrat modal에도 dismiss button을 nil로 추가해줬습니다
- confirm button -> action button으로 네이밍을 수정했습니다
- action button 함수에 모달 dismiss 되는 코드를 추가했습니다 
```swift 
protocol ModalProtocol {
    var actionButton: ByeBooButton { get }
    var dismissButton: ByeBooButton? { get }
}   
```
