### PR TITLE
Refactor/#120 키보드 개선

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestView.swift
@@ -107,9 +107,8 @@ final class WriteActiveTypeQuestView: BaseView {
         }
         
         contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.height.greaterThanOrEqualToSuperview()
-            $0.bottom.equalTo(confirmButton.snp.bottom).offset(24.adjustedH)
+            $0.edges.equalTo(scrollView.contentLayoutGuide)
+            $0.width.equalTo(scrollView.frameLayoutGuide)
         }
         
         title.snp.makeConstraints {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ActivationType/View/WriteActiveTypeQuestViewController.swift
@@ -18,6 +18,7 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
     private var answerText: String = ""
     private var emotionState: String = ""
     private var image: UIImage = UIImage()
+    private var isKeyboardUsed: Bool = false
     
     override func loadView() {
         view = rootView
@@ -81,16 +82,20 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
 extension WriteActiveTypeQuestViewController {
     @objc
     private func textViewMoveUp(_ notification: NSNotification) {
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            UIView.animate(withDuration: 0.3, animations: {
-                let offsetY = keyboardSize.height
-                self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
-            })
+        if !self.isKeyboardUsed {
+            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                UIView.animate(withDuration: 0.3, animations: {
+                    let offsetY = keyboardSize.height
+                    self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
+                })
+                self.isKeyboardUsed = true
+            }
         }
     }
     
     @objc
     private func textViewMoveDown() {
+        self.isKeyboardUsed = false
         self.view.transform = .identity
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
@@ -62,7 +62,7 @@ final class CongratSquare: BaseView {
             $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
             $0.width.equalTo(203.adjustedW)
             $0.height.equalTo(181.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(61.adjustedH)
+            $0.centerX.equalToSuperview()
         }
         
         descriptionLabel.snp.makeConstraints {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestViewController.swift
@@ -17,6 +17,7 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
     let questID: Int = 0
     private var answerText: String = ""
     private var emotionState: String = ""
+    private var isKeyboardUsed: Bool = false
     
     init(
         viewModel: WriteQuestionTypeViewModel
@@ -65,16 +66,20 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
 extension WriteQuestionTypeQuestViewController {
     @objc
     private func textViewMoveUp(_ notification: NSNotification) {
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            UIView.animate(withDuration: 0.3, animations: {
-                let offsetY = keyboardSize.height - self.rootView.safeAreaInsets.bottom * 4
-                self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
-            })
+        if !self.isKeyboardUsed{
+            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                UIView.animate(withDuration: 0.3, animations: {
+                    let offsetY = keyboardSize.height - self.rootView.safeAreaInsets.bottom * 4
+                    self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
+                    self.isKeyboardUsed = true
+                })
+            }
         }
     }
     
     @objc
     private func textViewMoveDown() {
+        isKeyboardUsed = false
         self.rootView.transform = .identity
     }
     


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #120

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 키보드가 올라와있는 상태에서 이모티콘 키보드로 바꿀 시 키보드가 한번 더 올라오던 것을 수정했습니다
- 그외 제약 관련 경고가 뜨던 것을 수정했습니다 

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "https://github.com/user-attachments/assets/a989d620-b3e8-43af-bef9-6881cbe4cf42" width ="250"> |


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황

- 시나리오 진행에 필요한 값

- 시나리오 진행에 필요한 조건

- 시나리오 완료 시 보장하는 결과

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`WriteVC`
- 키보드가 올라와있는 상태를 담은 변수를 만들어서 조건을 걸어주었습니다 
```swift
@objc
    private func textViewMoveUp(_ notification: NSNotification) {
        if !self.isKeyboardUsed {
            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
                UIView.animate(withDuration: 0.3, animations: {
                    let offsetY = keyboardSize.height
                    self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
                })
                self.isKeyboardUsed = true
            }
        }
    }
    
    @objc
    private func textViewMoveDown() {
        self.isKeyboardUsed = false
        self.view.transform = .identity
    }
```

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

