### PR TITLE
Style/#47 질문형 퀘스트 작성 UI 구현 

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/QuestTextField.swift
@@ -1,0 +1,113 @@
+//
+//  QuestTextField.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/8/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+enum QuestType {
+    case question
+    case activation
+    
+    var plaeholder: String {
+        switch self {
+        case .question:
+            return "글로 적다 보면, 스스로에게 한 걸음 더 가까워질 수 있어요."
+        case .activation:
+            return "꼭 적지 않아도 괜찮지만, 글로 정리해보면 스스로에게 한 걸음 더 가까워질 수 있어요."
+        }
+    }
+}
+
+final class QuestTextField: BaseView {
+    let textView = UITextView()
+    private let textCount = UILabel()
+    private let placeholder: String
+    private var isPlaceholderActive: Bool = true
+    private var count: Int = 0
+    
+    init(type: QuestType) {
+        placeholder = type.plaeholder
+        super.init(frame: .zero)
+        textView.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setUI() {
+        addSubviews(textView, textCount)
+    }
+    
+    override func setStyle() {
+        textView.do {
+            $0.backgroundColor = .white10
+            $0.layer.cornerRadius = 12
+            $0.textColor = .grayscale300
+            $0.text = placeholder
+            $0.font = FontManager.body3R16.font
+            $0.textContainerInset = UIEdgeInsets(top: 16.adjustedH, left: 24.adjustedW, bottom: 34.adjustedH, right: 24.adjustedW)
+        }
+        
+        textCount.do {
+            $0.text = "(\(count)/500)"
+            $0.font = FontManager.body5R14.font
+            $0.textColor = .grayscale300
+        }
+    }
+    
+    override func setLayout() {
+        textView.snp.makeConstraints {
+            $0.width.equalTo(327.adjustedW)
+            $0.height.equalTo(290.adjustedH)
+        }
+        
+        textCount.snp.makeConstraints {
+            $0.trailing.equalTo(textView.snp.trailing).inset(24)
+            $0.bottom.equalTo(textView.snp.bottom).inset(16.adjustedW)
+        }
+    }
+}
+
+extension QuestTextField: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if isPlaceholderActive == true {
+            isPlaceholderActive = false
+            textView.textColor = .white
+            textView.text = nil
+        }
+        print("이 텍스트뷰가 firstResponder? \(textView.isFirstResponder)")
+        textView.layer.borderColor = UIColor.primary300.cgColor
+        textView.layer.borderWidth = 1
+        textCount.textColor = .primary300
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = placeholder
+            textView.textColor = .grayscale300
+            isPlaceholderActive = true
+        }
+        textView.textColor = .grayscale300
+        textView.layer.borderWidth = 0
+        textCount.textColor = .grayscale300
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        if textView.text.count > 500 {
+            textView.deleteBackward()
+            textView.layer.borderColor = UIColor.error300.cgColor
+            textView.layer.borderWidth = 1
+            textCount.textColor = .error300
+        }
+        
+        count = textView.text.count
+        textCount.text = "(\(count)/500)"
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/QuestTextField.swift
@@ -22,6 +22,15 @@ enum QuestType {
             return "꼭 적지 않아도 괜찮지만, 글로 정리해보면 스스로에게 한 걸음 더 가까워질 수 있어요."
         }
     }
+    
+    var textLimit: Int {
+        switch self {
+        case .question:
+            return 500
+        case .activation:
+            return 200
+        }
+    }
 }
 
 final class QuestTextField: BaseView {
@@ -29,11 +38,13 @@ final class QuestTextField: BaseView {
     private let textCount = UILabel()
     private let placeholder: String
     private var isPlaceholderActive: Bool = true
+    private let limitCount: Int
     var count: Int = 0
     weak var delegate: TextViewProtocol?
     
     init(type: QuestType) {
         placeholder = type.plaeholder
+        limitCount = type.textLimit
         super.init(frame: .zero)
         textView.delegate = self
     }
@@ -60,7 +71,7 @@ final class QuestTextField: BaseView {
         }
         
         textCount.do {
-            $0.text = "(\(count)/500)"
+            $0.text = "(\(count)/\(limitCount)"
             $0.font = FontManager.body5R14.font
             $0.textColor = .grayscale300
         }
@@ -109,7 +120,7 @@ extension QuestTextField: UITextViewDelegate {
     }
     
     func textViewDidChange(_ textView: UITextView) {
-        if textView.text.count > 500 {
+        if textView.text.count > limitCount {
             textView.deleteBackward()
             self.layer.borderColor = UIColor.error300.cgColor
             self.layer.borderWidth = 1
@@ -117,7 +128,7 @@ extension QuestTextField: UITextViewDelegate {
         }
         
         count = textView.text.count
-        textCount.text = "(\(count)/500)"
+        textCount.text = "(\(count)/\(limitCount)"
         delegate?.changeStyle(count: count)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/QuestTextField.swift
@@ -25,11 +25,12 @@ enum QuestType {
 }
 
 final class QuestTextField: BaseView {
-    let textView = UITextView()
+    private let textView = UITextView()
     private let textCount = UILabel()
     private let placeholder: String
     private var isPlaceholderActive: Bool = true
-    private var count: Int = 0
+    var count: Int = 0
+    weak var delegate: TextViewProtocol?
     
     init(type: QuestType) {
         placeholder = type.plaeholder
@@ -46,13 +47,16 @@ final class QuestTextField: BaseView {
     }
     
     override func setStyle() {
-        textView.do {
+        self.do {
             $0.backgroundColor = .white10
             $0.layer.cornerRadius = 12
+        }
+        
+        textView.do {
+            $0.backgroundColor = .clear
             $0.textColor = .grayscale300
             $0.text = placeholder
             $0.font = FontManager.body3R16.font
-            $0.textContainerInset = UIEdgeInsets(top: 16.adjustedH, left: 24.adjustedW, bottom: 34.adjustedH, right: 24.adjustedW)
         }
         
         textCount.do {
@@ -63,14 +67,20 @@ final class QuestTextField: BaseView {
     }
     
     override func setLayout() {
-        textView.snp.makeConstraints {
+        self.snp.makeConstraints {
             $0.width.equalTo(327.adjustedW)
             $0.height.equalTo(290.adjustedH)
         }
         
+        textView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+            $0.bottom.equalToSuperview().inset(34.adjustedH)
+        }
+        
         textCount.snp.makeConstraints {
-            $0.trailing.equalTo(textView.snp.trailing).inset(24)
-            $0.bottom.equalTo(textView.snp.bottom).inset(16.adjustedW)
+            $0.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().inset(16.adjustedW)
         }
     }
 }
@@ -82,9 +92,8 @@ extension QuestTextField: UITextViewDelegate {
             textView.textColor = .white
             textView.text = nil
         }
-        print("이 텍스트뷰가 firstResponder? \(textView.isFirstResponder)")
-        textView.layer.borderColor = UIColor.primary300.cgColor
-        textView.layer.borderWidth = 1
+        self.layer.borderColor = UIColor.primary300.cgColor
+        self.layer.borderWidth = 1
         textCount.textColor = .primary300
     }
     
@@ -95,19 +104,20 @@ extension QuestTextField: UITextViewDelegate {
             isPlaceholderActive = true
         }
         textView.textColor = .grayscale300
-        textView.layer.borderWidth = 0
+        self.layer.borderWidth = 0
         textCount.textColor = .grayscale300
     }
     
     func textViewDidChange(_ textView: UITextView) {
         if textView.text.count > 500 {
             textView.deleteBackward()
-            textView.layer.borderColor = UIColor.error300.cgColor
-            textView.layer.borderWidth = 1
+            self.layer.borderColor = UIColor.error300.cgColor
+            self.layer.borderWidth = 1
             textCount.textColor = .error300
         }
         
         count = textView.text.count
         textCount.text = "(\(count)/500)"
+        delegate?.changeStyle(count: count)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/WriteQuestTitleView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Quest/WriteQuestTitleView.swift
@@ -1,0 +1,90 @@
+//
+//  WriteQuestTypeView.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/7/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class WriteQuestTitleView: BaseView {
+    private let stepStackView = UIStackView()
+    private let stepNum = UILabel()
+    private let stepTitle = UILabel()
+    
+    private let questNum: Int
+    private let questNumLabel: ByeBooYellowTag
+    
+    private let titleLabel = UILabel()
+    private let tipTag = ByeBooFilledTag(tagType: .purple, text: "작성 TIP")
+    
+        
+    init(stepNum: String, stepTitle: String, questNum: Int, title: String) {
+        self.stepNum.text = "STEP \(stepNum)"
+        self.stepTitle.text = stepTitle
+        self.questNum = questNum
+        self.titleLabel.text = title
+        questNumLabel = .init(text: "\(questNum)번째 퀘스트")
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func setUI() {
+        addSubviews(stepStackView, questNumLabel, titleLabel, tipTag)
+        stepStackView.addArrangedSubviews(stepNum, stepTitle)
+    }
+    
+    override func setStyle() {
+        stepStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 8.adjustedW
+        }
+        
+        stepNum.do {
+            $0.font = FontManager.cap1M12.font
+            $0.textColor = .grayscale300
+        }
+        
+        stepTitle.do {
+            $0.font = FontManager.body2M16.font
+            $0.textColor = .grayscale500
+        }
+        
+        titleLabel.do {
+            $0.font = FontManager.head1Sb24.font
+            $0.textColor = .white
+            $0.numberOfLines = 0
+            $0.textAlignment = .center
+            $0.lineBreakMode = .byWordWrapping
+        }
+    }
+    
+    override func setLayout() {
+        stepStackView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+        }
+        
+        questNumLabel.snp.makeConstraints {
+            $0.top.equalTo(stepStackView.snp.bottom).offset(12.adjustedH)
+            $0.centerX.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(questNumLabel.snp.bottom).offset(12.adjustedH)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(327.adjustedW)
+        }
+        
+        tipTag.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(25.5.adjustedH)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeView.swift
@@ -19,7 +19,7 @@ final class WriteQuestionTypeView: BaseView {
     )
     private let questTextField = QuestTextField(type: .question)
     private let descriptionLabel = UILabel()
-    private let confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
+    let confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
     
     override func setUI() {
         addSubviews(
@@ -28,6 +28,7 @@ final class WriteQuestionTypeView: BaseView {
             descriptionLabel,
             confirmButton
         )
+        questTextField.delegate = self
     }
     
     override func setStyle() {
@@ -67,6 +68,16 @@ final class WriteQuestionTypeView: BaseView {
             $0.width.equalTo(311.adjustedW)
             $0.bottom.equalTo(self.safeAreaLayoutGuide)
             $0.centerX.equalToSuperview()
+        }
+    }
+}
+
+extension WriteQuestionTypeView: TextViewProtocol {
+    func changeStyle(count: Int) {
+        if (count >= 10) {
+            confirmButton.updateType(.enabled)
+        } else {
+            confirmButton.updateType(.disabled)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeView.swift
@@ -28,7 +28,7 @@ final class WriteQuestionTypeView: BaseView {
             descriptionLabel,
             confirmButton
         )
-        questTextField.delegate = self
+        setDelegate()
     }
     
     override func setStyle() {
@@ -40,6 +40,10 @@ final class WriteQuestionTypeView: BaseView {
             $0.textColor = .grayscale400
             $0.textAlignment = .center
         }
+    }
+    
+    private func setDelegate() {
+        questTextField.delegate = self
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeView.swift
@@ -1,0 +1,72 @@
+//
+//  WriteQuestionTypeView.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/8/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class WriteQuestionTypeView: BaseView {
+    private let title = WriteQuestTitleView(
+        stepNum: "2", 
+        stepTitle: "상황 정리하기", 
+        questNum: 10,
+        title: "연애에서 반복됐던 문제 패턴 3가지를 생각해보아요."
+    )
+    private let questTextField = QuestTextField(type: .question)
+    private let descriptionLabel = UILabel()
+    private let confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
+    
+    override func setUI() {
+        addSubviews(
+            title,
+            questTextField,
+            descriptionLabel,
+            confirmButton
+        )
+    }
+    
+    override func setStyle() {
+        backgroundColor = .grayscale900
+        
+        descriptionLabel.do {
+            $0.text = "* 10글자 이상 작성해주세요."
+            $0.font = FontManager.cap2R12.font
+            $0.textColor = .grayscale400
+            $0.textAlignment = .center
+        }
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.endEditing(true)
+    }
+    
+    override func setLayout() {
+        title.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(200.adjustedH)
+        }
+        
+        questTextField.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(24.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+            $0.height.equalTo(290.adjustedH)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(questTextField.snp.bottom).offset(16.adjustedH)
+            $0.leading.equalToSuperview().inset(24.adjustedW)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.width.equalTo(311.adjustedW)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeViewController.swift
@@ -16,9 +16,9 @@ final class WriteQuestionTypeViewController: BaseViewController {
     }
     
     override func setAddTarget() {
-        print("등록")
         NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveUp), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveDown), name: UIResponder.keyboardWillHideNotification, object: nil)
+        rootView.confirmButton.addTarget(self, action: #selector(confirmButtonDidTapped), for: .touchUpInside)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -32,7 +32,6 @@ final class WriteQuestionTypeViewController: BaseViewController {
             UIView.animate(withDuration: 0.3, animations: {
                 let offsetY = keyboardSize.height - self.rootView.safeAreaInsets.bottom * 4
                 self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
-                print("keyboard height: \(keyboardSize.height)")
             })
         }
     }
@@ -40,5 +39,10 @@ final class WriteQuestionTypeViewController: BaseViewController {
     @objc
     private func textViewMoveDown() {
         self.rootView.transform = .identity
+    }
+    
+    @objc
+    private func confirmButtonDidTapped() {
+        
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeViewController.swift
@@ -1,0 +1,44 @@
+//
+//  WriteQuestionTypeViewController.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/8/25.
+//
+
+import UIKit
+
+final class WriteQuestionTypeViewController: BaseViewController {
+    
+    private let rootView = WriteQuestionTypeView()
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func setAddTarget() {
+        print("등록")
+        NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveUp), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveDown), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc
+    private func textViewMoveUp(_ notification: NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.3, animations: {
+                let offsetY = keyboardSize.height - self.rootView.safeAreaInsets.bottom * 4
+                self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
+                print("keyboard height: \(keyboardSize.height)")
+            })
+        }
+    }
+    
+    @objc
+    private func textViewMoveDown() {
+        self.rootView.transform = .identity
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/WriteQuestTypeViewModel.swift
@@ -1,0 +1,7 @@
+//
+//  WriteQuestionTypeViewModel.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/7/25.
+//
+

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/TextViewProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/TextViewProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  CountTextProtocol.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/8/25.
+//
+
+protocol TextViewProtocol: AnyObject {
+    func changeStyle(count: Int)
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #47 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 질문형 퀘스트 작성 UI 구현했습니다 

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src ="https://github.com/user-attachments/assets/653ee109-01b1-48fc-8c7a-1f8abb003e36" width ="250"> | <img src = "https://github.com/user-attachments/assets/cf48882e-0987-45df-8c23-2487c820a4ea" width ="250"> |

<img src ="https://github.com/user-attachments/assets/8221fa2e-ffd6-482b-8335-64b240079468" width = "250" />

500자 이상 입력 시 ui 변경되면서, 더이상 입력되지 않습니다

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
조건에 따른 텍스트 필드 처리
- 시나리오 진행에 필요한 값
10자 이내의 텍스트, 10자 이상의 텍스트, 500자 이상의 텍스트
- 시나리오 진행에 필요한 조건
Scenedelegate에 writeQuestTypeVC 올려서 진행했습니다.
- 시나리오 완료 시 보장하는 결과
10자 이내 시 완료 버튼 비활성화, 10자 이상 입력시 버튼 활성화
터치 시 키보드 올라갔다 화면 밖을 누를 시 키보드가 내려갑니다. 
텍스트 필드 포커싱 시 ui 변경되고, 키보드가 내려가면 원래도 ui가 변경됩니다. 
아무것도 없는채로 입력이 끝나면 다시 플레이스 홀더가 생깁니다. 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`WriteQuestTypeViewController`
- 키보드를 올렸다가 내리기 위해 옵저버를 사용했습니다 
```swift
override func setAddTarget() {
        NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveUp), name: UIResponder.keyboardWillShowNotification, object: nil)
        NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveDown), name: UIResponder.keyboardWillHideNotification, object: nil)
        rootView.confirmButton.addTarget(self, action: #selector(confirmButtonDidTapped), for: .touchUpInside)
    }
    
//옵저버 해제 
    override func viewDidDisappear(_ animated: Bool) {
        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
    }
    
    @objc
    private func textViewMoveUp(_ notification: NSNotification) {
        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
            UIView.animate(withDuration: 0.3, animations: {
                let offsetY = keyboardSize.height - self.rootView.safeAreaInsets.bottom * 4
                self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
            })
        }
    }
    
    @objc
    private func textViewMoveDown() {
//원래 있던 높이로 되돌아갑니다 
        self.rootView.transform = .identity
    }
```

`TextViewProtocol`
텍스트 카운트 10자를 기준으로 버튼 활성화를 분기처리하기 위해 delegate 사용했습니다. 
```swift
protocol TextViewProtocol: AnyObject {
    func changeStyle(count: Int)
}

extension WriteQuestionTypeView: TextViewProtocol {
    func changeStyle(count: Int) {
        if (count >= 10) {
            confirmButton.updateType(.enabled)
        } else {
            confirmButton.updateType(.disabled)
        }
    }
}


```

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[UITextView PlaceHolder](https://chokotingchock.tistory.com/entry/UIKit-UITextView-placeholder)
[키보드에 가려지는 뷰 올리기] (https://nsios.tistory.com/17)
