### PR TITLE
Style/#83 퀘스트 완료 UI 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
@@ -1,0 +1,19 @@
+//
+//  QuestAnswerEntity.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/10/25.
+//
+
+import Foundation
+
+struct QuestAnswerEntity {
+    var stepNumber: Int
+    var questNumber: Int
+    var createdAt: String
+    var question: String
+    var answer: String
+    var questEmotionState: String
+    var imageUrl: String?
+    var emotionDescription: String
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
@@ -12,7 +12,7 @@ struct QuestAnswerEntity {
     var questNumber: Int
     var createdAt: String
     var question: String
-    var answer: String
+    var answer: String?
     var questEmotionState: String
     var imageUrl: String?
     var emotionDescription: String

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/QuestAnswerInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/QuestAnswerInterface.swift
@@ -1,0 +1,10 @@
+//
+//  QuestAnswerInterface.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/10/25.
+//
+
+protocol QuestAnswerInterface {
+    func fetchQuestAnswer() async throws -> QuestAnswerEntity
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/QuestAnswerUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/QuestAnswerUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  QuestAnswerUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/10/25.
+//
+
+import Foundation
+
+protocol QuestAnswerUseCase {
+    func fetchQuestAnswer() async throws -> QuestAnswerEntity
+}
+
+struct DefaultQuestAnswerUseCase: QuestAnswerUseCase {
+    private let questAnswerRepository: QuestAnswerInterface
+    
+    init(questAnswerRepository: QuestAnswerInterface) {
+        self.questAnswerRepository = questAnswerRepository
+    }
+    
+    func fetchQuestAnswer() async throws -> QuestAnswerEntity {
+        return try await questAnswerRepository.fetchQuestAnswer()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionChip.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionChip.swift
@@ -10,52 +10,6 @@ import UIKit
 import SnapKit
 import Then
 
-enum ByeBooEmotion: CaseIterable {
-    case neutral
-    case selfUnderstanding
-    case sad
-    case relieved
-    
-    var key: String {
-        switch self {
-        case .neutral:
-            return "NEURTRAl"
-        case .sad:
-            return "SAD"
-        case .selfUnderstanding:
-            return "SELF_UNDERSTANDING"
-        case .relieved:
-            return "RELIEVED"
-        }
-    }
-    
-    var emotionImage: UIImageView {
-        switch self {
-        case .neutral:
-            return UIImageView(image: .neutral)
-        case .sad:
-            return UIImageView(image: .emotionSad)
-        case .selfUnderstanding:
-            return UIImageView(image: .selfUnderstanding)
-        case .relieved:
-            return UIImageView(image: .relieved)
-        }
-    }
-    
-    var emotionText: String {
-        switch self {
-        case .neutral:
-            return "그저그런"
-        case .sad:
-            return "슬픈"
-        case .selfUnderstanding:
-            return "자기이해"
-        case .relieved:
-            return "후련함"
-        }
-    }
-}
-
 final class ByeBooEmotionChip: BaseView {
     private let emotionImage: UIImageView
     let emotionTag: ByeBooFilledTag
@@ -106,18 +60,6 @@ final class ByeBooEmotionChip: BaseView {
             $0.top.equalTo(emotionImage.snp.bottom).offset(8.adjustedH)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(84.adjustedW)
-        }
-    }
-}
-
-extension ByeBooEmotion {
-    static func toEmotion(text: String) -> ByeBooEmotion {
-        switch text {
-        case "그저그런": return .neutral
-        case "슬픈": return .sad
-        case "자기이해": return .selfUnderstanding
-        case "후련함": return .relieved
-        default: return .neutral
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionChip.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionChip.swift
@@ -60,10 +60,16 @@ final class ByeBooEmotionChip: BaseView {
     private let emotionImage: UIImageView
     let emotionTag: ByeBooFilledTag
     let emotionType: ByeBooEmotion
-
-    init(emotionType: ByeBooEmotion) {
+    
+    init(emotionType: ByeBooEmotion, isPurple: Bool = false) {
         self.emotionImage = emotionType.emotionImage
-        self.emotionTag = ByeBooFilledTag(tagType: .largeGray, text: emotionType.emotionText)
+        
+        if isPurple == true {
+            self.emotionTag = ByeBooFilledTag(tagType: .largePurple, text: emotionType.emotionText)
+        } else {
+            self.emotionTag = ByeBooFilledTag(tagType: .largeGray, text: emotionType.emotionText)
+        }
+        
         self.emotionType = emotionType
         super.init(frame: .zero)
     }
@@ -100,6 +106,18 @@ final class ByeBooEmotionChip: BaseView {
             $0.top.equalTo(emotionImage.snp.bottom).offset(8.adjustedH)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(84.adjustedW)
+        }
+    }
+}
+
+extension ByeBooEmotion {
+    static func toEmotion(text: String) -> ByeBooEmotion {
+        switch text {
+        case "그저그런": return .neutral
+        case "슬픈": return .sad
+        case "자기이해": return .selfUnderstanding
+        case "후련함": return .relieved
+        default: return .neutral
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/TextBoxView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/TextBoxView.swift
@@ -25,7 +25,7 @@ final class TextBoxView: BaseView {
         self.titleLabel.text = title
 
         if let emotionType {
-            emotionChip = ByeBooEmotionChip(emotionType: emotionType)
+            emotionChip = ByeBooEmotionChip(emotionType: emotionType, isPurple: true)
         }
 
         super.init(frame: .zero)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Enum/ByeBooEmotion.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Enum/ByeBooEmotion.swift
@@ -1,0 +1,64 @@
+//
+//  ByeBooEmotion.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/11/25.
+//
+
+import UIKit
+
+enum ByeBooEmotion: CaseIterable {
+    case neutral
+    case selfUnderstanding
+    case sad
+    case relieved
+    
+    var key: String {
+        switch self {
+        case .neutral:
+            return "NEURTRAl"
+        case .sad:
+            return "SAD"
+        case .selfUnderstanding:
+            return "SELF_UNDERSTANDING"
+        case .relieved:
+            return "RELIEVED"
+        }
+    }
+    
+    var emotionImage: UIImageView {
+        switch self {
+        case .neutral:
+            return UIImageView(image: .neutral)
+        case .sad:
+            return UIImageView(image: .emotionSad)
+        case .selfUnderstanding:
+            return UIImageView(image: .selfUnderstanding)
+        case .relieved:
+            return UIImageView(image: .relieved)
+        }
+    }
+    
+    var emotionText: String {
+        switch self {
+        case .neutral:
+            return "그저그런"
+        case .sad:
+            return "슬픈"
+        case .selfUnderstanding:
+            return "자기이해"
+        case .relieved:
+            return "후련함"
+        }
+    }
+    
+    static func toEmotion(text: String) -> ByeBooEmotion {
+        switch text {
+        case "그저그런": return .neutral
+        case "슬픈": return .sad
+        case "자기이해": return .selfUnderstanding
+        case "후련함": return .relieved
+        default: return .neutral
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/ActionView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/ActionView.swift
@@ -8,15 +8,14 @@
 import UIKit
 
 import Kingfisher
+import SnapKit
 
 final class ActionView: BaseView {
 
-    private let iconImageView = UIImageView()
-    private let titleLabel = UILabel()
     private let photoView = UIImageView()
     private let descriptionView: TextBoxView?
     private let placeholderView = UIImageView()
-    
+    private let thinkTextView =  IconOneLineTextView(iconType: .think,text: "이렇게 완료했어요" )
     private let descriptionText: String?
     private let photoURL: String
     
@@ -41,14 +40,6 @@ final class ActionView: BaseView {
     }
     
     override func setStyle() {
-        iconImageView.do {
-            $0.image = .think
-        }
-        titleLabel.do {
-            $0.text = "이렇게 완료했어요"
-            $0.font = FontManager.body2M16.font
-            $0.textColor = .grayscale200
-        }
         photoView.do {
             $0.layer.cornerRadius = 12
             $0.clipsToBounds = true
@@ -63,9 +54,8 @@ final class ActionView: BaseView {
     
     override func setUI() {
         addSubviews(
-            iconImageView,
-            titleLabel,
-            photoView
+            photoView,
+            thinkTextView
         )
         
         if let descriptionView {
@@ -74,19 +64,20 @@ final class ActionView: BaseView {
     }
     
     override func setLayout() {
-        iconImageView.snp.makeConstraints {
+        thinkTextView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(24.5.adjustedH)
-            $0.leading.equalToSuperview().inset(24.adjustedW)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
         }
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24.5.adjustedH)
-            $0.leading.equalTo(iconImageView.snp.trailing).offset(8.adjustedW)
-        }
+        
         photoView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12.adjustedH)
+            $0.top.equalTo(thinkTextView.snp.bottom).offset(12.adjustedH)
             $0.size.equalTo(327.adjustedW)
             $0.centerX.equalToSuperview()
+            if descriptionView == nil {
+                $0.bottom.equalToSuperview().inset(24.5.adjustedH)
+            }
         }
+        
         if let descriptionView {
             descriptionView.snp.makeConstraints {
                 $0.top.equalTo(photoView.snp.bottom).offset(12.adjustedH)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/FeelView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/FeelView.swift
@@ -7,14 +7,15 @@
 
 import UIKit
 
+import SnapKit
+
 final class FeelView: BaseView {
 
-    private let iconImageView = UIImageView()
-    private let titleLabel = UILabel()
     private let descriptionView: TextBoxView
-    
     private let emotionType: String
     private let descriptionText: String
+    
+    private let titleTextView = IconOneLineTextView(iconType: .change, text: "퀘스트 완료 후, 이런 감정을 느꼈어요")
     
     init(emotionType: String, descriptionText: String) {
         self.emotionType = emotionType
@@ -29,35 +30,24 @@ final class FeelView: BaseView {
     }
     
     override func setStyle() {
-        iconImageView.do {
-            $0.image = .change
-        }
-        titleLabel.do {
-            $0.text = "퀘스트 완료 후, 이런 감정을 느꼈어요"
-            $0.font = FontManager.body2M16.font
-            $0.textColor = .grayscale200
-        }
+        
     }
     
     override func setUI() {
         addSubviews(
-            iconImageView,
-            titleLabel,
+            titleTextView,
             descriptionView
         )
     }
     
     override func setLayout() {
-        iconImageView.snp.makeConstraints {
+        titleTextView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(24.5.adjustedH)
-            $0.leading.equalToSuperview().inset(24.adjustedW)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
         }
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24.5.adjustedH)
-            $0.leading.equalTo(iconImageView.snp.trailing).offset(8.adjustedW)
-        }
+       
         descriptionView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12.adjustedH)
+            $0.top.equalTo(titleTextView.snp.bottom).offset(12.adjustedH)
             $0.horizontalEdges.equalToSuperview().inset(24.adjustedW)
             $0.bottom.equalToSuperview().inset(24.5.adjustedH)
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/ThinkView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/ThinkView.swift
@@ -7,10 +7,11 @@
 
 import UIKit
 
+import SnapKit
+
 final class ThinkView: BaseView {
 
-    private let iconImageView = UIImageView()
-    private let titleLabel = UILabel()
+    private let titleTextView = IconOneLineTextView(iconType: .think, text: "이렇게 생각했어요")
     private let descriptionView: TextBoxView
     
     private let descriptionText: String
@@ -27,35 +28,24 @@ final class ThinkView: BaseView {
     }
     
     override func setStyle() {
-        iconImageView.do {
-            $0.image = .think
-        }
-        titleLabel.do {
-            $0.text = "이렇게 생각했어요"
-            $0.font = FontManager.body2M16.font
-            $0.textColor = .grayscale200
-        }
+
     }
     
     override func setUI() {
         addSubviews(
-            iconImageView,
-            titleLabel,
+            titleTextView,
             descriptionView
         )
     }
     
     override func setLayout() {
-        iconImageView.snp.makeConstraints {
+        titleTextView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(24.5.adjustedH)
-            $0.leading.equalToSuperview().inset(24.adjustedW)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
         }
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24.5.adjustedH)
-            $0.leading.equalTo(iconImageView.snp.trailing).offset(8.adjustedW)
-        }
+        
         descriptionView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12.adjustedH)
+            $0.top.equalTo(titleTextView.snp.bottom).offset(12.adjustedH)
             $0.horizontalEdges.equalToSuperview().inset(24.adjustedW)
             $0.bottom.equalToSuperview().inset(24.5.adjustedH)
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestView.swift
@@ -11,7 +11,121 @@ import SnapKit
 import Then
 
 final class CompleteActiveTypeQuestView: BaseView {
+    
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    private let congratSquare = CongratSquare()
+    private let stepStackView = UIStackView()
+    private var stepNum: Int = 0
+    private let stepLabel = ByeBooYellowTag(text: "STEP 0")
+    private var questNum: Int = 0
+    private let questLabel = UILabel()
+    private let dateText = UILabel()
+    private let title = UILabel()
+    
+    override func setUI() {
+        addSubviews(scrollView)
+        scrollView.addSubview(contentView)
+        
+        contentView.addSubviews(
+            congratSquare,
+            stepStackView,
+            dateText,
+            title
+        )
+        
+        stepStackView.addArrangedSubviews(stepLabel, questLabel)
+    }
+    
     override func setStyle() {
-        backgroundColor = .primary200
+        backgroundColor = .grayscale900
+        
+        contentView.do {
+            $0.backgroundColor = .grayscale900
+        }
+        
+        stepStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 8
+        }
+        
+        questLabel.do {
+            $0.font = FontManager.body5R14.font
+            $0.textColor = .grayscale400
+        }
+        
+        dateText.do {
+            $0.font = FontManager.body5R14.font
+            $0.textColor = .grayscale400
+            $0.textAlignment = .center
+        }
+        
+        title.do {
+            $0.font = FontManager.head1Sb24.font
+            $0.numberOfLines = 2
+            $0.textColor = .grayscale100
+            $0.textAlignment = .center
+        }
+    }
+    
+    func bind(with entity: QuestAnswerEntity) {
+        self.stepNum = entity.stepNumber
+        stepLabel.updateText("STEP \(stepNum)")
+        self.questNum = entity.questNumber
+        self.questLabel.text = "\(questNum)번째 퀘스트"
+        self.title.text = entity.question
+        self.dateText.text = entity.createdAt
+        
+        let actionView = ActionView(descriptionText: entity.answer, photoURL: entity.imageUrl!)
+        let feelView = FeelView(
+            emotionType: entity.questEmotionState,
+            descriptionText: entity.emotionDescription
+        )
+
+        contentView.addSubviews(actionView, feelView)
+
+        actionView.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        feelView.snp.makeConstraints {
+            $0.top.equalTo(actionView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(24.adjustedH)
+        }
+    }
+    
+    override func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.greaterThanOrEqualToSuperview()
+        }
+        
+        congratSquare.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
+        
+        stepStackView.snp.makeConstraints {
+            $0.top.equalTo(congratSquare.snp.bottom).offset(32.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(124.5.adjustedW)
+            $0.width.equalTo(70.adjustedW)
+        }
+        
+        dateText.snp.makeConstraints {
+            $0.top.equalTo(stepStackView.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(147.5.adjustedW)
+        }
+        
+        title.snp.makeConstraints {
+            $0.top.equalTo(dateText.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
@@ -5,17 +5,55 @@
 //  Created by 이나연 on 7/10/25.
 //
 
+import Combine
 import UIKit
 
 final class CompleteActiveTypeQuestViewController: BaseViewController {
-    private let rootView = CompleteActiveTypeQuestView()
     
+    private let rootView = CompleteActiveTypeQuestView()
+    private let viewModel = CompleteQuestViewModel()
+    private var cancellables = Set<AnyCancellable>()
+    
+
     override func loadView() {
         view = rootView
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationItem.hidesBackButton = true
+        viewModel.action(.questAnswerDidLoad)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        ByeBooLogger.debug("뷰 디드로드")
+        
+        ByeBooNavigationBar.makeNavigationBar(
+            navigationItem: self.navigationItem,
+            navigationController: self.navigationController,
+            type: .close,
+            action: #selector(close)
+        )
+        
+        bind()
+    }
+    
+    private func bind() {
+        viewModel.output.resultPublisher
+            .sink { [weak self] result in
+                switch result {
+                case .success(let entity):
+                    self?.rootView.bind(with: entity)
+                case .failure(let error):
+                    ByeBooLogger.debug(error)
+                }
+            }
+            .store(in: &cancellables)
+    }
+}
+
+extension CompleteActiveTypeQuestViewController: Dismissible {
+    @objc func close() {
+        // TODO: - 퀘스트 메인 이동 수정
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
@@ -52,7 +52,7 @@ final class CompleteActiveTypeQuestViewController: BaseViewController {
 }
 
 extension CompleteActiveTypeQuestViewController: Dismissible {
-    @objc func close() {
+    func close() {
         // TODO: - 퀘스트 메인 이동 수정
         self.navigationController?.popViewController(animated: true)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -121,13 +121,6 @@ extension WriteActiveTypeQuestViewController: UIGestureRecognizerDelegate {
     -> Bool {
         return true
     }
-    
-//    func gestureRecognizer(
-//        _ gestureRecognizer: UIGestureRecognizer,
-//       shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer)
-//    -> Bool {
-//            return true
-//    }
 }
 
 extension WriteActiveTypeQuestViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
@@ -156,6 +149,5 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
     func presentNextViewController(from previousView: PreviousView) {
         let viewController = CompleteActiveTypeQuestViewController()
         self.navigationController?.pushViewController(viewController, animated: true)
-        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -33,13 +33,7 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(textViewMoveDown), name: UIResponder.keyboardWillHideNotification, object: nil)
         rootView.confirmButton.addTarget(self, action: #selector(confirmButtonDidTap), for: .touchUpInside)
     }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        rootView.layoutIfNeeded()
-        ByeBooLogger.debug("✅ tipTag frame: \(rootView.title.tipTag.frame)")
-    }
-    
+        
     private func setGesture() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(endEditingOnTap))
         let tipTagGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tipTagDidTap))

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
@@ -1,0 +1,81 @@
+//
+//  CongratSqusre.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/10/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CongratSquare: BaseView {
+    private let titleLabel = UILabel()
+    private let imageView = UIImageView()
+    private let descriptionLabel = UILabel()
+    
+    init() {
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setUI() {
+        addSubviews(titleLabel, imageView, descriptionLabel)
+    }
+    
+    override func setStyle() {
+        self.do {
+            $0.layer.cornerRadius = 12
+            $0.backgroundColor = .white10
+        }
+        
+        titleLabel.do {
+            $0.attributedText = "QUEST\nCOMPLETE!".makeTitle(rangedText: "QUEST")
+            $0.font = FontManager.head1Sb24.font
+            $0.numberOfLines = 2
+            $0.textAlignment = .center
+        }
+        
+        imageView.do {
+            $0.image = .congrate
+            $0.contentMode = .scaleAspectFill
+        }
+        
+        descriptionLabel.do {
+            $0.font = FontManager.body3R16.font
+            $0.text = "기특해요 !\n점점 극복에 가까워지고 있어요 :)"
+            $0.textColor = .grayscale300
+            $0.numberOfLines = 2
+            $0.textAlignment = .center
+        }
+    }
+    
+    override func setLayout() {
+        self.snp.makeConstraints {
+            $0.width.equalTo(325.adjustedW)
+            $0.height.equalTo(365.adjustedH)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(24.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(61.adjustedH)
+            $0.width.equalTo(203.adjustedW)
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
+            $0.width.equalTo(203.adjustedW)
+            $0.height.equalTo(181.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(61.adjustedH)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(imageView.snp.bottom).offset(16.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(61.adjustedH)
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
@@ -15,14 +15,6 @@ final class CongratSquare: BaseView {
     private let imageView = UIImageView()
     private let descriptionLabel = UILabel()
     
-    init() {
-        super.init(frame: .zero)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     override func setUI() {
         addSubviews(titleLabel, imageView, descriptionLabel)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
@@ -22,8 +22,6 @@ final class CompleteQuestionTypeQuestView: BaseView {
     private let questLabel = UILabel()
     private let dateText = UILabel()
     private let title = UILabel()
-    private let thinkTitle = IconOneLineTextView(iconType: .think, text: "이렇게 생각했어요")
-    private let changeTitle = IconOneLineTextView(iconType: .change, text: "퀘스트 완료 후, 이런 감정을 느꼈어요")
     
     override func setUI() {
         addSubviews(scrollView)
@@ -33,9 +31,7 @@ final class CompleteQuestionTypeQuestView: BaseView {
             congratSquare,
             stepStackView,
             dateText,
-            title,
-            thinkTitle,
-            changeTitle
+            title
         )
         
         stepStackView.addArrangedSubviews(stepLabel, questLabel)
@@ -82,48 +78,35 @@ final class CompleteQuestionTypeQuestView: BaseView {
         self.dateText.text = entity.createdAt
         
         
-        let thinkTextView = TextBoxView(title: entity.answer)
-        let changeTextView = TextBoxView (
-            title: entity.emotionDescription,
-            emotionType: ByeBooEmotion.toEmotion(text: entity.questEmotionState)
-        )
+        let thinkView = ThinkView(descriptionText: entity.answer!)
+        let feelView = FeelView(emotionType: entity.emotionDescription, descriptionText: entity.emotionDescription)
         
-        addSubviews(thinkTextView, changeTextView)
+        contentView.addSubviews(thinkView, feelView)
         
-        thinkTextView.isUserInteractionEnabled = false
-        changeTextView.isUserInteractionEnabled = false
-
-        contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.width.equalToSuperview()
-            $0.height.greaterThanOrEqualToSuperview()
-            $0.bottom.equalTo(changeTextView.snp.bottom).offset(24.adjustedH)
+        thinkView.isUserInteractionEnabled = false
+        feelView.isUserInteractionEnabled = false
+        
+        thinkView.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview()
         }
         
-        thinkTitle.snp.makeConstraints {
-            $0.top.equalTo(title.snp.bottom).offset(24.5.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
-        }
-        
-        thinkTextView.snp.makeConstraints {
-            $0.top.equalTo(thinkTitle.snp.bottom).offset(12.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
-        }
-        
-        changeTitle.snp.makeConstraints {
-            $0.top.equalTo(thinkTextView.snp.bottom).offset(24.5.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
-        }
-        
-        changeTextView.snp.makeConstraints {
-            $0.top.equalTo(changeTitle.snp.bottom).offset(12.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        feelView.snp.makeConstraints {
+            $0.top.equalTo(thinkView.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(24.adjustedH)
         }
     }
     
     override func setLayout() {
         scrollView.snp.makeConstraints {
             $0.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.greaterThanOrEqualToSuperview()
         }
         
         congratSquare.snp.makeConstraints {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
@@ -11,8 +11,141 @@ import SnapKit
 import Then
 
 final class CompleteQuestionTypeQuestView: BaseView {
+    
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    private let congratSquare = CongratSquare()
+    private let stepStackView = UIStackView()
+    private var stepNum: Int = 0
+    private let stepLabel = ByeBooYellowTag(text: "STEP 0")
+    private var questNum: Int = 0
+    private let questLabel = UILabel()
+    private let dateText = UILabel()
+    private let title = UILabel()
+    private let thinkTitle = IconOneLineTextView(iconType: .think, text: "이렇게 생각했어요")
+    private let changeTitle = IconOneLineTextView(iconType: .change, text: "퀘스트 완료 후, 이런 감정을 느꼈어요")
+    
+    override func setUI() {
+        addSubviews(scrollView)
+        scrollView.addSubview(contentView)
+        
+        contentView.addSubviews(
+            congratSquare,
+            stepStackView,
+            dateText,
+            title,
+            thinkTitle,
+            changeTitle
+        )
+        
+        stepStackView.addArrangedSubviews(stepLabel, questLabel)
+    }
+    
     override func setStyle() {
-        backgroundColor = .primary400
+        backgroundColor = .grayscale900
+        
+        contentView.do {
+            $0.backgroundColor = .grayscale900
+        }
+        
+        stepStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 8
+        }
+        
+        questLabel.do {
+            $0.font = FontManager.body5R14.font
+            $0.textColor = .grayscale400
+        }
+        
+        dateText.do {
+            $0.font = FontManager.body5R14.font
+            $0.textColor = .grayscale400
+            $0.textAlignment = .center
+        }
+        
+        title.do {
+            $0.font = FontManager.head1Sb24.font
+            $0.numberOfLines = 2
+            $0.textColor = .grayscale100
+            $0.textAlignment = .center
+        }
+        
+    }
+    
+    func bind(with entity: QuestAnswerEntity) {
+        self.stepNum = entity.stepNumber
+        stepLabel.updateText("STEP \(stepNum)")
+        self.questNum = entity.questNumber
+        self.questLabel.text = "\(questNum)번째 퀘스트"
+        self.title.text = entity.question
+        self.dateText.text = entity.createdAt
+        
+        
+        let thinkTextView = TextBoxView(title: entity.answer)
+        let changeTextView = TextBoxView (
+            title: entity.emotionDescription,
+            emotionType: ByeBooEmotion.toEmotion(text: entity.questEmotionState)
+        )
+        
+        addSubviews(thinkTextView, changeTextView)
+        
+        thinkTextView.isUserInteractionEnabled = false
+        changeTextView.isUserInteractionEnabled = false
+
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.greaterThanOrEqualToSuperview()
+            $0.bottom.equalTo(changeTextView.snp.bottom).offset(24.adjustedH)
+        }
+        
+        thinkTitle.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(24.5.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
+        
+        thinkTextView.snp.makeConstraints {
+            $0.top.equalTo(thinkTitle.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
+        
+        changeTitle.snp.makeConstraints {
+            $0.top.equalTo(thinkTextView.snp.bottom).offset(24.5.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
+        
+        changeTextView.snp.makeConstraints {
+            $0.top.equalTo(changeTitle.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
+    }
+    
+    override func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        congratSquare.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
+        
+        stepStackView.snp.makeConstraints {
+            $0.top.equalTo(congratSquare.snp.bottom).offset(32.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(124.5.adjustedW)
+            $0.width.equalTo(70.adjustedW)
+        }
+        
+        dateText.snp.makeConstraints {
+            $0.top.equalTo(stepStackView.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(147.5.adjustedW)
+        }
+        
+        title.snp.makeConstraints {
+            $0.top.equalTo(dateText.snp.bottom).offset(12.adjustedH)
+            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestViewController.swift
@@ -51,7 +51,7 @@ final class CompleteQuestionTypeQuestViewController: BaseViewController {
 }
 
 extension CompleteQuestionTypeQuestViewController: Dismissible {
-    @objc func close() {
+    func close() {
         // TODO: 퀘스트 메인 이동
         self.navigationController?.popViewController(animated: true)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 final class CompleteQuestionTypeQuestViewController: BaseViewController {
     
     private let rootView = CompleteQuestionTypeQuestView()
-    private let viewModel = CompleteQuestionTypeQuestViewModel()
+    private let viewModel = CompleteQuestViewModel()
     private var cancellables = Set<AnyCancellable>()
     
     override func loadView() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestViewController.swift
@@ -5,12 +5,54 @@
 //  Created by 이나연 on 7/10/25.
 //
 
+import Combine
 import UIKit
 
 final class CompleteQuestionTypeQuestViewController: BaseViewController {
+    
     private let rootView = CompleteQuestionTypeQuestView()
+    private let viewModel = CompleteQuestionTypeQuestViewModel()
+    private var cancellables = Set<AnyCancellable>()
     
     override func loadView() {
         view = rootView
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationItem.hidesBackButton = true
+        viewModel.action(.questAnswerDidLoad)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        ByeBooNavigationBar.makeNavigationBar(
+            navigationItem: self.navigationItem,
+            navigationController: self.navigationController,
+            type: .close,
+            action: #selector(close)
+        )
+        
+        bind()
+    }
+    
+    private func bind() {
+        viewModel.output.resultPublisher
+            .sink { [weak self] result in
+                switch result {
+                case .success(let entity):
+                    self?.rootView.bind(with: entity)
+                case .failure(let error):
+                    ByeBooLogger.debug(error)
+                }
+            }
+            .store(in: &cancellables)
+    }
+}
+
+extension CompleteQuestionTypeQuestViewController: Dismissible {
+    @objc func close() {
+        // TODO: 퀘스트 메인 이동
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
@@ -96,6 +96,5 @@ extension WriteQuestionTypeQuestViewController: BottomSheetProtocol {
     func presentNextViewController(from previousView: PreviousView) {
         let viewController = CompleteQuestionTypeQuestViewController()
         self.navigationController?.pushViewController(viewController, animated: true)
-        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/CompleteQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/CompleteQuestViewModel.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-final class CompleteQuestionTypeQuestViewModel: ViewModelType {
+final class CompleteQuestViewModel: ViewModelType {
     
     enum InputAction {
         case questAnswerDidLoad
@@ -52,7 +52,7 @@ final class CompleteQuestionTypeQuestViewModel: ViewModelType {
             question: "연애에서 반복됐던 문제 패턴 3가지를 생각해보아요.",
             answer: "내 X는 질투가 너무 많았슨... 그래서 동아리를 할 수가 없었슨.. 특히 솝트처럼 합숙하는 동아린 완전 금지였슨..ㅜㅜ",
             questEmotionState: "자기이해",
-            imageUrl: nil,
+            imageUrl: "https://default.image/url.png",
             emotionDescription: "퀘스트를 통해 스스로에 대해 더 잘 알게 되셨네요! 아주 바람직하게 나아가고 있어요."
         )
         return data

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/CompleteQuestionTypeQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/CompleteQuestionTypeQuestViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  CompleteQuestionTypeQuestViewModel.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/10/25.
+//
+
+import Combine
+import Foundation
+
+final class CompleteQuestionTypeQuestViewModel: ViewModelType {
+    
+    enum InputAction {
+        case questAnswerDidLoad
+    }
+    
+    struct Output {
+        let resultPublisher: AnyPublisher<Result<QuestAnswerEntity, ByeBooError>, Never>
+    }
+    
+    func action(_ trigger: InputAction) {
+        switch trigger {
+        case .questAnswerDidLoad:
+            let entity = fetchQuestAnswer()
+            resultSubject.send(.success(entity))
+        }
+    }
+    
+    private var resultSubject: PassthroughSubject<Result<QuestAnswerEntity, ByeBooError>, Never> = .init()
+    
+    var output: Output {
+        Output(
+            resultPublisher: resultSubject.eraseToAnyPublisher()
+        )
+    }
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
+//    private let useCase: QuestAnswerUseCase
+    
+//    init(useCase: QuestAnswerUseCase) {
+//        self.useCase = useCase
+//    }
+    
+    init() { }
+    
+    private func fetchQuestAnswer() -> QuestAnswerEntity {
+        let data = QuestAnswerEntity(
+            stepNumber: 2,
+            questNumber: 10,
+            createdAt: "2025-07-10",
+            question: "연애에서 반복됐던 문제 패턴 3가지를 생각해보아요.",
+            answer: "내 X는 질투가 너무 많았슨... 그래서 동아리를 할 수가 없었슨.. 특히 솝트처럼 합숙하는 동아린 완전 금지였슨..ㅜㅜ",
+            questEmotionState: "자기이해",
+            imageUrl: nil,
+            emotionDescription: "퀘스트를 통해 스스로에 대해 더 잘 알게 되셨네요! 아주 바람직하게 나아가고 있어요."
+        )
+        return data
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #83

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 퀘스트 완료 행동형, 질문형 모두 작업했습니다
- 주리드의 컴포넌트 중 제가 만든 iconOneLineTextView로 갈아끼울 수 있는 부분들을 수정했습니다
- 주리드 불러서 안되는거 말하면 말하면서 잘못된게 보이는 매직.......... 이것은 무엇일까요..?ㅜㅜ

|    구현 내용    |   퀘스트 완료 (행동형, Answer 없음)   |   퀘스트 완료 (행동형, Answer 있음)   |   퀘스트 완료 (질문형)  |
| :----------: | :--------------------------------: | :--------------------------------: | :----------------------: |
| GIF | <img src="https://github.com/user-attachments/assets/52948003-50bc-4381-b89e-eb9bc0aa0839" width="250" /> | <img src="https://github.com/user-attachments/assets/9e978f44-ef64-46c2-b82a-54d2f03e6ec9" width="250" /> | <img src="https://github.com/user-attachments/assets/e4d1d894-d6c4-4d34-a0e6-7b281f072a29" width="250" /> |

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
뷰가 잘 뜹니다
- 시나리오 진행에 필요한 값
N/A
- 시나리오 진행에 필요한 조건
SceneDelegate에 뷰컨트롤러 올려서 진행했습니다

- 시나리오 완료 시 보장하는 결과
뷰가 잘 뜹니다 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`QuestAnswerEntity`
- 퀘스트 완료 행동형 뷰컨과 질문형 뷰컨은 하나의 entity와 하나의 viewmodel을 사용합니다 
- 행동형에서는 이미지가 필수이지만 answer가 비어있을 수 있고, 질문형에서는 이미지가 비어있을 수 있기 때문에 해당 변수를 옵셔널로 처리했습니다
```swift
struct QuestAnswerEntity {
    var stepNumber: Int
    var questNumber: Int
    var createdAt: String
    var question: String
    var answer: String?
    var questEmotionState: String
    var imageUrl: String?
    var emotionDescription: String
}
```

`ActionView`
- 주리드의 컴포넌트를 야악간 수정했습니다
- 행동형에서 answer가 없는 경우 제약조건들이 겹치길래 분기처리를 해줬습니다
``` swift
 photoView.snp.makeConstraints {
            $0.top.equalTo(thinkTextView.snp.bottom).offset(12.adjustedH)
            $0.size.equalTo(327.adjustedW)
            $0.centerX.equalToSuperview()
            if descriptionView == nil {
                $0.bottom.equalToSuperview().inset(24.5.adjustedH)
            }
        }
```

