### PR TITLE
Style/#71 퀘스트 초기 시작 UI 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f20b889fe5b27fbcf4e988dd7ba4d8be77f58c98d85e39019badff552f504428",
+  "originHash" : "8786c6260ce0a6c8ddbbc2b99e46fdf81606dafe784d81dd8075ccd41b680c15",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
         "version" : "5.10.2"
-      }
-    },
-    {
-      "identity" : "lottie-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-ios",
-      "state" : {
-        "revision" : "a004050748dc197c56256a14dca49a035d74726c",
-        "version" : "4.5.2"
       }
     },
     {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Extension/String+.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Extension/String+.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension String {
-
+    
     var isValidNickname: Bool {
         let regularExpression = "(?=.{2,5}$)(?!.*[ㄱ-ㅎㅏ-ㅣ])[가-힣a-zA-Z0-9]+"
         let predicate = NSPredicate(format: "SELF MATCHES %@", regularExpression)
@@ -19,25 +19,31 @@ extension String {
         return String(self.prefix(limit))
     }
     
-    func makeTitle(rangedText: String) -> NSMutableAttributedString {
+    func makeTitle(rangedText: String, font: UIFont? = nil, baseFont: UIFont? = nil) -> NSMutableAttributedString {
         let attributedString = NSMutableAttributedString(string: self)
-        
+
         attributedString.addAttribute(
             .foregroundColor,
             value: UIColor.grayscale50,
             range: NSRange(location: 0, length: self.count)
         )
-        
-        let range = (self as NSString).range(of: rangedText)
-        if range.location != NSNotFound {
+        if let baseFont = baseFont {
             attributedString.addAttribute(
-                .foregroundColor,
-                value: UIColor.primary300,
-                range: range
+                .font,
+                value: baseFont,
+                range: NSRange(location: 0, length: self.count)
             )
         }
-        
+
+        let range = (self as NSString).range(of: rangedText)
+        if range.location != NSNotFound {
+            if let font = font {
+                attributedString.addAttribute(.font, value: font, range: range)
+            }
+            attributedString.addAttribute(.foregroundColor, value: UIColor.primary300, range: range)
+        }
+
         return attributedString
     }
-
+    
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
@@ -79,7 +79,7 @@ final class QuestStartView: BaseView {
         descriptionLabel.snp.makeConstraints {
             $0.top.equalTo(cloverImageView.snp.bottom).offset(31.5.adjustedH)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(262.adjustedW)
+            $0.width.equalTo(270.adjustedW)
         }
         confirmButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
@@ -1,0 +1,91 @@
+//
+//  QuestStartView.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/9/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class QuestStartView: BaseView {
+    
+    private let nickname: String
+    
+    init(nickname: String) {
+        self.nickname = nickname
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private let titleLabel = UILabel()
+    private let cloverImageView = UIImageView()
+    private let descriptionLabel = UILabel()
+    let confirmButton = ByeBooButton(titleText: "시작하기", type: .enabled)
+    
+    override func setStyle() {
+        titleLabel.do {
+            $0.attributedText = "QUEST JOURNEY\nSTART!".makeTitle(rangedText: "QUEST JOURNEY")
+            $0.textAlignment = .center
+            $0.font = FontManager.head1Sb24.font
+            $0.numberOfLines = 2
+        }
+        cloverImageView.do {
+            $0.image = .clover
+            $0.contentMode = .scaleAspectFit
+        }
+        descriptionLabel.do {
+            $0.font = FontManager.body3R16.font
+            $0.attributedText = """
+                \(nickname)님의 상황에 꼭 맞춘
+                감정 직면 여정의 퀘스트 30개를 드릴게요.\n
+                제가 드리는 퀘스트와 함께
+                이별을 극복해나가요 !
+                """.makeTitle(
+                    rangedText: "\(nickname)",
+                    font: FontManager.body1Sb16.font,
+                    baseFont: FontManager.body3R16.font
+                )
+            $0.textAlignment = .center
+            $0.numberOfLines = 0
+        }
+    }
+    
+    override func setUI() {
+        addSubviews(
+            titleLabel,
+            cloverImageView,
+            descriptionLabel,
+            confirmButton
+        )
+    }
+    
+    override func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).inset(50.adjustedH)
+            $0.centerX.equalToSuperview()
+        }
+        cloverImageView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(31.5.adjustedH)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(262.adjustedW)
+            $0.height.equalTo(259.adjustedH)
+        }
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(cloverImageView.snp.bottom).offset(31.5.adjustedH)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(262.adjustedW)
+        }
+        confirmButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
+            $0.width.equalTo(326.adjustedW)
+            $0.height.equalTo(53.adjustedH)
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
@@ -1,0 +1,56 @@
+//
+//  QuestStartViewController.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/9/25.
+//
+
+import UIKit
+
+final class QuestStartViewController: BaseViewController {
+    
+    private let rootView = QuestStartView(nickname: "하츠핑")
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tabBarController?.tabBar.isHidden = true
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        ByeBooNavigationBar.makeNavigationBar(
+            navigationItem: self.navigationItem,
+            navigationController: self.navigationController,
+            type: .back,
+            action: #selector(back)
+        )
+    }
+    
+    override func setAddTarget() {
+        rootView.confirmButton.addTarget(
+            self,
+            action: #selector(questStartButtonDidTap),
+            for: .touchUpInside
+        )
+    }
+}
+
+extension QuestStartViewController: BackNavigable {
+    
+    func back() {
+        self.navigationController?.popViewController(animated: true)
+    }
+}
+
+extension QuestStartViewController {
+    
+    @objc
+    func questStartButtonDidTap() {
+        // 퀘스트 
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #71 

## 📄 작업 내용
- 퀘스트 초기 시작 화면을 구현했습니다
- BottomNavigationCotroller가 적용되어도 바텀 GNB가 보이지 않도록 설정했습니다

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| 퀘스트 초기 화면 | <img src = "https://github.com/user-attachments/assets/6b08fcbd-57d9-43fb-9c1a-0c155ff29c0b" width ="250"> | <img src = "https://github.com/user-attachments/assets/8e1cdc68-c111-4bf9-b0b7-db8a9de3397c" width ="250"> |

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
   * BottomNavigationController가 적용되어도 GNB가 보이지 않고 퀘스트 초기 시작 화면만 보임
- 시나리오 진행에 필요한 값
   * N/A
- 시나리오 진행에 필요한 조건
   * BottomNavigationController에서 HomeViewController를 QuestStartViewController로 교체하고 배경색을 검정으로 설정해주세요
- 시나리오 완료 시 보장하는 결과
   * 테스트 목적, 상황과 같음

## 💻 주요 코드 설명
`QuestStartViewController`
- 바텀 GNB가 적용되어있어도 가리도록 설정했어요
```swift
import UIKit

final class QuestStartViewController: BaseViewController {
    
    private let rootView = QuestStartView(nickname: "하츠핑")
    
    override func loadView() {
        view = rootView
    }
    
    // 여기서!
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        tabBarController?.tabBar.isHidden = true
    }
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        ByeBooNavigationBar.makeNavigationBar(
            navigationItem: self.navigationItem,
            navigationController: self.navigationController,
            type: .back,
            action: #selector(back)
        )
    }
    
    override func setAddTarget() {
        rootView.confirmButton.addTarget(
            self,
            action: #selector(questStartButtonDidTap),
            for: .touchUpInside
        )
    }
}

extension QuestStartViewController: BackNavigable {
    
    func back() {
        self.navigationController?.popViewController(animated: true)
    }
}

extension QuestStartViewController {
    
    // 추후 퀘스트 전체 조회 화면 구현 시 연결할 예정
    @objc
    func questStartButtonDidTap() {
        // 퀘스트 
    }
}
```

`String+`
- makeTitle 메서드 최종 수정했습니다
- basefont를 전체 텍스트에 적용하고 font를 특정 텍스트에 적용하도록 수정했습니다
```swift
func makeTitle(rangedText: String, font: UIFont? = nil, baseFont: UIFont? = nil) -> NSMutableAttributedString {
    let attributedString = NSMutableAttributedString(string: self)

    attributedString.addAttribute(
        .foregroundColor,
        value: UIColor.grayscale50,
        range: NSRange(location: 0, length: self.count)
    )
    if let baseFont = baseFont {
        attributedString.addAttribute(
            .font,
            value: baseFont,
            range: NSRange(location: 0, length: self.count)
        )
    }

    let range = (self as NSString).range(of: rangedText)
    if range.location != NSNotFound {
        if let font = font {
            attributedString.addAttribute(.font, value: font, range: range)
        }
        attributedString.addAttribute(.foregroundColor, value: UIColor.primary300, range: range)
    }

    return attributedString
}
```
