### PR TITLE
Feat/#214 애플로그인 연결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -287,6 +288,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;

--- a/ByeBoo-iOS/ByeBoo-iOS/ByeBoo-iOS.entitlements
+++ b/ByeBoo-iOS/ByeBoo-iOS/ByeBoo-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooError.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooError.swift
@@ -21,6 +21,7 @@ enum ByeBooError: Error, LocalizedError {
     case beforeJourney
     case cannotOpenPage
     case kakaoOuathError
+    case appleLoginError
     
     var errorDescription: String? {
         switch self {
@@ -48,6 +49,8 @@ enum ByeBooError: Error, LocalizedError {
             return "페이지를 열 수 없음"
         case .kakaoOuathError:
             return "카카오 액세스 토큰 받기 실패"
+        case .appleLoginError:
+            return "애플 로그인 실패"
         case .unknownError:
             return nil
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import Alamofire
+import AuthenticationServices
 import KakaoSDKUser
 
 protocol NetworkService {
@@ -17,7 +18,7 @@ protocol NetworkService {
     ) async throws -> T
     func request(_ endPoint: EndPoint) async throws
     func request(image: Data, signedURL: String) async throws
-    func request() async throws -> String
+    func kakaoRequest() async throws -> String
 }
 
 struct DefaultNetworkService: NetworkService {
@@ -121,7 +122,7 @@ struct DefaultNetworkService: NetworkService {
            }
     }
     
-    func request() async throws -> String {
+    func kakaoRequest() async throws -> String {
         return try await withCheckedThrowingContinuation { continuation in
             if UserApi.isKakaoTalkLoginAvailable() {
                 UserApi.shared.loginWithKakaoTalk { ouathToken, error in

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -5,10 +5,10 @@
 //  Created by 최주리 on 6/25/25.
 //
 
+import AuthenticationServices
 import Foundation
 
 import Alamofire
-import AuthenticationServices
 import KakaoSDKUser
 
 protocol NetworkService {
@@ -19,16 +19,23 @@ protocol NetworkService {
     func request(_ endPoint: EndPoint) async throws
     func request(image: Data, signedURL: String) async throws
     func kakaoRequest() async throws -> String
+    func appleRequest() async throws -> (String, String)
 }
 
-struct DefaultNetworkService: NetworkService {
+final class DefaultNetworkService: NSObject, NetworkService {
+    private var continuation: CheckedContinuation<(String, String), Error>?
+    
     func request<T: Decodable>(
         _ endPoint: EndPoint,
         decodingType: T.Type
     ) async throws -> T {
         requestLogger(endPoint)
         
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self else { return }
+            let responseLogger: (DataResponse<BaseResponse<T>, AFError>) -> Void = self.responseLogger
+            let handleError = self.handleError
+            
             AF.request(
                 endPoint.requestURL,
                 method: endPoint.method,
@@ -50,7 +57,7 @@ struct DefaultNetworkService: NetworkService {
                     continuation.resume(returning: data)
                 case .failure:
                     if let data = response.data,
-                       let statusCode = response.response?.statusCode,  
+                       let statusCode = response.response?.statusCode,
                        let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
                         let error = handleError(statusCode, errorResponse.message)
                         ByeBooLogger.error(error)
@@ -68,7 +75,11 @@ struct DefaultNetworkService: NetworkService {
     func request(_ endPoint: EndPoint) async throws {
         requestLogger(endPoint)
         
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self else { return }
+            let responseLogger: (DataResponse<EmptyResponse, AFError>) -> Void = self.responseLogger
+            let handleError = self.handleError
+            
             AF.request(
                 endPoint.requestURL,
                 method: endPoint.method,
@@ -108,18 +119,18 @@ struct DefaultNetworkService: NetworkService {
                 method: .put,
                 headers: ["Content-Type": "image/jpeg"]
             )
-                   .validate()
-                   .response { response in
-                       ByeBooLogger.network(response)
-                       if let error = response.error {
-                           ByeBooLogger.error(error)
-                           continuation.resume(throwing: ByeBooError.unknownError)
-                       } else {
-                           ByeBooLogger.debug("이미지 업로드 성공")
-                           continuation.resume()
-                       }
-                   }
-           }
+            .validate()
+            .response { response in
+                ByeBooLogger.network(response)
+                if let error = response.error {
+                    ByeBooLogger.error(error)
+                    continuation.resume(throwing: ByeBooError.unknownError)
+                } else {
+                    ByeBooLogger.debug("이미지 업로드 성공")
+                    continuation.resume()
+                }
+            }
+        }
     }
     
     func kakaoRequest() async throws -> String {
@@ -145,7 +156,20 @@ struct DefaultNetworkService: NetworkService {
                     }
                 }
             }
+        }
+    }
+    
+    func appleRequest() async throws -> (String, String) {
+        return try await  withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
             
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
         }
     }
     
@@ -179,5 +203,39 @@ struct DefaultNetworkService: NetworkService {
         }
         
         return error
+    }
+}
+
+extension DefaultNetworkService: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first
+        else {
+            fatalError("windown 없음")
+        }
+        return window
+    }
+    
+    func authorizationController (
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let identityToken = credential.identityToken,
+              let authorizationCode = credential.authorizationCode else { return }
+        
+        let identityTokenString = String(data: identityToken, encoding: .utf8) ?? ""
+        let authorizationCodeString = String(data: authorizationCode, encoding: .utf8) ?? ""
+        
+        ByeBooLogger.debug("identity Token \(identityTokenString)")
+        ByeBooLogger.debug("authorization Code \(authorizationCodeString)")
+        
+        guard let continuation = self.continuation else { return }
+        continuation.resume(returning: (identityTokenString, authorizationCodeString))
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        guard let continuation = self.continuation else { return }
+        continuation.resume(throwing: ByeBooError.appleLoginError)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -164,7 +164,6 @@ final class DefaultNetworkService: NSObject, NetworkService {
             self.continuation = continuation
             let provider = ASAuthorizationAppleIDProvider()
             let request = provider.createRequest()
-            request.requestedScopes = [.fullName, .email]
             
             let controller = ASAuthorizationController(authorizationRequests: [request])
             controller.delegate = self

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -33,8 +33,6 @@ final class DefaultNetworkService: NSObject, NetworkService {
         
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self else { return }
-            let responseLogger: (DataResponse<BaseResponse<T>, AFError>) -> Void = self.responseLogger
-            let handleError = self.handleError
             
             AF.request(
                 endPoint.requestURL,
@@ -45,7 +43,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
             )
             .validate()
             .responseDecodable(of: BaseResponse<T>.self) { response in
-                responseLogger(response)
+                self.responseLogger(response)
                 switch response.result {
                 case .success(let data):
                     guard let data = data.data else {
@@ -59,7 +57,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
                     if let data = response.data,
                        let statusCode = response.response?.statusCode,
                        let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
-                        let error = handleError(statusCode, errorResponse.message)
+                        let error = self.handleError(statusCode, errorResponse.message)
                         ByeBooLogger.error(error)
                         continuation.resume(throwing: error)
                     } else {
@@ -77,8 +75,6 @@ final class DefaultNetworkService: NSObject, NetworkService {
         
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self else { return }
-            let responseLogger: (DataResponse<EmptyResponse, AFError>) -> Void = self.responseLogger
-            let handleError = self.handleError
             
             AF.request(
                 endPoint.requestURL,
@@ -89,7 +85,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
             )
             .validate()
             .responseDecodable(of: EmptyResponse.self) { response in
-                responseLogger(response)
+                self.responseLogger(response)
                 
                 switch response.result {
                 case .success:
@@ -98,7 +94,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
                     if let data = response.data,
                        let statusCode = response.response?.statusCode,
                        let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
-                        let error = handleError(statusCode, errorResponse.message)
+                        let error = self.handleError(statusCode, errorResponse.message)
                         ByeBooLogger.error(error)
                         continuation.resume(throwing: error)
                     } else {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/KeychainManager.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/KeychainManager.swift
@@ -12,6 +12,7 @@ enum KeyType: String {
     case authorization
     case accessToken
     case refreshToken
+    case authorizationCode
 }
 
 enum KeychainManager {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -25,14 +25,17 @@ struct DefaultAuthRepository: AuthInterface {
     
     // MARK: Network
     
-    func kakaoLogin(platform: LoginPlatform) async throws{
+    func kakaoLogin(platform: LoginPlatform) async throws {
         let authorization = try await network.kakaoRequest()
         keychainService.save(key: .authorization, token: authorization)
         try await postLogin(platform: platform)
     }
     
     func appleLogin(platform: LoginPlatform) async throws {
-        
+        let (identityToken, authorizationCode) = try await network.appleRequest()
+        keychainService.save(key: .authorization, token: identityToken)
+        keychainService.save(key: .authorizationCode, token: authorizationCode)
+        try await postLogin(platform: platform)
     }
     
     
@@ -52,5 +55,8 @@ struct DefaultAuthRepository: AuthInterface {
 
 struct MockAuthRepository: AuthInterface {
     func kakaoLogin(platform: LoginPlatform) async throws  {
+    }
+    
+    func appleLogin(platform: LoginPlatform) async throws {
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -5,6 +5,7 @@
 //  Created by 이나연 on 8/26/25.
 //
 
+import AuthenticationServices
 import Foundation
 
 struct DefaultAuthRepository: AuthInterface {
@@ -25,10 +26,15 @@ struct DefaultAuthRepository: AuthInterface {
     // MARK: Network
     
     func kakaoLogin(platform: LoginPlatform) async throws{
-        let authorization = try await network.request()
+        let authorization = try await network.kakaoRequest()
         keychainService.save(key: .authorization, token: authorization)
         try await postLogin(platform: platform)
     }
+    
+    func appleLogin(platform: LoginPlatform) async throws {
+        
+    }
+    
     
     private func postLogin(platform: LoginPlatform) async throws {
         let loginRequestDTO = LoginRequestDTO(platform: platform.rawValue)

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/AuthInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/AuthInterface.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol AuthInterface {
     func kakaoLogin(platform: LoginPlatform) async throws
+    func appleLogin(platform: LoginPlatform) async throws
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/SocialLoginUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/SocialLoginUseCase.swift
@@ -23,7 +23,7 @@ struct DefaultKakaoLoginUseCase: SocialLoginUseCase {
         case .KAKAO:
             return try await repository.kakaoLogin(platform: platform)
         case .APPLE:
-            return
+            return try await repository.appleLogin(platform: platform)
         }
         
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 이나연 on 8/19/25.
 //
 
+import AuthenticationServices
 import Combine
 import UIKit
 
@@ -35,16 +36,15 @@ final class LoginViewController: BaseViewController {
     }
 }
 
-extension LoginViewController {
+extension LoginViewController{
     @objc
-    func kakaoLoginButtonDidTap() {
-        ByeBooLogger.debug("로그인 버튼 터치됨")
-        viewModel.action(.kakaoLoginButtonDidTap)
+    private func kakaoLoginButtonDidTap() {
+        viewModel.action(.socialLoginButtonDidTap(platform: .KAKAO))
     }
     
     @objc
-    func appleLoginButtonDidTap() {
-        
+    private func appleLoginButtonDidTap() {
+        viewModel.action(.socialLoginButtonDidTap(platform: .APPLE))
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
@@ -5,12 +5,13 @@
 //  Created by 이나연 on 8/26/25.
 //
 
+import AuthenticationServices
 import Combine
 import Foundation
 
-final class LoginViewModel {
+final class LoginViewModel: NSObject {
         
-    private var kakaoLoginAuthSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+    private var socialLoginAuthSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var postLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var isRegisteredSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
     
@@ -37,8 +38,7 @@ final class LoginViewModel {
 
 extension LoginViewModel {
     enum Input {
-        case kakaoLoginButtonDidTap
-        case appleLoginButtonDidTap
+        case socialLoginButtonDidTap(platform: LoginPlatform)
     }
     
     struct Output {
@@ -47,33 +47,27 @@ extension LoginViewModel {
     
     func action(_ trigger: Input) {
         switch trigger {
-        case .kakaoLoginButtonDidTap:
-            kakaoLogin()
-        case .appleLoginButtonDidTap:
-            appleLogin()
+        case .socialLoginButtonDidTap(let platform) :
+            socialLogin(platform: platform)
         }
     }
 }
 
 extension LoginViewModel {
-    private func kakaoLogin() {
+    private func socialLogin(platform: LoginPlatform) {
         Task {
             do {
-                let _ = try await socialLoginUseCase.execute(platform: .KAKAO)
-                kakaoLoginAuthSubject.send(.success(()))
+                let _ = try await socialLoginUseCase.execute(platform: platform)
+                socialLoginAuthSubject.send(.success(()))
                 getIsRegistered()
             } catch {
                 guard let error = error as? ByeBooError else {
                     return
                 }
                 ByeBooLogger.error(error as ByeBooError)
-                kakaoLoginAuthSubject.send(.failure(error))
+                socialLoginAuthSubject.send(.failure(error))
             }
         }
-    }
-    
-    private func appleLogin() {
-        
     }
     
     private func getIsRegistered() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 final class LoginViewModel {
-    
+        
     private var kakaoLoginAuthSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var postLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var isRegisteredSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
@@ -22,14 +22,14 @@ final class LoginViewModel {
     
     private var cancellables = Set<AnyCancellable>()
     
-    private let kakaoLoginUseCase: SocialLoginUseCase
+    private let socialLoginUseCase: SocialLoginUseCase
     private let getIsRegisteredUseCase: GetIsRegisteredUseCase
     
     init(
-        kakaoLoginUseCase: SocialLoginUseCase,
+        socialLoginUseCase: SocialLoginUseCase,
         getIsRegisteredUseCase: GetIsRegisteredUseCase
     ) {
-        self.kakaoLoginUseCase = kakaoLoginUseCase
+        self.socialLoginUseCase = socialLoginUseCase
         self.getIsRegisteredUseCase = getIsRegisteredUseCase
     }
     
@@ -59,7 +59,7 @@ extension LoginViewModel {
     private func kakaoLogin() {
         Task {
             do {
-                let _ = try await kakaoLoginUseCase.execute(platform: .KAKAO)
+                let _ = try await socialLoginUseCase.execute(platform: .KAKAO)
                 kakaoLoginAuthSubject.send(.success(()))
                 getIsRegistered()
             } catch {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -182,7 +182,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             )
         }
         DIContainer.shared.register(type: LoginViewModel.self) { container in
-            guard let kakaoLoginUseCase = container.resolve(type: SocialLoginUseCase.self),
+            guard let socialLoginUseCase = container.resolve(type: SocialLoginUseCase.self),
                   let getIsRegisteredUseCase = container.resolve(type: GetIsRegisteredUseCase.self)
             else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
@@ -190,7 +190,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             }
             
             return LoginViewModel(
-                socialLoginUseCase: kakaoLoginUseCase,
+                socialLoginUseCase: socialLoginUseCase,
                 getIsRegisteredUseCase: getIsRegisteredUseCase
             )
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -190,7 +190,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             }
             
             return LoginViewModel(
-                kakaoLoginUseCase: kakaoLoginUseCase,
+                socialLoginUseCase: kakaoLoginUseCase,
                 getIsRegisteredUseCase: getIsRegisteredUseCase
             )
         }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #214 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 애플로그인 연동했습니다~~~!

|    구현 내용    |    IPhone 13 mini   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/69c382db-4c05-4d38-bcbb-bb518944d466" width ="250"> | 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### 네트워크 서비스 stuct -> class 교체 
애플로그인에서 사용되는 프로토콜을 채택하기 위해 Network Service를 struct -> class로 교체했습니다.
이에 따라 발생되는 순환참조를 해결하기 위해 아래와 같은 코드를 추가했습니다
```swift
guard let self else { return }
let responseLogger: (DataResponse<BaseResponse<T>, AFError>) -> Void = self.responseLogger
let handleError = self.handleError
```
reponseLogger를 캡처해서 함수 안에서 지역상수로 사용될 수 있게 합니다....  근데 이부분은 공부를 좀 더 해오겠습니다..

### 애플로그인 연동 
identity token과 authorization code를 리턴해주기 위해서 리턴타입을 (String, String)으로 했습니다
continuation을 따로 변수로 선언해준 이유는, 애플로그인 성공, 실패시 실행되는 함수에서 continuation.resume을 해주기 위해서입니다. 

```swift
 func appleRequest() async throws -> (String, String) {
        return try await  withCheckedThrowingContinuation { continuation in
            self.continuation = continuation
            let provider = ASAuthorizationAppleIDProvider()
            let request = provider.createRequest()
            request.requestedScopes = [.fullName, .email]
            
            let controller = ASAuthorizationController(authorizationRequests: [request])
            controller.delegate = self
            controller.presentationContextProvider = self
            controller.performRequests()
        }
    }
```

### 뷰모델 구조 리팩토링
기존에 카카오, 애플 구분하던 것을 소셜로그인이라는 하나의 함수로 합쳤습니다 
로그인뷰컨트롤러에서 플랫폼을 다르게 하여 보내주게 됩니다 

```swift
 private func socialLogin(platform: LoginPlatform) {
        Task {
            do {
                let _ = try await socialLoginUseCase.execute(platform: platform)
                socialLoginAuthSubject.send(.success(()))
                getIsRegistered()
            } catch {
                guard let error = error as? ByeBooError else {
                    return
                }
                ByeBooLogger.error(error as ByeBooError)
                socialLoginAuthSubject.send(.failure(error))
            }
        }
```
