### PR TITLE
Feat/#102 퀘스트 시작 뷰 작업

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
@@ -17,7 +17,7 @@ struct DataDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: UsersInterface.self) { _ in
             return DefaultUsersRepository(network: networkService, userDefatulsService: userDefaultService)
         }
-        
+         
         DIContainer.shared.register(type: GetQuestInfoInterface.self) { _ in
             return DefaultGetQuestInfoRepository(network: networkService, userDefaultService: userDefaultService)
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -58,6 +58,8 @@ struct DefaultNetworkService: NetworkService {
                                 message: errorResponse.message
                             )
                         }
+                        
+                        
                         ByeBooLogger.error(error)
                         continuation.resume(throwing: error)
                     } else {
@@ -92,16 +94,7 @@ struct DefaultNetworkService: NetworkService {
                     if let data = response.data,
                        let statusCode = response.response?.statusCode,
                        let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
-                        let error: ByeBooError
-                        
-                        if statusCode == 404 {
-                            error = ByeBooError.notFoundQuest
-                        } else {
-                            error = ByeBooError.networkError(
-                                code: statusCode,
-                                message: errorResponse.message
-                            )
-                        }
+                        let error = handleError(statusCode, errorResponse.message)
                         ByeBooLogger.error(error)
                         continuation.resume(throwing: error)
                     } else {
@@ -126,5 +119,20 @@ struct DefaultNetworkService: NetworkService {
         ByeBooLogger.network("StatusCode: \(response.response!.statusCode)")
         ByeBooLogger.network("Header: \(response.response!.headers)")
         ByeBooLogger.network("Description: \(response.response!.description)")
+    }
+    
+    private func handleError(_ statusCode: Int, _ errorResponse: String) -> ByeBooError {
+        let error: ByeBooError
+        
+        if statusCode == 404 {
+            error = ByeBooError.notFoundQuest
+        } else {
+            error = ByeBooError.networkError(
+                code: statusCode,
+                message: errorResponse
+            )
+        }
+        
+        return error
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeHeaderView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeHeaderView.swift
@@ -56,6 +56,10 @@ extension HomeHeaderView {
         journeyProgressView?.updateName(name)
     }
     
+    func updateJourney(_ title: String) {
+        journeyProgressView?.updateJourney(title)
+    }
+    
     func updateState(_ state: HomeState) {
         if state.hasProgress {
             if journeyProgressView == nil {
@@ -71,8 +75,6 @@ extension HomeHeaderView {
                 journeyProgressView,
                 textBox
             )
-            
-            journeyProgressView.updateJourney(state.title)
         }
         
         homeStateView.updateState(state)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeView.swift
@@ -46,11 +46,8 @@ extension HomeView {
         headerView.updateTextBox(text)
     }
     
-    func updateProgress(_ progress: Int) {
+    func updateProgressView(_ name: String, _ progress: Int) {
         headerView.updateProgress(progress)
-    }
-    
-    func updateName(_ name: String) {
         headerView.updateName(name)
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeView.swift
@@ -46,9 +46,14 @@ extension HomeView {
         headerView.updateTextBox(text)
     }
     
-    func updateProgressView(_ name: String, _ progress: Int) {
+    func updateProgressView(
+        name: String,
+        progress: Int,
+        journey: String
+    ) {
         headerView.updateProgress(progress)
         headerView.updateName(name)
+        headerView.updateJourney(journey)
     }
     
     func updateState(_ state: HomeState) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
@@ -89,30 +89,6 @@ extension HomeViewController {
             }
             .store(in: &cancellables)
         
-        viewModel.output.countResult
-            .receive(on: DispatchQueue.main)
-            .sink { result in
-                switch result {
-                case .success(let count):
-                    self.rootView.updateProgress(count)
-                case .failure(let failure):
-                    ByeBooLogger.error(failure)
-                }
-            }
-            .store(in: &cancellables)
-        
-        viewModel.output.userResult
-            .receive(on: DispatchQueue.main)
-            .sink { result in
-                switch result {
-                case .success(let name):
-                    self.rootView.updateName(name)
-                case .failure(let failure):
-                    ByeBooLogger.error(failure)
-                }
-            }
-            .store(in: &cancellables)
-        
         viewModel.output.homeStateResult
             .receive(on: DispatchQueue.main)
             .sink { result in
@@ -122,6 +98,18 @@ extension HomeViewController {
                     self.state = state
                 case .failure(let failure):
                     ByeBooLogger.error(failure)
+                }
+            }
+            .store(in: &cancellables)
+        
+        Publishers.CombineLatest(viewModel.output.countResult, viewModel.output.userResult)
+            .receive(on: DispatchQueue.main)
+            .sink { count, name in
+                switch (count, name) {
+                case let (.success(count), .success(name)):
+                    self.rootView.updateProgressView(name, count)
+                default:
+                    ByeBooLogger.error(ByeBooError.noData)
                 }
             }
             .store(in: &cancellables)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
@@ -102,12 +102,23 @@ extension HomeViewController {
             }
             .store(in: &cancellables)
         
-        Publishers.CombineLatest(viewModel.output.countResult, viewModel.output.userResult)
+        Publishers.CombineLatest3(
+            viewModel.output.countResult,
+            viewModel.output.userResult,
+            viewModel.output.journeyResult
+        )
             .receive(on: DispatchQueue.main)
-            .sink { count, name in
-                switch (count, name) {
-                case let (.success(count), .success(name)):
-                    self.rootView.updateProgressView(name, count)
+            .sink {
+                count,
+                name,
+                journey in
+                switch (count, name, journey) {
+                case let (.success(count), .success(name), .success(journey)):
+                    self.rootView.updateProgressView(
+                        name: name,
+                        progress: count,
+                        journey: journey.title
+                    )
                 default:
                     ByeBooLogger.error(ByeBooError.noData)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
@@ -65,9 +65,8 @@ extension HomeViewController {
         switch state {
         case .beforeJourneyStart:
             let viewController = QuestStartViewController(viewModel: viewModel)
-            viewController.hidesBottomBarWhenPushed = true
-            viewController.navigationItem.hidesBackButton = true
-            navigationController?.pushViewController(viewController, animated: false)
+            viewController.modalPresentationStyle = .overFullScreen
+            self.present(viewController, animated: false)
         case .beforeQuest:
             navigationController?.tabBarController?.selectedIndex = 1
         case .afterJourney, .afterQuest:

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
@@ -120,7 +120,7 @@ extension HomeViewController {
                         journey: journey.title
                     )
                 default:
-                    ByeBooLogger.error(ByeBooError.noData)
+                    ByeBooLogger.error(ByeBooError.unknownError)
                 }
             }
             .store(in: &cancellables)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/HomeViewController.swift
@@ -65,7 +65,7 @@ extension HomeViewController {
         switch state {
         case .beforeJourneyStart:
             let viewController = QuestStartViewController(viewModel: viewModel)
-            viewController.modalPresentationStyle = .overFullScreen
+            viewController.modalPresentationStyle = .fullScreen
             self.present(viewController, animated: false)
         case .beforeQuest:
             navigationController?.tabBarController?.selectedIndex = 1

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/JourneyProgressView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/JourneyProgressView.swift
@@ -86,6 +86,6 @@ extension JourneyProgressView {
     
     func updateJourney(_ journey: String) {
         self.journeyTitle = journey
-        titleLabel.text = "\(name)님의 \(journeyTitle)"
+        titleLabel.text = "\(name)님의 \(journeyTitle) 여정"
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Onboarding/HomeOnboardingView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Onboarding/HomeOnboardingView.swift
@@ -115,7 +115,7 @@ extension HomeOnboardingView {
     }
     
     func startPressAnimation() {
-        UIView.animate(withDuration: 1.5) {
+        UIView.animate(withDuration: 1) {
             self.foregroundView.alpha = 1
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Onboarding/HomeOnboardingViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Onboarding/HomeOnboardingViewController.swift
@@ -51,7 +51,7 @@ extension HomeOnboardingViewController {
             
             let duration = Date().timeIntervalSince(start)
             
-            if duration >= 1.5 {
+            if duration >= 1 {
                 let tabBarController = BottomNavigationViewController()
                 
                 if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -17,6 +17,7 @@ final class HomeViewModel {
     private var countResultSubject = PassthroughSubject<Result<Int, ByeBooError>, Never>()
     private var userResultSubject = PassthroughSubject<Result<String, ByeBooError>, Never>()
     private var homeStateResultSubject = PassthroughSubject<Result<HomeState, ByeBooError>, Never>()
+    private var journeyResultSubject = PassthroughSubject<Result<JourneyEntity, ByeBooError>, Never>()
 
     private let fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase
     private let fetchCompleteQuestCountUseCase: FetchCompleteQuestCountUseCase
@@ -40,7 +41,8 @@ final class HomeViewModel {
             characterResult: characterResultSubject.eraseToAnyPublisher(),
             countResult: countResultSubject.eraseToAnyPublisher(),
             userResult: userResultSubject.eraseToAnyPublisher(),
-            homeStateResult: homeStateResultSubject.eraseToAnyPublisher()
+            homeStateResult: homeStateResultSubject.eraseToAnyPublisher(),
+            journeyResult: journeyResultSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -55,6 +57,7 @@ extension HomeViewModel: ViewModelType {
         let countResult: AnyPublisher<Result<Int, ByeBooError>, Never>
         let userResult: AnyPublisher<Result<String, ByeBooError>, Never>
         let homeStateResult: AnyPublisher<Result<HomeState, ByeBooError>, Never>
+        let journeyResult: AnyPublisher<Result<JourneyEntity, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -108,8 +111,14 @@ extension HomeViewModel {
             do {
                 let journey = try await fetchUserJourneyUseCase.execute()
                 homeStateResultSubject.send(.success(.beforeJourneyStart(journey: journey)))
+                journeyResultSubject.send(.success(journey))
             } catch {
                 homeStateResultSubject.send(
+                    .failure(
+                        error as? ByeBooError ?? ByeBooError.unknownError
+                    )
+                )
+                journeyResultSubject.send(
                     .failure(
                         error as? ByeBooError ?? ByeBooError.unknownError
                     )

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Information/View/Loading/LoadingViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Information/View/Loading/LoadingViewController.swift
@@ -25,7 +25,7 @@ final class LoadingViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             guard let viewModel = DIContainer.shared.resolve(type: JourneyResultViewModel.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 fatalError()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
@@ -39,14 +39,15 @@ final class QuestCheckViewController: BaseViewController {
         super.viewDidLoad()
         
         // state가 before journey인 경우
-        guard let startViewModel = DIContainer.shared.resolve(type: QuestStartViewModel.self) else {
-            ByeBooLogger.error(ByeBooError.DIFailedError)
-            fatalError()
-        }
-        
-        let viewController = QuestStartViewController(viewModel: startViewModel)
-        viewController.modalPresentationStyle = .fullScreen
-        self.present(viewController, animated: false)
+        // 요거 viewDidLoad말고 다른 곳에서 해주어야 함 !!!!!!
+//        guard let startViewModel = DIContainer.shared.resolve(type: QuestStartViewModel.self) else {
+//            ByeBooLogger.error(ByeBooError.DIFailedError)
+//            fatalError()
+//        }
+//        
+//        let viewController = QuestStartViewController(viewModel: startViewModel)
+//        viewController.modalPresentationStyle = .fullScreen
+//        self.present(viewController, animated: false)
         
         bind()
         viewModel.action(.handleStartQuestButtonDidTap)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
@@ -38,6 +38,16 @@ final class QuestCheckViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // state가 before journey인 경우
+        guard let startViewModel = DIContainer.shared.resolve(type: QuestStartViewModel.self) else {
+            ByeBooLogger.error(ByeBooError.DIFailedError)
+            fatalError()
+        }
+        
+        let viewController = QuestStartViewController(viewModel: startViewModel)
+        viewController.modalPresentationStyle = .fullScreen
+        self.present(viewController, animated: false)
+        
         bind()
         viewModel.action(.handleStartQuestButtonDidTap)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
@@ -33,7 +33,6 @@ final class QuestCheckViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.navigationBar.isHidden = true
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     override func viewDidLoad() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
@@ -12,17 +12,10 @@ import Then
 
 final class QuestStartView: BaseView {
     
-    private let nickname: String
+    private var nickname: String = "하츠핑"
+    private var journey: String = "감정 직면 여정"
     
-    init(nickname: String) {
-        self.nickname = nickname
-        super.init(frame: .zero)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
+    let backButton = UIImageView()
     private let titleLabel = UILabel()
     private let cloverImageView = UIImageView()
     private let descriptionLabel = UILabel()
@@ -30,6 +23,10 @@ final class QuestStartView: BaseView {
     
     override func setStyle() {
         backgroundColor = .grayscale900
+        backButton.do {
+            $0.image = .left.withTintColor(.white)
+            $0.isUserInteractionEnabled = true
+        }
         titleLabel.do {
             $0.attributedText = "QUEST JOURNEY\nSTART!".makeTitle(rangedText: "QUEST JOURNEY")
             $0.textAlignment = .center
@@ -44,7 +41,7 @@ final class QuestStartView: BaseView {
             $0.font = FontManager.body3R16.font
             $0.attributedText = """
                 \(nickname)님의 상황에 꼭 맞춘
-                감정 직면 여정의 퀘스트 30개를 드릴게요.\n
+                \(journey)의 퀘스트 30개를 드릴게요.\n
                 제가 드리는 퀘스트와 함께
                 이별을 극복해나가요 !
                 """.makeTitle(
@@ -59,6 +56,7 @@ final class QuestStartView: BaseView {
     
     override func setUI() {
         addSubviews(
+            backButton,
             titleLabel,
             cloverImageView,
             descriptionLabel,
@@ -67,8 +65,13 @@ final class QuestStartView: BaseView {
     }
     
     override func setLayout() {
+        backButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(72.adjustedH)
+            $0.leading.equalToSuperview().inset(24.adjustedW)
+            $0.size.equalTo(24.adjustedW)
+        }
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide.snp.top).inset(50.adjustedH)
+            $0.top.equalTo(backButton.snp.bottom).inset(67.adjustedH)
             $0.centerX.equalToSuperview()
         }
         cloverImageView.snp.makeConstraints {
@@ -88,5 +91,35 @@ final class QuestStartView: BaseView {
             $0.width.equalTo(326.adjustedW)
             $0.height.equalTo(53.adjustedH)
         }
+    }
+}
+
+extension QuestStartView {
+    func updateName(_ nickname: String) {
+        self.nickname = nickname
+        descriptionLabel.attributedText = """
+                \(nickname)님의 상황에 꼭 맞춘
+                \(self.journey) 여정의 퀘스트 30개를 드릴게요.\n
+                제가 드리는 퀘스트와 함께
+                이별을 극복해나가요 !
+                """.makeTitle(
+                    rangedText: "\(nickname)",
+                    font: FontManager.body1Sb16.font,
+                    baseFont: FontManager.body3R16.font
+                )
+    }
+    
+    func updateJourney(_ journey: String) {
+        self.journey = journey
+        descriptionLabel.attributedText = """
+                \(self.nickname)님의 상황에 꼭 맞춘
+                \(journey) 여정의 퀘스트 30개를 드릴게요.\n
+                제가 드리는 퀘스트와 함께
+                이별을 극복해나가요 !
+                """.makeTitle(
+                    rangedText: "\(self.nickname)",
+                    font: FontManager.body1Sb16.font,
+                    baseFont: FontManager.body3R16.font
+                )
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartView.swift
@@ -71,7 +71,7 @@ final class QuestStartView: BaseView {
             $0.size.equalTo(24.adjustedW)
         }
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(backButton.snp.bottom).inset(67.adjustedH)
+            $0.top.equalTo(backButton.snp.bottom).offset(67.adjustedH) 
             $0.centerX.equalToSuperview()
         }
         cloverImageView.snp.makeConstraints {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
@@ -58,7 +58,18 @@ final class QuestStartViewController: BaseViewController {
 
 extension QuestStartViewController: BackNavigable {
     func back() {
-        dismiss(animated: false)
+        if let presentingVC = self.presentingViewController {
+            if let tabBarController = presentingVC as? UITabBarController {
+                // 홈 탭에서 진입
+                if tabBarController.selectedIndex == 0 {
+                    self.dismiss(animated: false)
+                } else {
+                    // 퀘스트 탭에서 진입
+                    self.dismiss(animated: false)
+                    tabBarController.selectedIndex = 0
+                }
+            }
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
@@ -12,7 +12,7 @@ final class QuestStartViewController: BaseViewController {
     
     private let viewModel: QuestStartViewModel
     private var cancellables = Set<AnyCancellable>()
-    private let rootView = QuestStartView(nickname: "하츠핑")
+    private let rootView = QuestStartView()
     
     init(viewModel: QuestStartViewModel) {
         self.viewModel = viewModel
@@ -34,14 +34,10 @@ final class QuestStartViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        ByeBooNavigationBar.makeNavigationBar(
-            navigationItem: self.navigationItem,
-            navigationController: self.navigationController,
-            type: .back,
-            action: #selector(back)
-        )
+
         bind()
+        setGesture()
+        viewModel.action(.viewDidLoad)
     }
     
     override func setAddTarget() {
@@ -51,12 +47,18 @@ final class QuestStartViewController: BaseViewController {
             for: .touchUpInside
         )
     }
+    
+    private func setGesture() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(back))
+        tapGestureRecognizer.isEnabled = true
+        tapGestureRecognizer.cancelsTouchesInView = false
+        rootView.backButton.addGestureRecognizer(tapGestureRecognizer)
+    }
 }
 
 extension QuestStartViewController: BackNavigable {
-    
     func back() {
-        self.navigationController?.popViewController(animated: true)
+        dismiss(animated: false)
     }
 }
 
@@ -67,13 +69,37 @@ extension QuestStartViewController {
     }
     
     private func bind() {
+        viewModel.output.nameResult
+            .receive(on: DispatchQueue.main)
+            .sink { result in
+                switch result {
+                case .success(let name):
+                    self.rootView.updateName(name)
+                case .failure(let failure):
+                    ByeBooLogger.error(failure)
+                }
+            }
+            .store(in: &cancellables)
+        
+        viewModel.output.journeyResult
+            .receive(on: DispatchQueue.main)
+            .sink { result in
+                switch result {
+                case .success(let journey):
+                    self.rootView.updateJourney(journey.title)
+                case .failure(let failure):
+                    ByeBooLogger.error(failure)
+                }
+            }
+            .store(in: &cancellables)
+        
         viewModel.output.startResult
             .receive(on: DispatchQueue.main)
             .sink { result in
                 switch result {
                 case .success:
                     self.navigationController?.tabBarController?.selectedIndex = 1
-                    self.navigationController?.popToRootViewController(animated: true)
+                    self.dismiss(animated: false)
                 case .failure(let failure):
                     ByeBooLogger.error(failure)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestStartViewController.swift
@@ -109,8 +109,18 @@ extension QuestStartViewController {
             .sink { result in
                 switch result {
                 case .success:
-                    self.navigationController?.tabBarController?.selectedIndex = 1
-                    self.dismiss(animated: false)
+                    if let presentingVC = self.presentingViewController {
+                        if let tabBarController = presentingVC as? UITabBarController {
+                            // 홈 탭에서 진입
+                            if tabBarController.selectedIndex == 0 {
+                                self.dismiss(animated: false)
+                                tabBarController.selectedIndex = 1
+                            } else {
+                                // 퀘스트 탭에서 진입
+                                self.dismiss(animated: false)
+                            }
+                        }
+                    }
                 case .failure(let failure):
                     ByeBooLogger.error(failure)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestStartViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestStartViewModel.swift
@@ -15,28 +15,49 @@ final class QuestStartViewModel {
     private(set) var output: Output
     
     private var startResultSubject = PassthroughSubject<Result<Bool, ByeBooError>, Never>()
+    private var nameResultSubject = PassthroughSubject<Result<String, ByeBooError>, Never>()
+    private var journeyResultSubject = PassthroughSubject<Result<JourneyEntity, ByeBooError>, Never>()
+    
     
     private let startJourneyUseCase: StartJourneyUseCase
+    private let getUserNameUseCase: GetUserNameUseCase
+    private let fetchJourneyUseCase: FetchUserJourneyUseCase
     
-    init(startJourneyUseCase: StartJourneyUseCase) {
+    init(
+        startJourneyUseCase: StartJourneyUseCase,
+        getUserNameUseCase: GetUserNameUseCase,
+        fetchJourneyUseCase: FetchUserJourneyUseCase
+    ) {
         self.startJourneyUseCase = startJourneyUseCase
+        self.getUserNameUseCase = getUserNameUseCase
+        self.fetchJourneyUseCase = fetchJourneyUseCase
         
-        output = Output(startResult: startResultSubject.eraseToAnyPublisher())
+        output = Output(
+            startResult: startResultSubject.eraseToAnyPublisher(),
+            nameResult: nameResultSubject.eraseToAnyPublisher(),
+            journeyResult: journeyResultSubject.eraseToAnyPublisher()
+        )
     }
 }
 
 extension QuestStartViewModel: ViewModelType {
     
     enum Input {
+        case viewDidLoad
         case buttonDidTap
     }
     
     struct Output {
         let startResult: AnyPublisher<Result<Bool, ByeBooError>, Never>
+        let nameResult: AnyPublisher<Result<String, ByeBooError>, Never>
+        let journeyResult: AnyPublisher<Result<JourneyEntity, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
         switch trigger {
+        case .viewDidLoad:
+            fetchJourney()
+            getUserName()
         case .buttonDidTap:
             startJourney()
         }
@@ -53,6 +74,26 @@ extension QuestStartViewModel {
                 startResultSubject.send(.failure(error as? ByeBooError ?? ByeBooError.unknownError))
             }
         }
+    }
+    
+    private func fetchJourney() {
+        Task {
+            do {
+                let journey = try await fetchJourneyUseCase.execute()
+                journeyResultSubject.send(.success(journey))
+            } catch {
+                journeyResultSubject.send(
+                    .failure(
+                        error as? ByeBooError ?? ByeBooError.unknownError
+                    )
+                )
+            }
+        }
+    }
+    
+    private func getUserName() {
+        let name = getUserNameUseCase.execute()
+        nameResultSubject.send(.success(name))
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -89,7 +89,11 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 return
             }
             
-            return QuestStartViewModel(startJourneyUseCase: startJourneyUseCase)
+            return QuestStartViewModel(
+                startJourneyUseCase: startJourneyUseCase,
+                getUserNameUseCase: getUserNameUseCase,
+                fetchJourneyUseCase: fetchUserJourneyUseCase
+            )
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #102 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 퀘스트 시작 관련 UI 정보 업데이트 로직 추가했습니당
- 퀘스트 시작 뷰를 모달형식으로 변경했습니당
- 홈 화면에서 정보 업데이트 누락이 있어서 update 방식 변경했습니당

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/78f6462c-13ba-4157-90b7-88de4ded01cd" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`HomeViewController`
- 세가지 퍼블리셔의 값을 모두 받았을 때 가장 최신값을 return 하는 함수 ~ 입니다
- progressView가 nil일 때 name과 journey가 방출되면 정보를 업데이트하지 못해서 묶어서 보내주기로 결정 했습니다 ~ 
```swift
Publishers.CombineLatest3(
            viewModel.output.countResult,
            viewModel.output.userResult,
            viewModel.output.journeyResult
        )
            .receive(on: DispatchQueue.main)
            .sink {
                count,
                name,
                journey in
                switch (count, name, journey) {
                case let (.success(count), .success(name), .success(journey)):
                    self.rootView.updateProgressView(
                        name: name,
                        progress: count,
                        journey: journey.title
                    )
                default:
                    ByeBooLogger.error(ByeBooError.unknownError)
                }
            }
            .store(in: &cancellables)
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
승준이가 퀘스트 탭 나머지 로직 작업 해주시면 됩니다. !
