### PR TITLE
Setting/#13 GitHub action로 CI 적용

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,8 +28,8 @@ jobs:
           set -o pipefail
           xcodebuild \
             -project ByeBoo-iOS/ByeBoo-iOS.xcodeproj \
-            -scheme App \
+            -scheme ByeBoo-iOS \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=16.6' \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
             clean build | xcpretty
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,35 @@
+name: iOS build test
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Generate xcconfig
+        run: |
+          mkdir -p ByeBoo-iOS/Data/Config
+          echo "BASE_URL = ${BASE_URL}" > ByeBoo-iOS/Data/Config/Config.xcconfig
+        env:
+          BASE_URL: ${{ secrets.BASE_URL }}
+
+      - name: Build with xcodebuild
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project ByeBoo-iOS/ByeBoo-iOS.xcodeproj \
+            -scheme App \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=16.6' \
+            clean build | xcpretty
+


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #13 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
### GitHub Actions를 활용한 CI 빌드 검증 자동화 구축
PR이 생성될 때마다 자동으로 빌드 검증을 수행하여 코드 품질을 보장하는 워크플로우를 추가했습니다.
- PR 생성/업데이트 시 자동으로 xcodebuild를 실행하여 빌드 성공 여부를 검증합니다
- 빌드 실패 시 PR 머지를 방지하여 main 브랜치의 안정성을 보장합니다

`set -o pipefail` 빌드 오류가 발생하면 fail 
```
  - name: Build with xcodebuild
        run: |
          set -o pipefail
          xcodebuild \
            -project ByeBoo-iOS/ByeBoo-iOS.xcodeproj \
            -scheme ByeBoo-iOS \
            -sdk iphonesimulator \
            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
            clean build | xcpretty
```

## ✅ 기대 효과
1. 코드 품질 향상: 빌드가 깨지는 코드가 main에 머지되는 것을 사전에 차단
2. 개발 생산성 증대: 로컬에서 빌드를 깜빡하고 푸시한 경우에도 자동으로 검증
3. 협업 효율성: 리뷰어가 빌드 성공 여부를 수동으로 확인할 필요 없음
4. 배포 안정성: CI에서 검증된 코드만 배포되어 프로덕션 안정성 확보



## 🔧 추가 설정 필요 사항
프로젝트의 Config 파일에 새로운 속성(API 키, URL 등)이 추가되는 경우, GitHub Repository Settings에서 반드시 Secret을 설정해주어야 합니다.