### PR TITLE
Feat/#115 행동형 퀘스트 완료 조회 API 연동

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestAnswerRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestAnswerRepository.swift
@@ -22,7 +22,7 @@ struct DefaultQuestAnswerRepository: QuestAnswerInterface {
     func fetchQuestAnswer(questID: Int) async throws -> QuestAnswerEntity {
         let userID: Int = userDefaultService.load(key: .userID) ?? 1
         let result = try await network.request(
-            QuestAPI.answer(userID: 186, questID: 5),
+            QuestAPI.answer(userID: userID, questID: questID),
             decodingType: QuestAnswerResponseDTO.self
         )
         return result.toEntity()

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestAnswerRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestAnswerRepository.swift
@@ -22,7 +22,7 @@ struct DefaultQuestAnswerRepository: QuestAnswerInterface {
     func fetchQuestAnswer(questID: Int) async throws -> QuestAnswerEntity {
         let userID: Int = userDefaultService.load(key: .userID) ?? 1
         let result = try await network.request(
-            QuestAPI.answer(userID: userID, questID: questID),
+            QuestAPI.answer(userID: 186, questID: 5),
             decodingType: QuestAnswerResponseDTO.self
         )
         return result.toEntity()

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/SaveQuestActiveRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/SaveQuestActiveRepository.swift
@@ -66,7 +66,7 @@ struct DefaultSaveActiveQuestRepository: SaveQuestActiveInterface{
         )
         
         let _ = try await network.request(
-            QuestAPI.active(userID: 186, questID: 6, request: saveQuestActiveDTO)
+            QuestAPI.active(userID: userID, questID: questID, request: saveQuestActiveDTO)
         )
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
@@ -12,7 +12,7 @@ struct QuestAnswerEntity {
     var questNumber: Int
     var createdAt: String
     var question: String
-    var answer: String?
+    var answer: String
     var questEmotionState: String
     var imageUrl: String?
     var emotionDescription: String

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/ActionView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/ActionView.swift
@@ -20,14 +20,14 @@ final class ActionView: BaseView {
     private let photoURL: String
     
     init(
-        descriptionText: String?,
+        descriptionText: String,
         photoURL: String
     ) {
         self.descriptionText = descriptionText
         self.photoURL = photoURL
         
-        if let text = descriptionText {
-            descriptionView = TextBoxView(title: text)
+        if descriptionText != ""  {
+            descriptionView = TextBoxView(title: descriptionText)
         } else {
             descriptionView = nil
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
@@ -33,7 +33,7 @@ final class CompleteActiveTypeQuestViewController: BaseViewController {
         super.viewDidLoad()
         
         self.navigationItem.hidesBackButton = true
-        viewModel.action(.questAnswerDidLoad(questID: 31))
+        viewModel.action(.questAnswerDidLoad(questID: 5))
         
         ByeBooNavigationBar.makeNavigationBar(
             navigationItem: self.navigationItem,
@@ -47,6 +47,7 @@ final class CompleteActiveTypeQuestViewController: BaseViewController {
     
     private func bind() {
         viewModel.output.resultPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 switch result {
                 case .success(let entity):

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/CompleteActiveTypeQuestViewController.swift
@@ -33,7 +33,7 @@ final class CompleteActiveTypeQuestViewController: BaseViewController {
         super.viewDidLoad()
         
         self.navigationItem.hidesBackButton = true
-        viewModel.action(.questAnswerDidLoad(questID: 5))
+        viewModel.action(.questAnswerDidLoad(questID: self.questID))
         
         ByeBooNavigationBar.makeNavigationBar(
             navigationItem: self.navigationItem,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -96,7 +96,9 @@ extension WriteActiveTypeQuestViewController {
     
     @objc
     private func confirmButtonDidTap() {
-        if rootView.questTextField.textView.text == rootView.questTextField.placeholder {
+        if rootView.questTextField.textView.text == rootView.questTextField.placeholder ||
+            rootView.questTextField.textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
             answerText = ""
         } else {
             answerText = rootView.questTextField.textView.text

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -201,7 +201,7 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
             ByeBooLogger.error(ByeBooError.DIFailedError)
             fatalError()
         }
-        
+
         let uuidKey = UUID().uuidString
         ByeBooLogger.debug("UUID: \(uuidKey)")
         self.viewModel.action(.didTapCompleteButton(
@@ -211,7 +211,8 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
             image: self.image,
             imageKey: uuidKey)
         )
-        
+
+        viewModel.action(.questAnswerDidLoad(questID: self.questID))
         let viewController = CompleteActiveTypeQuestViewController(viewModel: viewModel)
         self.navigationController?.pushViewController(viewController, animated: true)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -96,7 +96,11 @@ extension WriteActiveTypeQuestViewController {
     
     @objc
     private func confirmButtonDidTap() {
-        answerText = rootView.questTextField.textView.text ?? ""
+        if rootView.questTextField.textView.text == rootView.questTextField.placeholder {
+            answerText = ""
+        } else {
+            answerText = rootView.questTextField.textView.text
+        }
         
         let viewController = EmotionBottomSheetViewController()
         viewController.previousView = .activation

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -46,7 +46,7 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
         setGesture()
         bind()
         presentPhotoPicker()
-        viewModel.action(.viewDidLoad(quesetID: 1))
+        viewModel.action(.viewDidLoad(quesetID: 5))
     }
     
     override func setAddTarget() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
@@ -39,9 +39,9 @@ final class CongratSquare: BaseView {
         
         descriptionLabel.do {
             $0.font = FontManager.body3R16.font
-            $0.text = "기특해요 !\n점점 극복에 가까워지고 있어요\n:)"
+            $0.text = "기특해요 !\n점점 극복해나가고 있어요 :)"
             $0.textColor = .grayscale300
-            $0.numberOfLines = 3
+            $0.numberOfLines = 2
             $0.textAlignment = .center
         }
     }
@@ -49,7 +49,7 @@ final class CongratSquare: BaseView {
     override func setLayout() {
         self.snp.makeConstraints {
             $0.width.equalTo(325.adjustedW)
-            $0.height.equalTo(386.adjustedH)
+            $0.height.equalTo(365.adjustedH)
         }
         
         titleLabel.snp.makeConstraints {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
@@ -36,7 +36,7 @@ enum QuestType {
 final class QuestTextField: BaseView {
     let textView = UITextView()
     private let textCount = UILabel()
-    private let placeholder: String
+    let placeholder: String
     private var isPlaceholderActive: Bool = true
     private let limitCount: Int
     var count: Int = 0

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
@@ -35,10 +35,10 @@ enum QuestType {
 
 final class QuestTextField: BaseView {
     let textView = UITextView()
-    private let textCount = UILabel()
+    var textCount = UILabel()
     let placeholder: String
     private var isPlaceholderActive: Bool = true
-    private let limitCount: Int
+    let limitCount: Int
     var count: Int = 0
     weak var delegate: QuestCompleteProtocol?
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
@@ -77,7 +77,7 @@ final class CompleteQuestionTypeQuestView: BaseView {
         self.title.text = entity.question
         self.dateText.text = entity.createdAt
         
-        let thinkView = ThinkView(descriptionText: entity.answer!)
+        let thinkView = ThinkView(descriptionText: entity.answer)
         let feelView = FeelView(emotionType: entity.questEmotionState, descriptionText: entity.emotionDescription)
         
         contentView.addSubviews(thinkView, feelView)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/CompleteQuestionTypeQuestView.swift
@@ -77,7 +77,6 @@ final class CompleteQuestionTypeQuestView: BaseView {
         self.title.text = entity.question
         self.dateText.text = entity.createdAt
         
-        
         let thinkView = ThinkView(descriptionText: entity.answer!)
         let feelView = FeelView(emotionType: entity.questEmotionState, descriptionText: entity.emotionDescription)
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestView.swift
@@ -95,7 +95,8 @@ extension WriteQuestionTypeQuestView {
 }
 extension WriteQuestionTypeQuestView: QuestCompleteProtocol {
     func changeStyle(count: Int) {
-        if (count >= 10) {
+        if (count >= 10) &&
+            (!questTextField.textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
             confirmButton.updateType(.enabled)
         } else {
             confirmButton.updateType(.disabled)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
@@ -80,7 +80,11 @@ extension WriteQuestionTypeQuestViewController {
     
     @objc
     private func confirmButtonDidTap() {
-        answerText = rootView.questTextField.textView.text ?? ""
+        if rootView.questTextField.textView.text == rootView.questTextField.placeholder {
+            answerText = ""
+        } else {
+            answerText = rootView.questTextField.textView.text
+        }
         
         let viewController = EmotionBottomSheetViewController()
         viewController.previousView = .question

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
@@ -151,10 +151,14 @@ extension WriteQuestionTypeQuestViewController: BottomSheetProtocol {
         
         ByeBooLogger.debug("text: \(answerText)")
         ByeBooLogger.debug("emtionState: \(emotionState)")
-        self.viewModel.action(.presentCompleteView(questID: 31, answer: answerText, emotionState: emotionState))
+        self.viewModel.action(.presentCompleteView(
+            questID: self.questID,
+            answer: self.answerText,
+            emotionState: self.emotionState
+            )
+        )
         
         let viewController = CompleteQuestionTypeQuestViewController(viewModel: viewModel)
         self.navigationController?.pushViewController(viewController, animated: true)
     }
-
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
@@ -80,12 +80,6 @@ extension WriteQuestionTypeQuestViewController {
     
     @objc
     private func confirmButtonDidTap() {
-        if rootView.questTextField.textView.text == rootView.questTextField.placeholder {
-            answerText = ""
-        } else {
-            answerText = rootView.questTextField.textView.text
-        }
-        
         let viewController = EmotionBottomSheetViewController()
         viewController.previousView = .question
         viewController.delegate = self

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
@@ -80,6 +80,7 @@ extension WriteQuestionTypeQuestViewController {
     
     @objc
     private func confirmButtonDidTap() {
+        answerText = rootView.questTextField.textView.text
         let viewController = EmotionBottomSheetViewController()
         viewController.previousView = .question
         viewController.delegate = self

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/CompleteQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/CompleteQuestViewModel.swift
@@ -50,7 +50,7 @@ extension CompleteQuestViewModel {
     private func fetchQuestAnswer(questID: Int) {
         Task {
             do {
-                let entity = try await questAnswerUseCase.execute(questID: 31)
+                let entity = try await questAnswerUseCase.execute(questID: questID)
                 resultSubject.send(.success(entity))
             } catch {
                 guard let error = error as? ByeBooError else {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/ViewModel/WriteQuestTypeViewModel.swift
@@ -64,7 +64,7 @@ extension WriteQuestionTypeViewModel {
     private func getQuestInfo(questID: Int) {
         Task {
             do {
-                let questInfo = try await getQuestInfoUseCase.execute(questID: 31)
+                let questInfo = try await getQuestInfoUseCase.execute(questID: questID)
                 questInfoResultSubject.send(.success(questInfo))
             } catch {
                 guard let error = error as? ByeBooError else {
@@ -78,7 +78,7 @@ extension WriteQuestionTypeViewModel {
     private func postQuestType(questID: Int, answer: String, emotionState: String) {
         Task {
             do {
-                try await saveQuestTypeUseCase.execute(questID: 31, answer: answer, emotionState: emotionState)
+                try await saveQuestTypeUseCase.execute(questID: questID, answer: answer, emotionState: emotionState)
                 didSuccessPostSubject.send(.success(()))
             } catch {
                 guard let error = error as? ByeBooError else {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #115

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 행동형 퀘스트 완료 조회 API 연결했습니다
- 변경된 congrat square 수정했습니다

|    구현 내용    |  텍스트 있는 경우   |  텍스트 없는 경우   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/46606b65-765b-411a-95c6-132c4ec01901" width ="250"> | <img src = "https://github.com/user-attachments/assets/dbb9e82b-a4fb-46f0-861f-61ac0da90b47" width ="250"> |


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황

- 시나리오 진행에 필요한 값

- 시나리오 진행에 필요한 조건

- 시나리오 완료 시 보장하는 결과

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`WriteActiveQuestVC`
- 이 뷰에서는 내용 작성을 안하는 것이 가능합니다 이 경우 서버에서 빈 문자열로 보내달라고 하셔서 분기처리했습니다 
- 그에 따른 QuestAnswerEntity의 answer가 String?이었는데 String으로 변경해주었습니다 
```swift
 private func confirmButtonDidTap() {
        if rootView.questTextField.textView.text == rootView.questTextField.placeholder {
            answerText = ""
        } else {
            answerText = rootView.questTextField.textView.text
        }
```
ActionView에서 원래 옵셔널 바인딩해주던 것도 분기처리 방식을 변경 해주었습니다 
```swift
  if descriptionText != ""  {
            descriptionView = TextBoxView(title: descriptionText)
        } else {
            descriptionView = nil
        }
```
