### PR TITLE
Fix/#146 2번째 QA를 반영했습니다

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/SaveQuestActiveRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/SaveQuestActiveRepository.swift
@@ -28,8 +28,6 @@ struct DefaultSaveActiveQuestRepository: SaveQuestActiveInterface{
         image: Data,
         imageKey: String
     ) async throws {
-//        let userID: Int = userDefaultService.load(key: .userID) ?? 1
-
         let url = try await makeSignedURL(imageKey: imageKey)
 
         try await putImage(signedURL: url, image: image)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
@@ -103,8 +103,7 @@ final class ByeBooNicknameTextField: BaseView {
         errorIcon.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(24.adjustedW)
             $0.centerY.equalToSuperview()
-            $0.width.equalTo(18.adjustedW)
-            $0.height.equalTo(18.adjustedH)
+            $0.width.height.equalTo(24.adjustedW)
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/ByeBooNicknameTextField.swift
@@ -73,6 +73,7 @@ final class ByeBooNicknameTextField: BaseView {
             $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 24.adjustedW, height: 0))
             $0.leftViewMode = .always
             $0.textColor = .grayscale300
+            $0.tintColor = .white
         }
         
         errorIcon.do {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionChip.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionChip.swift
@@ -53,6 +53,8 @@ final class ByeBooEmotionChip: BaseView {
             $0.width.equalTo(84.adjustedW)
             $0.height.equalTo(76.adjustedH)
             $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(8)
+            $0.bottom.equalTo(emotionTag.snp.top).offset(-8)
             $0.centerX.equalToSuperview()
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuestModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuestModalView.swift
@@ -33,8 +33,10 @@ final class QuestModalView: BaseView, ModalProtocol {
     }
     
     override func setStyle() {
-        backgroundColor = .grayscale90080
-        layer.cornerRadius = 12.adjustedW
+        self.do {
+            $0.backgroundColor = .grayscale90080
+            $0.layer.cornerRadius = 12.adjustedW
+        }
         
         imageView.do {
             $0.backgroundColor = .clear
@@ -57,13 +59,11 @@ final class QuestModalView: BaseView, ModalProtocol {
             $0.numberOfLines = 0
             $0.lineBreakMode = .byWordWrapping
             $0.font = FontManager.sub2Sb18.font
-            $0.setContentHuggingPriority(.required, for: .horizontal)
-            $0.setContentCompressionResistancePriority(.required, for: .horizontal)
         }
         
         tipButton.do {
             $0.setTitle("작성 TIP", for: .normal)
-            $0.titleLabel?.font = FontManager.body4Sb14.font
+            $0.titleLabel?.font = FontManager.body5R14.font
             $0.backgroundColor = .clear
             $0.setTitleColor(.grayscale300, for: .normal)
             $0.layer.cornerRadius = 12.adjustedW
@@ -84,10 +84,6 @@ final class QuestModalView: BaseView, ModalProtocol {
     }
     
     override func setLayout() {
-        self.snp.makeConstraints {
-            $0.height.equalTo(301.adjustedH)
-        }
-        
         imageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(24.adjustedH)
             $0.centerX.equalToSuperview()
@@ -105,8 +101,7 @@ final class QuestModalView: BaseView, ModalProtocol {
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(questLabel.snp.bottom).offset(8.adjustedH)
             $0.centerX.equalToSuperview()
-            $0.leading.greaterThanOrEqualToSuperview().inset(16.adjustedW)
-            $0.trailing.lessThanOrEqualToSuperview().inset(16.adjustedW)
+            $0.horizontalEdges.equalToSuperview().inset(24.adjustedW)
         }
         
         tipButton.snp.makeConstraints {
@@ -119,9 +114,9 @@ final class QuestModalView: BaseView, ModalProtocol {
         actionButton.snp.makeConstraints {
             $0.top.equalTo(tipButton.snp.bottom).offset(17.5.adjustedH)
             $0.centerX.equalToSuperview()
-            $0.width.greaterThanOrEqualTo(titleLabel.snp.width).offset(16.adjustedW)
+            $0.horizontalEdges.equalToSuperview().inset(24.adjustedW)
             $0.height.equalTo(53.adjustedH)
-            $0.bottom.equalToSuperview().inset(20.adjustedH)
+            $0.bottom.equalToSuperview().inset(24.adjustedH)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Extension/UICollectionView+.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Extension/UICollectionView+.swift
@@ -1,0 +1,22 @@
+//
+//  UICollectionView+.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 7/17/25.
+//
+
+import UIKit
+
+extension UICollectionView {
+    
+    func scrollToHeader(at section: Int) {
+        guard let attributes = layoutAttributesForSupplementaryElement(
+            ofKind: Self.elementKindSectionHeader,
+            at: IndexPath(item: 0, section: section)
+        ) else {
+            return
+        }
+        let offsetY = max(attributes.frame.origin.y - contentInset.top, 0)
+        setContentOffset(CGPoint(x: 0, y: offsetY), animated: true)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/FeelView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/ArchiveQuest/View/FeelView.swift
@@ -33,10 +33,6 @@ final class FeelView: BaseView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func setStyle() {
-        
-    }
-    
     override func setUI() {
         addSubviews(
             titleTextView,
@@ -46,7 +42,7 @@ final class FeelView: BaseView {
     
     override func setLayout() {
         titleTextView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24.5.adjustedH)
+            $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
         }
        

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Information/View/InformationViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Information/View/InformationViewController.swift
@@ -143,8 +143,10 @@ extension InformationViewController: BackNavigable {
     func back() {
         switch informationViewType {
         case .selectEmotion:
+            selectEmotionView.resetSelected()
             move(viewType: inputNicknameType, progress: .first)
         case .selectQuest:
+            selectQuestView.resetSelected()
             move(viewType: selectEmotionType, progress: .second)
         default:
             break

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckHeaderView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckHeaderView.swift
@@ -20,16 +20,7 @@ final class QuestCheckHeaderView: BaseView {
     private let subTitleLabel = UILabel()
     
     override func setStyle() {
-        backgroundColor = .black50
-        
-        let blurEffect = UIBlurEffect(style: .systemChromeMaterialDark)
-        let blurView = UIVisualEffectView(effect: blurEffect)
-        blurView.backgroundColor = .black
-        insertSubview(blurView, at: 0)
-
-        blurView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
+        backgroundColor = .grayscale900
         
         titleLabel.do {
             $0.font = FontManager.head1M24.font

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
@@ -13,6 +13,7 @@ import SnapKit
 final class QuestCheckViewController: BaseViewController {
     
     private var isStartedQuset = false
+    private var allCompleted = false
     
     let questsCheckView = QuestsCheckView()
     private let viewModel: QuestsViewModel
@@ -65,7 +66,7 @@ final class QuestCheckViewController: BaseViewController {
                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
                 withReuseIdentifier: QuestStepHeaderView.identifier
             )
-            $0.backgroundColor = .black
+            $0.backgroundColor = .grayscale900
         }
     }
     
@@ -94,7 +95,7 @@ final class QuestCheckViewController: BaseViewController {
                 guard let step = quests.steps.first else { return }
                 if quests.currentStep > step.quests.count {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        self?.scrollToCurrentStep()
+                        self?.scrollToStep()
                     }
                 }
             case (.success(_), .success(_), .failure(_)):
@@ -130,31 +131,31 @@ final class QuestCheckViewController: BaseViewController {
             .store(in: &cancellable)
     }
     
-    private func scrollToCurrentStep() {
+    private func scrollToStep() {
         guard let questsEntity = questsEntity else { return }
         for (sectionIndex, step) in questsEntity.steps.enumerated() {
-            if let _ = step.quests.firstIndex(
-                where: {
-                    $0.questNumber == questsEntity.currentStep
-                }) {
-                var indexPath = IndexPath(item: 0, section: sectionIndex)
-                
-                if step.stepNumber == 5 {
-                    indexPath = IndexPath(item: step.quests.count - 1, section: sectionIndex)
-                    questsCheckView.questCollectionView.scrollToItem(at: indexPath, at: .bottom, animated: true)
+            let collectionView = questsCheckView.questCollectionView
+            
+            if let _ = step.quests.firstIndex(where: { $0.questNumber == questsEntity.currentStep }) {
+                // MARK: - 마지막 퀘스트 완료 시 STEP 1으로 스크롤
+                if quest?.questNumber == 30 && allCompleted {
+                    collectionView.scrollToHeader(at: 0)
                     return
                 }
                 
-                if let attributes = questsCheckView.questCollectionView.layoutAttributesForSupplementaryElement(
-                    ofKind: UICollectionView.elementKindSectionHeader,
-                    at: indexPath
-                ) {
-                    let offsetY = attributes.frame.origin.y - questsCheckView.questCollectionView.contentInset.top
-                    questsCheckView.questCollectionView.setContentOffset(
-                        CGPoint(x: 0, y: offsetY.adjustedH),
-                        animated: true
+                // MARK: - 마지막 스텝 진입 시 맨 아래로 스크롤
+                if step.stepNumber == 5 {
+                    let maxOffsetY = collectionView.contentSize.height - collectionView.bounds.height + 30
+                    let bottomOffset = CGPoint(
+                        x: 0,
+                        y: max(maxOffsetY, 0)
                     )
+                    collectionView.setContentOffset(bottomOffset, animated: true)
+                    return
                 }
+                
+                // MARK: - 다음 스텝으로 넘어간 경우 해당 STEP으로 스크롤
+                collectionView.scrollToHeader(at: sectionIndex)
                 return
             }
         }
@@ -162,7 +163,7 @@ final class QuestCheckViewController: BaseViewController {
 }
 
 extension QuestCheckViewController: UICollectionViewDelegate {
-        
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         quest = questsEntity?.steps[indexPath.section].quests[indexPath.item]
         let currentStep = questsEntity?.currentStep
@@ -178,7 +179,6 @@ extension QuestCheckViewController: UICollectionViewDelegate {
         
         if questNumber < step {
             let questType: QuestType = (quest?.questStyle == QuestStyle.recording.key) ? .question : .activation
-            
             let archiveQuestViewController = ArchiveQuestViewController(
                 viewModel: viewModel,
                 questID: questID ?? 1,
@@ -202,6 +202,10 @@ extension QuestCheckViewController: UICollectionViewDelegate {
     }
     
     private func moveWriteQuest(quest: QuestEntity?) {
+        if quest?.questNumber == 30 {
+            allCompleted = true
+        }
+        
         if quest?.questStyle == QuestStyle.recording.key {
             guard let viewModel = DIContainer.shared.resolve(type: WriteQuestionTypeViewModel.self),
                   let questID = quest?.questId else {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestCheckViewController.swift
@@ -204,6 +204,10 @@ extension QuestCheckViewController: UICollectionViewDelegate {
     private func moveWriteQuest(quest: QuestEntity?) {
         if quest?.questNumber == 30 {
             allCompleted = true
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.questsCheckView.questCollectionView.scrollToHeader(at: 0)
+            }
         }
         
         if quest?.questStyle == QuestStyle.recording.key {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestsCheckView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/QuestsCheckView.swift
@@ -18,10 +18,6 @@ final class QuestsCheckView: BaseView {
         collectionViewLayout: CollectionViewFactory.createLayout()
     )
     
-    override func setStyle() {
-        backgroundColor = .grayscale900
-    }
-    
     override func setUI() {
         addSubviews(
             questCheckHeaderView,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
@@ -68,6 +68,7 @@ final class QuestTextField: BaseView {
             $0.textColor = .grayscale300
             $0.text = placeholder
             $0.font = FontManager.body3R16.font
+            $0.tintColor = .white
         }
         
         textCount.do {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/QuestionType/View/WriteQuestionTypeQuestView.swift
@@ -57,7 +57,7 @@ final class WriteQuestionTypeQuestView: BaseView {
         }
         
         questTextField.snp.makeConstraints {
-            $0.top.equalTo(title.snp.bottom).offset(24.adjustedH)
+            $0.top.equalTo(title.snp.bottom).offset(8.adjustedH)
             $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
             $0.height.equalTo(290.adjustedH)
         }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #146 

## 📄 작업 내용
- 자동 스크롤 조정 : 항상 섹션 헤더로 스크롤 / 마지막 STEP인 경우 맨 아래로 스크롤 / 전체 퀘스트 완료 시 맨 위로 스크롤
- QuestModalView 레이아웃 수정
- 퀘스트 전체 조회 화면 배경색 통일
- 닉네임 텍스트필드 에러 아이콘 크기 수정
- 닉네임 텍스트필드 및 퀘스트 작성 커서 색상을 흰색으로 변경
- 정보 입력 뷰 : 이전 화면에서 다시 현재 화면으로 돌아왔을 때 선택한 정보가 초기화되도록 수정
- 그외 : 나연, 주리가 요청한 부분