### PR TITLE
Refactor/#139 로딩 로직 수정햇습니다 ~

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/CustomLoadingView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/CustomLoadingView.swift
@@ -39,15 +39,13 @@ final class CustomLoadingView: UIView {
     }
     
     func show() {
-        guard let scene = UIApplication.shared.connectedScenes.first else { return }
-        guard let delegate = scene.delegate as? SceneDelegate else { return }
-        guard let window = delegate.window else { return }
-        
         if self.superview != nil { return }
-        
-        window.addSubview(self)
-        self.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first {
+            window.addSubview(self)
+            self.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Onboarding/HomeOnboardingView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Onboarding/HomeOnboardingView.swift
@@ -100,13 +100,13 @@ final class HomeOnboardingView: BaseView {
 extension HomeOnboardingView {
     func startAnimation() {
         
-        UIView.animate(withDuration: 0.3, delay: 0.2) {
+        UIView.animate(withDuration: 0.4, delay: 0.3) {
             self.welcomeView.alpha = 1
         } completion: { _ in
-            UIView.animate(withDuration: 0.3, delay: 0.2) {
+            UIView.animate(withDuration: 0.4, delay: 0.3) {
                 self.introduceView.alpha = 1
             } completion: { _ in
-                UIView.animate(withDuration: 0.3, delay: 0.2) {
+                UIView.animate(withDuration: 0.4, delay: 0.2) {
                     self.descriptionLabel.alpha = 1
                     self.bubbleImageView.alpha = 1
                     self.characterImageView.isUserInteractionEnabled = true

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
@@ -40,7 +40,6 @@ final class QuestCheckViewController: BaseViewController {
         
         bind()
         viewModel.action(.questViewWillAppear)
-        CustomLoadingView.shared.show()
     }
     
     override func viewDidLoad() {
@@ -50,7 +49,6 @@ final class QuestCheckViewController: BaseViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        CustomLoadingView.shared.hide()
         self.navigationController?.navigationBar.isHidden = false
     }
     
@@ -99,7 +97,6 @@ final class QuestCheckViewController: BaseViewController {
                         self?.scrollToCurrentStep()
                     }
                 }
-                CustomLoadingView.shared.hide()
             case (.success(_), .success(_), .failure(_)):
                 guard let startViewModel = DIContainer.shared.resolve(type: QuestStartViewModel.self) else {
                     ByeBooLogger.error(ByeBooError.DIFailedError)
@@ -112,15 +109,25 @@ final class QuestCheckViewController: BaseViewController {
                     self?.viewModel.action(.questViewWillAppear)
                     self?.bind()
                 }
-                CustomLoadingView.shared.hide()
                 self?.present(viewController, animated: false)
                 
             default:
-                CustomLoadingView.shared.hide()
                 ByeBooLogger.error(ByeBooError.unknownError)
             }
         }
         .store(in: &cancellable)
+        
+        viewModel.output.loadingPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { result in
+                switch result {
+                case true:
+                    CustomLoadingView.shared.show()
+                case false:
+                    CustomLoadingView.shared.hide()
+                }
+            }
+            .store(in: &cancellable)
     }
     
     private func scrollToCurrentStep() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestsViewModel.swift
@@ -13,6 +13,9 @@ final class QuestsViewModel: ViewModelType {
     private let nameSubject = PassthroughSubject<Result<String, ByeBooError>, Never>.init()
     private let journeySubject = PassthroughSubject<Result<JourneyEntity, ByeBooError>, Never>.init()
     private let questsSubject = PassthroughSubject<Result<ProgressingQuestsEntity, ByeBooError>, Never>.init()
+    
+    private let loadingSubject = PassthroughSubject<Bool, Never>.init()
+    
     private(set) var output: Output
     
     private let progressingQuestsUseCase: GetProgressingQuestsUseCase
@@ -34,7 +37,8 @@ final class QuestsViewModel: ViewModelType {
         self.output = Output(
             namePublisher: nameSubject.eraseToAnyPublisher(),
             journeyPublisher: journeySubject.eraseToAnyPublisher(),
-            questsPublisher: questsSubject.eraseToAnyPublisher()
+            questsPublisher: questsSubject.eraseToAnyPublisher(),
+            loadingPublisher: loadingSubject.eraseToAnyPublisher()
         )
     }
     
@@ -48,18 +52,21 @@ final class QuestsViewModel: ViewModelType {
             do {
                 let journeyEntity = try await fetchUserJourneyUseCase.execute()
                 journeySubject.send(.success(journeyEntity))
+                loadingSubject.send(false)
             } catch {
                 journeySubject.send(
                     .failure(
                         error as? ByeBooError ?? ByeBooError.unknownError
                     )
                 )
+                loadingSubject.send(false)
             }
         }
     }
     
     private func fetchProgressingQuests() {
         guard let userID = getUserIDUseCase.execute() else {
+            loadingSubject.send(false)
             questsSubject.send(.success(.stub()))
             return
         }
@@ -68,8 +75,10 @@ final class QuestsViewModel: ViewModelType {
             do {
                 let quests = try await progressingQuestsUseCase.execute(userID: userID)
                 questsSubject.send(.success(quests))
+                loadingSubject.send(false)
             } catch {
                 questsSubject.send(.failure(error as! ByeBooError))
+                loadingSubject.send(false)
             }
         }
     }
@@ -85,11 +94,13 @@ extension QuestsViewModel {
         let namePublisher: AnyPublisher<Result<String, ByeBooError>, Never>
         let journeyPublisher: AnyPublisher<Result<JourneyEntity, ByeBooError>, Never>
         let questsPublisher: AnyPublisher<Result<ProgressingQuestsEntity, ByeBooError>, Never>
+        let loadingPublisher: AnyPublisher<Bool, Never>
     }
     
     func action(_ trigger: InputAction) {
         switch trigger {
         case .questViewWillAppear:
+            loadingSubject.send(true)
             getUseName()
             fetchUserJourney()
             fetchProgressingQuests()


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #139 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- viewController에서 관리해주던 상태를 viewModel에서 관리하도록 수정하였습니다 ~ 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`QuestViewModel`
- viewmodel에서 네트워크 통신 시작할 때 loading을 true로 바꿔주고 끝났을 때 false로 바꿔줍니다
- 실패할 확률이 없으므로 `AnyPublisher<Bool, Never>`로 해줬습니다
```swift
let loadingPublisher: AnyPublisher<Bool, Never>

       Task {
            do {
                let journeyEntity = try await fetchUserJourneyUseCase.execute()
                journeySubject.send(.success(journeyEntity))
                loadingSubject.send(false)
            } catch {
                journeySubject.send(
                    .failure(
                        error as? ByeBooError ?? ByeBooError.unknownError
                    )
                )
                loadingSubject.send(false)
            }
        }
```

`QuestCheckViewController`
- loadingpublisher로 나타내고, 사라지게 ~ 
```swift
         viewModel.output.loadingPublisher
            .receive(on: DispatchQueue.main)
            .sink { result in
                switch result {
                case true:
                    CustomLoadingView.shared.show()
                case false:
                    CustomLoadingView.shared.hide()
                }
            }
            .store(in: &cancellable)
```
