### PR TITLE
Feat/#193 헤더 구조 변경

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ByeBoo-iOS/Resource/Info.plist";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 업로드를 위해 갤러리 접근 권한이 필요합니다. 사진 선택을 위해 [설정]에서 접근 권한을 허용해 주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -211,6 +212,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ByeBoo-iOS/Resource/Info.plist";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 업로드를 위해 갤러리 접근 권한이 필요합니다. 사진 선택을 위해 [설정]에서 접근 권한을 허용해 주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;

--- a/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
@@ -20,7 +20,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         DIContainer.shared.dependencyInject()
         
-        let viewController = LoginViewController()
+        guard let viewModel = DIContainer.shared.resolve(type: InformationViewModel.self) else {
+            ByeBooLogger.error(ByeBooError.DIFailedError)
+            fatalError()
+        }
+        
+        let viewController = InformationViewController(viewModel: viewModel)
 
         let navigationController = UINavigationController(rootViewController: viewController)
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/EndPoint.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/EndPoint.swift
@@ -63,16 +63,16 @@ extension EndPoint {
 
 enum HeaderType {
     case basic
-    case withAuth(userID: Int)
+    case withAuth(acessToken: String)
     
     var value: HTTPHeaders {
         switch self {
         case .basic:
             return ["Content-Type": "application/json"]
-        case .withAuth(let userID):
+        case .withAuth(let acessToken):
             return [
                 "Content-Type": "application/json",
-                "userId": "\(userID)"
+                "Authorization": "Bearer \(acessToken)"
             ]
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/QuestAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/QuestAPI.swift
@@ -10,13 +10,13 @@ import Foundation
 import Alamofire
 
 enum QuestAPI {
-    case checkQuest(userID: Int, questID: Int)
-    case recording(userID: Int, questID: Int, request: SaveQuestRequestDTO)
-    case active(userID: Int, questID: Int, request: SaveQuestActiveRequestDTO)
-    case images(userID: Int, request: SignedURLRequestDTO)
-    case tip(userID: Int, questID: Int)
-    case answer(userID: Int, questID: Int)
-    case progressingQuests(userID: Int)
+    case checkQuest(questID: Int)
+    case recording(questID: Int, request: SaveQuestRequestDTO)
+    case active(questID: Int, request: SaveQuestActiveRequestDTO)
+    case images(request: SignedURLRequestDTO)
+    case tip(questID: Int)
+    case answer(questID: Int)
+    case progressingQuests
 }
 
 extension QuestAPI: EndPoint {
@@ -27,17 +27,17 @@ extension QuestAPI: EndPoint {
     
     var path: String {
         switch self {
-        case .checkQuest(_, let questID):
+        case .checkQuest(let questID):
             return "/\(questID)"
-        case .recording(_, let questID, _):
+        case .recording(let questID, _):
             return "/\(questID)/recording"
-        case .active(_, let questID, _):
+        case .active(let questID, _):
             return "/\(questID)/active"
         case .images:
             return "/images/signed-url"
-        case .tip(_, let questID):
+        case .tip(let questID):
             return "/\(questID)/tip"
-        case .answer(_, let questID):
+        case .answer(let questID):
             return "/answer/\(questID)"
         case .progressingQuests:
             return "/all/progress"
@@ -55,14 +55,8 @@ extension QuestAPI: EndPoint {
     
     var headers: HeaderType {
         switch self {
-        case let .checkQuest(userID, _),
-            let .recording(userID, _, _),
-            let .active(userID, _, _),
-            let .tip(userID, _),
-            let .images(userID, _),
-            let .answer(userID, _),
-            let .progressingQuests(userID):
-            return .withAuth(userID: userID)
+        case .checkQuest, .recording, .active, .tip, .images, .answer, .progressingQuests:
+            return .withAuth(acessToken: Bundle.main.infoDictionary?["MASTER_TOKEN"] as! String)
         }
     }
     
@@ -81,11 +75,11 @@ extension QuestAPI: EndPoint {
     
     var bodyParameters: Parameters? {
         switch self {
-        case let .recording(_, _, dto):
+        case let .recording(_, dto):
             return try? dto.toDictionary()
-        case let .active(_, _, dto):
+        case let .active(_, dto):
             return try? dto.toDictionary()
-        case let .images(_, dto):
+        case let .images(dto):
             return try? dto.toDictionary()
         case .checkQuest, .tip, .answer, .progressingQuests:
             return nil

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/UsersAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/UsersAPI.swift
@@ -53,8 +53,8 @@ extension UsersAPI: EndPoint {
         case .journey, .sendUser, .character, .count, .start:
             return .withAuth(acessToken: Bundle.main.infoDictionary?["MASTER_TOKEN"] as! String)
         }
-        
     }
+    
     var parameterEncoding: ParameterEncoding {
         switch self {
         case .journey, .character, .count, .start:

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/UsersAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/UsersAPI.swift
@@ -10,11 +10,11 @@ import Foundation
 import Alamofire
 
 enum UsersAPI {
-    case journey(userID: Int)
+    case journey
     case sendUser(requestDTO: UserRequestDTO)
-    case character(userID: Int)
-    case count(userID: Int)
-    case start(userID: Int)
+    case character
+    case count
+    case start
 }
 
 extension UsersAPI: EndPoint {
@@ -42,7 +42,7 @@ extension UsersAPI: EndPoint {
         case .journey, .character, .count:
             return .get
         case .sendUser:
-            return .post
+            return .patch
         case .start:
             return .patch
         }
@@ -50,13 +50,11 @@ extension UsersAPI: EndPoint {
     
     var headers: HeaderType {
         switch self {
-        case .journey(let userID), .character(let userID), .count(let userID), .start(let userID):
-            return .withAuth(userID: userID)
-        case .sendUser:
-            return .basic
+        case .journey, .sendUser, .character, .count, .start:
+            return .withAuth(acessToken: Bundle.main.infoDictionary?["MASTER_TOKEN"] as! String)
         }
+        
     }
-    
     var parameterEncoding: ParameterEncoding {
         switch self {
         case .journey, .character, .count, .start:
@@ -79,3 +77,4 @@ extension UsersAPI: EndPoint {
         }
     }
 }
+

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestsRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestsRepository.swift
@@ -22,7 +22,7 @@ struct DefaultQuestRepository: QuestsInterface {
     
     func fetchProgressingQuests(userID: Int) async throws -> ProgressingQuestsEntity {
         let result = try await network.request(
-            QuestAPI.progressingQuests(userID: userID),
+            QuestAPI.progressingQuests,
             decodingType: ProgressingQuestsResponseDTO.self
         )
         return result.toEntity()
@@ -31,7 +31,7 @@ struct DefaultQuestRepository: QuestsInterface {
     func getQuestInfo(questID: Int) async throws -> QuestInfoEntity {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
         let result = try await network.request(
-            QuestAPI.checkQuest(userID: userID, questID: questID),
+            QuestAPI.checkQuest(questID: questID),
             decodingType: QuestInfoResponseDTO.self
         )
         return result.toEntity()
@@ -40,7 +40,7 @@ struct DefaultQuestRepository: QuestsInterface {
     func fetchQuestAnswer(questID: Int) async throws -> QuestAnswerEntity {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
         let result = try await network.request(
-            QuestAPI.answer(userID: userID, questID: questID),
+            QuestAPI.answer(questID: questID),
             decodingType: QuestAnswerResponseDTO.self
         )
         return result.toEntity()
@@ -50,7 +50,7 @@ struct DefaultQuestRepository: QuestsInterface {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
         
         let tip = try await network.request(
-            QuestAPI.tip(userID: userID, questID: questID),
+            QuestAPI.tip(questID: questID),
             decodingType: QuestTipResponseDTO.self
         )
         return tip.toEntity()
@@ -68,7 +68,7 @@ struct DefaultQuestRepository: QuestsInterface {
         let saveQuestRequestDTO: SaveQuestRequestDTO = .init(answer: answer, questEmotionState: emotionState)
         
         let _ = try await network.request(
-            QuestAPI.recording(userID: userID, questID: questID, request: saveQuestRequestDTO)
+            QuestAPI.recording(questID: questID, request: saveQuestRequestDTO)
         )
     }
     
@@ -79,7 +79,7 @@ struct DefaultQuestRepository: QuestsInterface {
         let signedURLRequestDTO = SignedURLRequestDTO(contentType: "image/jpeg", imageKey: imageKey)
         
         let result = try await network.request(
-            QuestAPI.images(userID: userID, request: signedURLRequestDTO),
+            QuestAPI.images(request: signedURLRequestDTO),
             decodingType: SignedURLResponseDTO.self
         )
         
@@ -104,7 +104,7 @@ struct DefaultQuestRepository: QuestsInterface {
         )
         
         let _ = try await network.request(
-            QuestAPI.active(userID: userID, questID: questID, request: saveQuestActiveDTO)
+            QuestAPI.active(questID: questID, request: saveQuestActiveDTO)
         )
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
@@ -24,7 +24,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchJourney() async throws -> JourneyEntity {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
         let result = try await network.request(
-            UsersAPI.journey(userID: userID),
+            UsersAPI.journey,
             decodingType: UserJourneyResponseDTO.self
         )
         
@@ -49,7 +49,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchCharacterDialogue() async throws -> String {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
         let result = try await network.request(
-            UsersAPI.character(userID: userID),
+            UsersAPI.character,
             decodingType: DialogueResponseDTO.self
         )
         
@@ -59,7 +59,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchCompleteQuestCount() async throws -> Int {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
         let result = try await network.request(
-            UsersAPI.count(userID: userID),
+            UsersAPI.count,
             decodingType: CompleteQuestCountResponseDTO.self
         )
         
@@ -68,7 +68,7 @@ struct DefaultUsersRepository: UsersInterface {
     
     func startJourney() async throws {
         let userID: Int = userDefaultsService.load(key: .userID) ?? 1
-        try await network.request(UsersAPI.start(userID: userID))
+        try await network.request(UsersAPI.start)
     }
     
     // MARK: Persistence

--- a/ByeBoo-iOS/ByeBoo-iOS/Resource/Info.plist
+++ b/ByeBoo-iOS/ByeBoo-iOS/Resource/Info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진 업로드를 위해 갤러리 접근 권한이 필요합니다. 사진 선택을 위해 [설정]에서 접근 권한을 허용해 주세요.</string>
+	<key>MASTER_TOKEN</key>
+	<string>$(MASTER_TOKEN)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #193

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 서버의 로그인API 배포에 따라 리퀘스트 헤더가 수정되었습니다
- 아직 로그인을 붙이기 전이기 때문에 리퀘스트 헤더에 마스터 토큰을 임시로 넣었습니다
- config 파일은 카톡으로 공유드릴게요!


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
```swift
enum HeaderType {
    case basic
    case withAuth(acessToken: String)
    
    var value: HTTPHeaders {
        switch self {
        case .basic:
            return ["Content-Type": "application/json"]
        case .withAuth(let acessToken):
            return [
                "Content-Type": "application/json",
                "Authorization": "Bearer \(acessToken)"
            ]
        }
    }
}
```
```swift
var headers: HeaderType {
        switch self {
        case .journey, .sendUser, .character, .count, .start:
            return .withAuth(acessToken: Bundle.main.infoDictionary?["MASTER_TOKEN"] as! String)
        }
}
```
이렇게 수정해두었습니다


