### PR TITLE
Refactor/#162 멘토링 피드백 내용 반영 

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
@@ -14,7 +14,7 @@ struct DataDependencyAssembler: DependencyAssembler {
     
     func assemble() {
         DIContainer.shared.register(type: UsersInterface.self) { _ in
-            return DefaultUsersRepository(network: networkService, userDefatulsService: userDefaultService)
+            return DefaultUsersRepository(network: networkService, userDefaultsService: userDefaultService)
         }
         
         DIContainer.shared.register(type: QuestsInterface.self) { _ in

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
@@ -13,10 +13,10 @@ struct DefaultUsersRepository: UsersInterface {
     
     init(
         network: NetworkService,
-        userDefatulsService: UserDefaultService
+        userDefaultsService: UserDefaultService
     ) {
         self.network = network
-        self.userDefaultsService = userDefatulsService
+        self.userDefaultsService = userDefaultsService
     }
     
     // MARK: Network

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/ProgressingQuestsEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/ProgressingQuestsEntity.swift
@@ -32,30 +32,43 @@ extension ProgressingQuestsEntity {
         return .init(
             progressPeriod: 1,
             currentStep: 1,
-            steps: [StepEntity.stub()]
+            steps: (1...5).map { StepEntity.stub(stepNumber: $0) }
         )
     }
 }
 
 extension StepEntity {
     
-    static func stub() -> Self {
+    static func stub(stepNumber: Int) -> Self {
         return .init(
-            stepNumber: 1,
-            step: "감정 쏟아내기",
-            quests: [QuestEntity.stub()]
+            stepNumber: stepNumber,
+            step: stepName(for: stepNumber),
+            quests: (1...6).map { _ in
+                QuestEntity.stub(index: (stepNumber))
+            }
         )
+    }
+    
+    private static func stepName(for number: Int) -> String {
+        switch number {
+        case 1: return "마음 깨우기"
+        case 2: return "혼자 있는 힘 기르기"
+        case 3: return "감정에 이름 붙이기"
+        case 4: return "혼자 있는 힘 기르기"
+        case 5: return "스스로에게 대접하기"
+        default: return "단계 \(number)"
+        }
     }
 }
 
 extension QuestEntity {
     
-    static func stub() -> Self {
+    static func stub(index: Int) -> Self {
         return .init(
-            questId: 31,
+            questId: 30 + index,
             question: "무슨 일이 있었나요?",
             questStyle: "RECORDING",
-            questNumber: 1
+            questNumber: index
         )
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestTipEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestTipEntity.swift
@@ -23,17 +23,30 @@ struct QuestTipEntity {
 extension QuestTipDataEntity {
     static func stub() -> QuestTipDataEntity {
         return .init(
-            step: "1",
+            step: "감정 정리하기",
             stepNumber: 1,
-            questNumber: 1,
-            question: "question",
-            tips: [.stub()]
+            questNumber: 10,
+            question: "연애에서 반복됐던 문제 패턴 3가지를 생각해보아요.",
+            tips: QuestTipEntity.stub()
         )
     }
 }
 
 extension QuestTipEntity {
-    static func stub() -> QuestTipEntity {
-        return .init(tipStep: 1, tipAnswer: "tip answer")
+    static func stub() -> [QuestTipEntity] {
+        return [
+            .init(
+                tipStep: 1,
+                tipAnswer: "그 사람의 눈치를 보느라 하고 싶은 걸 억누르고 참았던 적이 있지 않나요? 하지만 이제는, 더 이상 맞춰줄 필요 없어요. 내 마음대로, 나답게 생각해도 되는 시간이에요. 억눌렀던 마음을 천천히 꺼내 보면서, 잃어버렸던 ‘진짜 나’를 다시 찾아가봐요."
+            ),
+            .init(
+                tipStep: 2,
+                tipAnswer: "그 사람이 싫어해서 참았던 말투, 옷차림, 취미는 무엇이었나요? 해보고 싶었지만, 싸우게 될까봐 망설였던 건요?"
+            ),
+            .init(
+                tipStep: 3,
+                tipAnswer: "관계 속에서 잃었던 나의 일부를 다시 인식하게 돼요. 내가 어떤 부분에서 억눌려 있었는지 알게 돼요. 앞으로 어떤 걸 자유롭게 선택할 수 있는지 알게 돼요."
+            )
+        ]
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionBottomSheetView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionBottomSheetView.swift
@@ -15,6 +15,7 @@ final class EmotionBottomSheetView: BaseView {
     private let titleLabel = UILabel()
     private let emotionChipFirstStackView = UIStackView()
     private let emotionChipSecondStackView = UIStackView()
+    private let dividerNum = 2
     
     let confirmButton = ByeBooButton(titleText: "완료", type: .disabled)
     var emotionChips: [ByeBooEmotionChip] = []
@@ -28,14 +29,16 @@ final class EmotionBottomSheetView: BaseView {
             confirmButton
         )
         
-        ByeBooEmotion.allCases.enumerated().forEach { index, emotion in
+        ByeBooEmotion.allCases.prefix(dividerNum).forEach { emotion in
             let chip = ByeBooEmotionChip(emotionType: emotion)
             emotionChips.append(chip)
-            if index < 2 {
-                emotionChipFirstStackView.addArrangedSubview(chip)
-            } else {
-                emotionChipSecondStackView.addArrangedSubview(chip)
-            }
+            emotionChipFirstStackView.addArrangedSubview(chip)
+        }
+        
+        ByeBooEmotion.allCases.suffix(dividerNum).forEach { emotion in
+            let chip = ByeBooEmotionChip(emotionType: emotion)
+            emotionChips.append(chip)
+            emotionChipSecondStackView.addArrangedSubview(chip)
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionBottomSheetView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/EmotionBottomSheet/EmotionBottomSheetView.swift
@@ -15,7 +15,6 @@ final class EmotionBottomSheetView: BaseView {
     private let titleLabel = UILabel()
     private let emotionChipFirstStackView = UIStackView()
     private let emotionChipSecondStackView = UIStackView()
-    private let dividerNum = 2
     
     let confirmButton = ByeBooButton(titleText: "완료", type: .disabled)
     var emotionChips: [ByeBooEmotionChip] = []
@@ -29,16 +28,16 @@ final class EmotionBottomSheetView: BaseView {
             confirmButton
         )
         
-        ByeBooEmotion.allCases.prefix(dividerNum).forEach { emotion in
+        ByeBooEmotion.allCases.enumerated().forEach { _, emotion in
             let chip = ByeBooEmotionChip(emotionType: emotion)
             emotionChips.append(chip)
-            emotionChipFirstStackView.addArrangedSubview(chip)
-        }
-        
-        ByeBooEmotion.allCases.suffix(dividerNum).forEach { emotion in
-            let chip = ByeBooEmotionChip(emotionType: emotion)
-            emotionChips.append(chip)
-            emotionChipSecondStackView.addArrangedSubview(chip)
+            
+            switch emotion {
+            case .neutral, .sad:
+                emotionChipFirstStackView.addArrangedSubview(chip)
+            case .selfUnderstanding, .relieved:
+                emotionChipSecondStackView.addArrangedSubview(chip)
+            }
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Navigation/BottomNavigationViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Navigation/BottomNavigationViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-
-
 final class BottomNavigationViewController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,7 +24,11 @@ final class BottomNavigationViewController: UITabBarController {
               let questViewModel = DIContainer.shared.resolve(type: QuestsViewModel.self)
         else {
             ByeBooLogger.error(ByeBooError.DIFailedError)
-            fatalError()
+            
+            let viewController = OnboardingViewController()
+            navigationController?.pushViewController(viewController, animated: false)
+            
+            return
         }
         
         self.viewControllers = [

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Navigation/BottomNavigationViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Navigation/BottomNavigationViewController.swift
@@ -25,8 +25,18 @@ final class BottomNavigationViewController: UITabBarController {
         else {
             ByeBooLogger.error(ByeBooError.DIFailedError)
             
-            let viewController = OnboardingViewController()
-            navigationController?.pushViewController(viewController, animated: false)
+            //TODO: Login으로 변경
+            let tempViewController = OnboardingViewController()
+            
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                
+                ViewControllerUtils.setRootViewController(
+                    window: window,
+                    viewController: tempViewController,
+                    withAnimation: true
+                )
+            }
             
             return
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Extension/Collection+.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Extension/Collection+.swift
@@ -1,0 +1,12 @@
+//
+//  Collection+.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/31/25.
+//
+
+extension Collection {
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestHeaderView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestHeaderView.swift
@@ -19,10 +19,10 @@ final class ArchiveQuestHeaderView: BaseView {
 
     private let type: QuestHeaderType
     private let stepStackView = UIStackView()
-    let stepLabel = UILabel()
-    let questNumberLabel = UILabel()
-    let dateLabel = UILabel()
-    let questTitleLabel = UILabel()
+    private(set) var stepLabel = UILabel()
+    private(set) var questNumberLabel = UILabel()
+    private(set) var dateLabel = UILabel()
+    private(set) var questTitleLabel = UILabel()
     
     private let stepNumber: Int
     private let questNumber: Int

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestHeaderView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestHeaderView.swift
@@ -19,9 +19,9 @@ final class ArchiveQuestHeaderView: BaseView {
 
     private let type: QuestHeaderType
     private let stepStackView = UIStackView()
-    private(set) var stepLabel = UILabel()
-    private(set) var questNumberLabel = UILabel()
-    private(set) var dateLabel = UILabel()
+    private let stepLabel = UILabel()
+    private let questNumberLabel = UILabel()
+    private let dateLabel = UILabel()
     private(set) var questTitleLabel = UILabel()
     
     private let stepNumber: Int

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/FeelView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/FeelView.swift
@@ -12,8 +12,8 @@ import SnapKit
 final class FeelView: BaseView {
 
     private let descriptionView: TextBoxView
-    var emotionType: String
-    var descriptionText: String
+    private(set) var emotionType: String
+    private(set) var descriptionText: String
     
     private let titleTextView = IconOneLineTextView(iconType: .change, text: "퀘스트 완료 후, 이런 감정을 느꼈어요")
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/FeelView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/FeelView.swift
@@ -12,8 +12,8 @@ import SnapKit
 final class FeelView: BaseView {
 
     private let descriptionView: TextBoxView
-    private(set) var emotionType: String
-    private(set) var descriptionText: String
+    private var emotionType: String
+    private var descriptionText: String
     
     private let titleTextView = IconOneLineTextView(iconType: .change, text: "퀘스트 완료 후, 이런 감정을 느꼈어요")
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ThinkView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ThinkView.swift
@@ -13,7 +13,7 @@ final class ThinkView: BaseView {
     
     private let titleTextView = IconOneLineTextView(iconType: .think, text: "이렇게 생각했어요")
     private let descriptionView: TextBoxView
-    private(set) var descriptionText: String
+    private let descriptionText: String
     
     init(descriptionText: String) {
         self.descriptionText = descriptionText

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ThinkView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ThinkView.swift
@@ -13,7 +13,7 @@ final class ThinkView: BaseView {
     
     private let titleTextView = IconOneLineTextView(iconType: .think, text: "이렇게 생각했어요")
     private let descriptionView: TextBoxView
-    var descriptionText: String
+    private(set) var descriptionText: String
     
     init(descriptionText: String) {
         self.descriptionText = descriptionText

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
@@ -14,7 +14,7 @@ final class QuestTipView: BaseView {
     
     private let navigationView = UIView()
     private let titleLabel = UILabel()
-    let closeButton = UIButton()
+    private(set) var closeButton = UIButton()
     private let stepStackView = UIStackView()
     private var stepNum: Int = 0
     private let stepLabel = ByeBooYellowTag(text: "STEP 0")

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
@@ -58,6 +58,7 @@ final class QuestTipView: BaseView {
         ]
         
         let tips = entity.tips
+        
         tips.enumerated().forEach { index, tip in
             
             guard tips[safe: index] != nil else { return }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
@@ -57,17 +57,14 @@ final class QuestTipView: BaseView {
             "이 퀘스트가 끝나면 어떤 변화가 생길까요?"
         ]
         
-        entity.tips.enumerated().forEach { index, tip in
-            let iconType: IconType = {
-                switch index {
-                case 0: return .write
-                case 1: return .think
-                case 2: return .change
-                default: return .write
-                }
-            }()
+        let tips = entity.tips
+        tips.enumerated().forEach { index, tip in
             
-            let iconTitleLabel = IconOneLineTextView(iconType: iconType, text: tipQuestion[index])
+            guard tips[safe: index] != nil else { return }
+            
+            let iconType: [IconType] = [.write, .think, .change]
+            
+            let iconTitleLabel = IconOneLineTextView(iconType: iconType[index], text: tipQuestion[index])
             let textView = TextBoxView(title: tip.tipAnswer)
             let dividerView = SectionDividerView()
             self.addSubviews(iconTitleLabel, textView, dividerView)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestTipViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestTipViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 
 final class QuestTipViewModel: ViewModelType {
     
-    
     private var questTipSubject: PassthroughSubject<Result<QuestTipDataEntity, ByeBooError>, Never> = .init()
      
     var output: Output {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/CompleteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/CompleteActiveTypeQuestView.swift
@@ -15,13 +15,13 @@ final class CompleteActiveTypeQuestView: BaseView {
     private let scrollView = UIScrollView()
     private let contentView = UIView()
     private let congratSquare = CongratSquare()
-    private let stepStackView = UIStackView()
-    private var stepNum: Int = 0
-    private let stepLabel = ByeBooYellowTag(text: "STEP 0")
-    private var questNum: Int = 0
-    private let questLabel = UILabel()
-    private let dateText = UILabel()
-    private let title = UILabel()
+    private var headerView = ArchiveQuestHeaderView(
+        type: .complete,
+        stepNumber: 0,
+        questNumber: 0,
+        date: "",
+        questTitle:""
+    )
     
     override func setUI() {
         addSubviews(scrollView)
@@ -29,12 +29,8 @@ final class CompleteActiveTypeQuestView: BaseView {
         
         contentView.addSubviews(
             congratSquare,
-            stepStackView,
-            dateText,
-            title
+            headerView
         )
-        
-        stepStackView.addArrangedSubviews(stepLabel, questLabel)
     }
     
     override func setStyle() {
@@ -43,40 +39,15 @@ final class CompleteActiveTypeQuestView: BaseView {
         contentView.do {
             $0.backgroundColor = .grayscale900
         }
-        
-        stepStackView.do {
-            $0.axis = .horizontal
-            $0.spacing = 8
-            $0.distribution = .equalCentering
-        }
-        
-        questLabel.do {
-            $0.font = FontManager.body5R14.font
-            $0.textColor = .grayscale400
-        }
-        
-        dateText.do {
-            $0.font = FontManager.body5R14.font
-            $0.textColor = .grayscale400
-            $0.textAlignment = .center
-        }
-        
-        title.do {
-            $0.font = FontManager.head1M24.font
-            $0.numberOfLines = 0
-            $0.textColor = .grayscale100
-            $0.textAlignment = .center
-            $0.lineBreakMode = .byWordWrapping
-        }
     }
     
     func bind(with entity: QuestAnswerEntity) {
-        self.stepNum = entity.stepNumber
-        stepLabel.updateText("STEP \(stepNum)")
-        self.questNum = entity.questNumber
-        self.questLabel.text = "\(questNum)번째 퀘스트"
-        self.title.text = entity.question
-        self.dateText.text = entity.createdAt.dateFormat()
+        headerView.updateUI(
+            stepNumber: entity.stepNumber,
+            questNumber: entity.questNumber,
+            date: entity.createdAt,
+            title: entity.question
+        )
         
         let actionView = ActionView(descriptionText: entity.answer, photoURL: entity.imageUrl!)
         let feelView = FeelView(
@@ -87,7 +58,7 @@ final class CompleteActiveTypeQuestView: BaseView {
         contentView.addSubviews(actionView, feelView)
 
         actionView.snp.makeConstraints {
-            $0.top.equalTo(title.snp.bottom)
+            $0.top.equalTo(headerView.questTitleLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview()
         }
         
@@ -114,19 +85,9 @@ final class CompleteActiveTypeQuestView: BaseView {
             $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
         }
         
-        stepStackView.snp.makeConstraints {
+        headerView.snp.makeConstraints {
             $0.top.equalTo(congratSquare.snp.bottom).offset(32.adjustedH)
-            $0.centerX.equalToSuperview()
-        }
-        
-        dateText.snp.makeConstraints {
-            $0.top.equalTo(stepStackView.snp.bottom).offset(12.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(147.5.adjustedW)
-        }
-        
-        title.snp.makeConstraints {
-            $0.top.equalTo(dateText.snp.bottom).offset(12.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+            $0.horizontalEdges.equalToSuperview()
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/WriteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/WriteActiveTypeQuestView.swift
@@ -11,9 +11,9 @@ import SnapKit
 import Then
 
 final class WriteActiveTypeQuestView: BaseView {
-    let scrollView = UIScrollView()
-    let contentView = UIView()
-    let title = WriteQuestTitleView(
+    private(set) var scrollView = UIScrollView()
+    private(set) var contentView = UIView()
+    private(set) var title = WriteQuestTitleView(
         stepNum: "",
         stepTitle: "",
         questNum: 0,
@@ -25,13 +25,13 @@ final class WriteActiveTypeQuestView: BaseView {
     private let imgTitleLabel = UILabel()
     private let imgCountLabel = UILabel()
     var imgCount: Int = 0
-    let imageContainer = ImagePickerContainer()
+    private(set) var imageContainer = ImagePickerContainer()
     
     private let textStackView = UIStackView()
     private let grayTag = ByeBooFilledTag(tagType: .smallGray, text: "선택")
     private let thinkTitleLabel = UILabel()
-    let questTextField = QuestTextField(type: .activation)
-    let confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
+    private(set) var questTextField = QuestTextField(type: .activation)
+    private(set) var confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
     
     override func setUI() {
         addSubviews(scrollView)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/WriteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/WriteActiveTypeQuestView.swift
@@ -12,7 +12,7 @@ import Then
 
 final class WriteActiveTypeQuestView: BaseView {
     private(set) var scrollView = UIScrollView()
-    private(set) var contentView = UIView()
+    private let contentView = UIView()
     private(set) var title = WriteQuestTitleView(
         stepNum: "",
         stepTitle: "",

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/QuestionType/CompleteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/QuestionType/CompleteQuestionTypeQuestView.swift
@@ -15,13 +15,13 @@ final class CompleteQuestionTypeQuestView: BaseView {
     private let scrollView = UIScrollView()
     private let contentView = UIView()
     private let congratSquare = CongratSquare()
-    private let stepStackView = UIStackView()
-    private var stepNum: Int = 0
-    private let stepLabel = ByeBooYellowTag(text: "STEP 0")
-    private var questNum: Int = 0
-    private let questLabel = UILabel()
-    private let dateText = UILabel()
-    private let title = UILabel()
+    private var headerView = ArchiveQuestHeaderView(
+        type: .complete,
+        stepNumber: 0,
+        questNumber: 0,
+        date: "",
+        questTitle:""
+    )
     
     override func setUI() {
         addSubviews(scrollView)
@@ -29,12 +29,8 @@ final class CompleteQuestionTypeQuestView: BaseView {
         
         contentView.addSubviews(
             congratSquare,
-            stepStackView,
-            dateText,
-            title
+            headerView
         )
-        
-        stepStackView.addArrangedSubviews(stepLabel, questLabel)
     }
     
     override func setStyle() {
@@ -43,40 +39,15 @@ final class CompleteQuestionTypeQuestView: BaseView {
         contentView.do {
             $0.backgroundColor = .grayscale900
         }
-        
-        stepStackView.do {
-            $0.axis = .horizontal
-            $0.spacing = 8
-        }
-        
-        questLabel.do {
-            $0.font = FontManager.body5R14.font
-            $0.textColor = .grayscale400
-        }
-        
-        dateText.do {
-            $0.font = FontManager.body5R14.font
-            $0.textColor = .grayscale400
-            $0.textAlignment = .center
-        }
-        
-        title.do {
-            $0.font = FontManager.head1M24.font
-            $0.numberOfLines = 0
-            $0.textColor = .grayscale100
-            $0.textAlignment = .center
-            $0.lineBreakMode = .byWordWrapping
-        }
-        
     }
     
     func bind(with entity: QuestAnswerEntity) {
-        self.stepNum = entity.stepNumber
-        stepLabel.updateText("STEP \(stepNum)")
-        self.questNum = entity.questNumber
-        self.questLabel.text = "\(questNum)번째 퀘스트"
-        self.title.text = entity.question
-        self.dateText.text = entity.createdAt.dateFormat()
+        headerView.updateUI(
+            stepNumber: entity.stepNumber,
+            questNumber: entity.questNumber,
+            date: entity.createdAt,
+            title: entity.question
+        )
         
         let thinkView = ThinkView(descriptionText: entity.answer)
         let feelView = FeelView(emotionType: entity.questEmotionState, descriptionText: entity.emotionDescription)
@@ -87,7 +58,7 @@ final class CompleteQuestionTypeQuestView: BaseView {
         feelView.isUserInteractionEnabled = false
         
         thinkView.snp.makeConstraints {
-            $0.top.equalTo(title.snp.bottom)
+            $0.top.equalTo(headerView.questTitleLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview()
         }
         
@@ -113,20 +84,10 @@ final class CompleteQuestionTypeQuestView: BaseView {
             $0.top.equalToSuperview().inset(16.adjustedH)
             $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
         }
-        
-        stepStackView.snp.makeConstraints {
+                
+        headerView.snp.makeConstraints {
             $0.top.equalTo(congratSquare.snp.bottom).offset(32.adjustedH)
-            $0.centerX.equalToSuperview()
-        }
-        
-        dateText.snp.makeConstraints {
-            $0.top.equalTo(stepStackView.snp.bottom).offset(12.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(147.5.adjustedW)
-        }
-        
-        title.snp.makeConstraints {
-            $0.top.equalTo(dateText.snp.bottom).offset(12.adjustedH)
-            $0.leading.trailing.equalToSuperview().inset(24.adjustedW)
+            $0.horizontalEdges.equalToSuperview()
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/QuestionType/WriteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/QuestionType/WriteQuestionTypeQuestView.swift
@@ -11,15 +11,15 @@ import SnapKit
 import Then
 
 final class WriteQuestionTypeQuestView: BaseView {
-    let title = WriteQuestTitleView(
+    private(set) var title = WriteQuestTitleView(
         stepNum: "",
         stepTitle: "",
         questNum: 0,
         title: ""
     )
-    let questTextField = QuestTextField(type: .question)
+    private(set) var questTextField = QuestTextField(type: .question)
     private let descriptionLabel = UILabel()
-    let confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
+    private(set) var confirmButton = ByeBooButton(titleText: "완료하기", type: .disabled)
     
     override func setUI() {
         addSubviews(


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #162 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
멘토링 내용을 전체적으로 반영했습니다. 


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### 바텀네비게이션 의존성 주입 실패 시 fatal error가 나는 것
guard let viewmodel에서 의존성 주입 실패 시 fatal error 대신 다른 방법을 찾아보면 좋겠다는 내용을 반영하여서 의존성 주입 실패시 온보딩으로 가도록 네비게이션해두었습니다. 그런데 테스트를 어떻게 해야될지 모르겠어요..
```swift
 private func setViewController() {
        
        guard let homeViewModel = DIContainer.shared.resolve(type: HomeViewModel.self),
              let myPageViewModel = DIContainer.shared.resolve(type: MyPageViewModel.self),
              let questViewModel = DIContainer.shared.resolve(type: QuestsViewModel.self)
        else {
            ByeBooLogger.error(ByeBooError.DIFailedError)
            
            let viewController = OnboardingViewController()
            navigationController?.pushViewController(viewController, animated: false)
            
            return
        }
    }
```

### 접근제어자 수정
updateUI를 하느라 접근제어자 private 대신 Internal를 썼던 부분들을 전부 private(set) var로 수정했습니다.

### index out of range 방지를 위한 노력 
인덱스에 직접 접근하는 것을 방지하기 위해 아래와 같이 작업했습니다. 
제가 작성했던 부분에서 인덱스에 직접 접근했던 부분은 두가지가 있었는데요 

1. 바텀시트
바텀 시트에서 index를 2로 접근해 위, 아래 이모지들을 구분하는 것을 prefix, suffix를 사용하는 것으로 수정했습니다. 
매직넘버를 없애기 위해 dividerNum = 2를 추가하여 사용했습니다. 
```swift
ByeBooEmotion.allCases.prefix(dividerNum).forEach { emotion in
            let chip = ByeBooEmotionChip(emotionType: emotion)
            emotionChips.append(chip)
            emotionChipFirstStackView.addArrangedSubview(chip)
        }
        
ByeBooEmotion.allCases.suffix(dividerNum).forEach { emotion in
    let chip = ByeBooEmotionChip(emotionType: emotion)
    emotionChips.append(chip)
    emotionChipSecondStackView.addArrangedSubview(chip)
}
```
2. 퀘스트 팁 
```swift
extension Collection {
    subscript (safe index: Index) -> Element? {
        return indices.contains(index) ? self[index] : nil
    }
}
```
index가 유효한지 판단하는 익스텐션을 추가하였습니다. 
```swift
 let tips = entity.tips
tips.enumerated().forEach { index, tip in
    guard tips[safe: index] != nil else { return }
    let iconType: [IconType] = [.write, .think, .change]
    let iconTitleLabel = IconOneLineTextView(iconType: iconType[index], text: tipQuestion[index])
```
팁의 인덱스가 safe할 시에만 인덱스 접근을 하도록 수정했습니다. 

### 그외
Complete 퀘스트 부분에서 제목 부분을 주리언니가 만든 ArchiveQuestHeader로 갈아끼웠습니다. 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[prefix, suffix](https://sheep1sik.tistory.com/122)
[배열 접근](https://h1guitar.tistory.com/202)

