### PR TITLE
Feat/#218 로그아웃 및 회원탈퇴 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/AuthAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/AuthAPI.swift
@@ -10,10 +10,10 @@ import Foundation
 import Alamofire
 
 enum AuthAPI {
-    case login(requestDTO: LoginRequestDTO)
-    case reissue
-    case logout
-    case withdraw
+    case login(header: HeaderType, requestDTO: LoginRequestDTO)
+    case reissue(header: HeaderType)
+    case logout(header: HeaderType)
+    case withdraw(header: HeaderType)
 }
 
 extension AuthAPI: EndPoint {
@@ -44,33 +44,12 @@ extension AuthAPI: EndPoint {
     }
     
     var headers: HeaderType {
-        let keychainService = DefaultKeychainService()
-        let userDefaultsService = DefaultUserDefaultService()
         switch self {
-        case .login:
-            return .withAuth(acessToken: keychainService.load(key: .authorization))
-        case .reissue:
-            return .withAuth(acessToken: keychainService.load(key: .refreshToken))
-        case .logout:
-            return .withAuth(acessToken: keychainService.load(key: .accessToken))
-        case .withdraw:
-            let loginPlatform: String? = userDefaultsService.load(key: .loginPlatcform)
-            guard let loginPlatform = loginPlatform else {
-               return .withAuth(acessToken: keychainService.load(key: .accessToken))
-            }
-            
-            switch loginPlatform {
-            case "KAKAO":
-                return .withAuth(acessToken: keychainService.load(key: .accessToken))
-            case "APPLE":
-                return .withAuthCode(
-                    acessToken: keychainService.load(key: .accessToken),
-                    authorizationCode: keychainService.load(key: .authorizationCode)
-                )
-            default :
-                ByeBooLogger.debug("login Platform 없음")
-                return .withAuth(acessToken: keychainService.load(key: .accessToken))
-            }
+        case .login(let header, _),
+            .reissue(let header),
+            .logout(let header),
+            .withdraw(let header):
+            return header
         }
     }
     
@@ -90,7 +69,7 @@ extension AuthAPI: EndPoint {
     
     var bodyParameters: Alamofire.Parameters? {
         switch self {
-        case .login(let dto):
+        case .login(_, let dto):
             return try? dto.toDictionary()
         case .reissue, .logout, .withdraw:
             return nil

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/AuthAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/AuthAPI.swift
@@ -45,13 +45,32 @@ extension AuthAPI: EndPoint {
     
     var headers: HeaderType {
         let keychainService = DefaultKeychainService()
+        let userDefaultsService = DefaultUserDefaultService()
         switch self {
         case .login:
             return .withAuth(acessToken: keychainService.load(key: .authorization))
         case .reissue:
             return .withAuth(acessToken: keychainService.load(key: .refreshToken))
-        case .logout, .withdraw:
+        case .logout:
             return .withAuth(acessToken: keychainService.load(key: .accessToken))
+        case .withdraw:
+            let loginPlatform: String? = userDefaultsService.load(key: .loginPlatcform)
+            guard let loginPlatform = loginPlatform else {
+               return .withAuth(acessToken: keychainService.load(key: .accessToken))
+            }
+            
+            switch loginPlatform {
+            case "KAKAO":
+                return .withAuth(acessToken: keychainService.load(key: .accessToken))
+            case "APPLE":
+                return .withAuthCode(
+                    acessToken: keychainService.load(key: .accessToken),
+                    authorizationCode: keychainService.load(key: .authorizationCode)
+                )
+            default :
+                ByeBooLogger.debug("login Platform 없음")
+                return .withAuth(acessToken: keychainService.load(key: .accessToken))
+            }
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/EndPoint.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/EndPoint.swift
@@ -64,6 +64,7 @@ extension EndPoint {
 enum HeaderType {
     case basic
     case withAuth(acessToken: String)
+    case withAuthCode(acessToken: String, authorizationCode: String)
     
     var value: HTTPHeaders {
         switch self {
@@ -73,6 +74,12 @@ enum HeaderType {
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(acessToken)"
+            ]
+        case .withAuthCode(let acessToken, let authorizationCode):
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(acessToken)",
+                "X-Apple-Code": "\(authorizationCode)"
             ]
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
@@ -12,5 +12,5 @@ enum UserDefaultsKey: String {
     case userID
     case isHelperShown
     case isRegistered
-    case loginPlatcform
+    case loginPlatform
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
@@ -12,4 +12,5 @@ enum UserDefaultsKey: String {
     case userID
     case isHelperShown
     case isRegistered
+    case loginPlatcform
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -27,14 +27,15 @@ struct DefaultAuthRepository: AuthInterface {
     
     func kakaoLogin(platform: LoginPlatform) async throws {
         let authorization = try await network.kakaoRequest()
+        let _ = userDefaultsService.save("KAKAO", key: .loginPlatcform)
         keychainService.save(key: .authorization, token: authorization)
         try await postLogin(platform: platform)
     }
     
     func appleLogin(platform: LoginPlatform) async throws {
-        let (identityToken, authorizationCode) = try await network.appleRequest()
+        let (identityToken, _) = try await network.appleRequest()
+        let _ = userDefaultsService.save("APPLE", key: .loginPlatcform)
         keychainService.save(key: .authorization, token: identityToken)
-        keychainService.save(key: .authorizationCode, token: authorizationCode)
         try await postLogin(platform: platform)
     }
     
@@ -50,6 +51,25 @@ struct DefaultAuthRepository: AuthInterface {
         keychainService.save(key: .refreshToken, token: result.refreshToken)
     }
     
+    func logout() async throws {
+        try await network.request(AuthAPI.logout)
+    }
+    
+    func withdraw() async throws {
+        let loginPlatform: String? = userDefaultsService.load(key: .loginPlatcform)
+        guard let loginPlatform = loginPlatform else { return }
+        
+        switch loginPlatform {
+        case "KAKAO":
+            return try await network.request(AuthAPI.withdraw)
+        case "APPLE":
+            let (_, authorizationCode) = try await network.appleRequest()
+            keychainService.save(key: .authorizationCode, token: authorizationCode)
+            return try await network.request(AuthAPI.withdraw)
+        default :
+            return
+        }
+    }
 }
 
 
@@ -58,5 +78,11 @@ struct MockAuthRepository: AuthInterface {
     }
     
     func appleLogin(platform: LoginPlatform) async throws {
+    }
+    
+    func logout() async throws {
+    }
+    
+    func withdraw() async throws {
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -70,6 +70,7 @@ struct DefaultAuthRepository: AuthInterface {
                 AuthAPI.withdraw(header: header)
             )
         case "APPLE":
+            // TODO: - authroization code 서버에서 처리하기 
             let (_, authorizationCode) = try await network.appleRequest()
             keychainService.save(key: .authorizationCode, token: authorizationCode)
             

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -27,14 +27,14 @@ struct DefaultAuthRepository: AuthInterface {
     
     func kakaoLogin(platform: LoginPlatform) async throws {
         let authorization = try await network.kakaoRequest()
-        let _ = userDefaultsService.save("KAKAO", key: .loginPlatcform)
+        let _ = userDefaultsService.save("KAKAO", key: .loginPlatform)
         keychainService.save(key: .authorization, token: authorization)
         try await postLogin(platform: platform)
     }
     
     func appleLogin(platform: LoginPlatform) async throws {
         let (identityToken, _) = try await network.appleRequest()
-        let _ = userDefaultsService.save("APPLE", key: .loginPlatcform)
+        let _ = userDefaultsService.save("APPLE", key: .loginPlatform)
         keychainService.save(key: .authorization, token: identityToken)
         try await postLogin(platform: platform)
     }
@@ -42,8 +42,9 @@ struct DefaultAuthRepository: AuthInterface {
     
     private func postLogin(platform: LoginPlatform) async throws {
         let loginRequestDTO = LoginRequestDTO(platform: platform.rawValue)
+        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .authorization))
         let result = try await network.request(
-            AuthAPI.login(requestDTO: loginRequestDTO),
+            AuthAPI.login(header: header, requestDTO: loginRequestDTO),
             decodingType: PostLoginResponseDTO.self
         )
         _ = userDefaultsService.save(result.isRegistered, key: .isRegistered)
@@ -52,20 +53,34 @@ struct DefaultAuthRepository: AuthInterface {
     }
     
     func logout() async throws {
-        try await network.request(AuthAPI.logout)
+        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
+        try await network.request(
+            AuthAPI.logout(header: header)
+        )
     }
     
     func withdraw() async throws {
-        let loginPlatform: String? = userDefaultsService.load(key: .loginPlatcform)
+        let loginPlatform: String? = userDefaultsService.load(key: .loginPlatform)
         guard let loginPlatform = loginPlatform else { return }
         
         switch loginPlatform {
         case "KAKAO":
-            return try await network.request(AuthAPI.withdraw)
+            let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
+            return try await network.request(
+                AuthAPI.withdraw(header: header)
+            )
         case "APPLE":
             let (_, authorizationCode) = try await network.appleRequest()
             keychainService.save(key: .authorizationCode, token: authorizationCode)
-            return try await network.request(AuthAPI.withdraw)
+            
+            let header: HeaderType = .withAuthCode(
+                acessToken: keychainService.load(key: .accessToken),
+                authorizationCode: keychainService.load(key: .authorizationCode)
+            )
+            
+            return try await network.request(
+                AuthAPI.withdraw(header: header)
+            )
         default :
             return
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -108,6 +108,14 @@ struct DomainDependencyAssembler: DependencyAssembler {
             return DefaultKakaoLoginUseCase(repository: authRepository)
         }
         
+        DIContainer.shared.register(type: LogoutUseCase.self) { _ in
+            return DefaultLogoutUseCase(repository: authRepository)
+        }
+        
+        DIContainer.shared.register(type: WithdrawUseCase.self) { _ in
+            return DefaultWithdrawUseCase(repository: authRepository)
+        }
+        
         DIContainer.shared.register(type: CalculateRemainingTimeUseCase.self) { _ in
             return DefaultCalculateRemainingTimeUseCase()
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/AuthInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/AuthInterface.swift
@@ -10,4 +10,6 @@ import Foundation
 protocol AuthInterface {
     func kakaoLogin(platform: LoginPlatform) async throws
     func appleLogin(platform: LoginPlatform) async throws
+    func logout() async throws
+    func withdraw() async throws
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/LogoutUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/LogoutUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  LogoutUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 8/29/25.
+//
+
+import Foundation
+
+protocol LogoutUseCase {
+    func execute() async throws
+}
+
+struct DefaultLogoutUseCase: LogoutUseCase {
+    private let repository: AuthInterface
+    
+    init(repository: AuthInterface) {
+        self.repository = repository
+    }
+    
+    func execute() async throws {
+        return try await repository.logout()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/WithdrawUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/WithdrawUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  WithdrawUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 8/29/25.
+//
+
+import Foundation
+
+protocol WithdrawUseCase {
+    func execute() async throws
+}
+
+struct DefaultWithdrawUseCase: WithdrawUseCase {
+    private let repository: AuthInterface
+    
+    init(repository: AuthInterface) {
+        self.repository = repository
+    }
+    
+    func execute() async throws {
+        return try await repository.withdraw()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/ConfirmModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/ConfirmModalView.swift
@@ -7,8 +7,31 @@
 
 import UIKit
 
-final class ConfirmModalView: BaseView, ModalProtocol {
+enum ConfirmModalType {
+    case logout
+    case withdraw
     
+    var title: String {
+        switch self {
+        case .logout:
+            return "로그아웃하시겠어요?"
+        case .withdraw:
+            return "정말 탈퇴하시겠어요?"
+        }
+    }
+    
+    var description: String? {
+        switch self {
+        case .logout:
+            return nil
+        case .withdraw:
+            return "탈퇴 시 모든 데이터가 삭제됩니다."
+        }
+    }
+}
+
+final class ConfirmModalView: BaseView, ModalProtocol {
+    var modalType: ConfirmModalType?
     private let titleLabel = UILabel()
     private let descriptionLabel = UILabel()
     private let buttonStackView = UIStackView()
@@ -16,13 +39,13 @@ final class ConfirmModalView: BaseView, ModalProtocol {
     let actionButton: ByeBooButton
     
     init(
-        title: String,
-        description: String? = nil,
+        modalType: ConfirmModalType,
         dismissButton: ByeBooButton?,
         actionButton: ByeBooButton
     ) {
-        self.titleLabel.text = title
-        self.descriptionLabel.text = description
+        self.modalType = modalType
+        self.titleLabel.text = modalType.title
+        self.descriptionLabel.text = modalType.description
         self.dismissButton = dismissButton
         self.actionButton = actionButton
         super.init(frame: .zero)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/CongrateModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/CongrateModalView.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 final class CongrateModalView: BaseView, ModalProtocol {
-    
+    var modalType: ConfirmModalType? = nil
     let actionButton: ByeBooButton = ByeBooButton(titleText: "바로가기", type: .enabled)
     let dismissButton: ByeBooButton? = nil
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuestModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuestModalView.swift
@@ -11,6 +11,7 @@ import SnapKit
 import Then
 
 final class QuestModalView: BaseView, ModalProtocol {
+    var modalType: ConfirmModalType? = nil
     let actionButton: ByeBooButton = ByeBooButton(titleText: "진행하기", type: .enabled)
     var dismissButton: ByeBooButton?
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuitModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuitModalView.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 final class QuitModalView: BaseView, ModalProtocol {
-    
+    var modalType: ConfirmModalType? = nil
     private let titleLabel = UILabel()
     private let secondDescriptionLabel = UILabel()
     private let buttonStackView = UIStackView()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
@@ -79,6 +79,12 @@ final class MyPageViewController: BaseViewController {
 extension MyPageViewController {
     
     private func bind() {
+        bindUserResult()
+        bindLogoutResult()
+        bindWithdrawResult()
+    }
+    
+    private func bindUserResult() {
         viewModel.output.userResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
@@ -91,7 +97,9 @@ extension MyPageViewController {
                 }
             }
             .store(in: &cancellables)
-        
+    }
+    
+    private func bindLogoutResult() {
         viewModel.output.logoutResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
@@ -104,8 +112,9 @@ extension MyPageViewController {
                 }
             }
             .store(in: &cancellables)
+    }
         
-        
+    private func bindWithdrawResult() {
         viewModel.output.withdrawResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
@@ -91,6 +91,33 @@ extension MyPageViewController {
                 }
             }
             .store(in: &cancellables)
+        
+        viewModel.output.logoutResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success:
+                    ByeBooLogger.debug("로그아웃 성공")
+                    self?.navigateInitialViewController()
+                case .failure(let failure):
+                    ByeBooLogger.error(failure)
+                }
+            }
+            .store(in: &cancellables)
+        
+        
+        viewModel.output.withdrawResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success:
+                    ByeBooLogger.debug("탈퇴 성공")
+                    self?.navigateInitialViewController()
+                case .failure(let failure):
+                    ByeBooLogger.error(failure)
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -139,15 +166,14 @@ extension MyPageViewController {
             ExternalLink.serviceTerm.openURL(for: self)
         case .logout:
             let logoutModalView = createConfirmModal(
-                title: "로그아웃하시겠어요?",
+                modalType: .logout,
                 dismissOption: "취소",
                 actionOption: "로그아웃"
             )
             presentModal(to: logoutModalView)
         case .cancel:
             let cancelModalView = createConfirmModal(
-                title: "정말 탈퇴하시겠어요?",
-                description: "탈퇴 시 모든 데이터가 삭제됩니다.",
+                modalType: .withdraw,
                 dismissOption: "취소",
                 actionOption: "탈퇴하기"
             )
@@ -156,8 +182,7 @@ extension MyPageViewController {
     }
     
     private func createConfirmModal(
-        title: String,
-        description: String? = nil,
+        modalType: ConfirmModalType,
         dismissOption: String? = nil,
         actionOption: String
     ) -> ConfirmModalView {
@@ -165,18 +190,40 @@ extension MyPageViewController {
         let actionButton = ByeBooButton(titleText: actionOption, type: .enabled)
         
         return ConfirmModalView(
-            title: title,
-            description: description,
+            modalType: modalType,
             dismissButton: dismissButton,
             actionButton: actionButton
         )
     }
     
     private func presentModal(to modal: BaseView & ModalProtocol) {
+        guard let modalType = modal.modalType else { return }
+        let action: (() -> Void) = {
+            switch modalType{
+            case .logout:
+                self.viewModel.action(.logoutActionButtonDidTap)
+            case .withdraw:
+                self.viewModel.action(.withdrawActionButtonDidTap)
+            }
+        }
+        
         ModalBuilder(
             modalView: modal,
-            action: nil,
+            action: action,
             rootViewController: self
         ).present()
+    }
+    
+    private func navigateInitialViewController() {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let sceneDelegate = windowScene.delegate as? SceneDelegate else {
+            return
+        }
+
+        let viewController = ViewControllerFactory.shared.makeLoginViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+        
+        sceneDelegate.window?.rootViewController = navigationController
+        sceneDelegate.window?.makeKeyAndVisible()
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewModel/MyPageViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewModel/MyPageViewModel.swift
@@ -12,18 +12,28 @@ final class MyPageViewModel: ViewModelType {
     
     private var cancellables = Set<AnyCancellable>()
     private var userResultSubject: PassthroughSubject<Result<String, ByeBooError>, Never> = .init()
+    private var logoutResultSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+    private var withdrawResultSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     
     private(set) var output: Output
 
     private let getUserNameUseCase: GetUserNameUseCase
+    private let logoutUseCase: LogoutUseCase
+    private let withdrawUseCase: WithdrawUseCase
     
     init(
-        getUserNameUseCase: GetUserNameUseCase
+        getUserNameUseCase: GetUserNameUseCase,
+        logoutUseCase: LogoutUseCase,
+        withdrawUseCase: WithdrawUseCase
     ) {
         self.getUserNameUseCase = getUserNameUseCase
+        self.logoutUseCase = logoutUseCase
+        self.withdrawUseCase = withdrawUseCase
         
         output = Output(
-            userResult: userResultSubject.eraseToAnyPublisher()
+            userResult: userResultSubject.eraseToAnyPublisher(),
+            logoutResult: logoutResultSubject.eraseToAnyPublisher(),
+            withdrawResult: withdrawResultSubject.eraseToAnyPublisher()
         )
     }
     
@@ -31,6 +41,10 @@ final class MyPageViewModel: ViewModelType {
         switch trigger {
         case .viewWillAppear:
             getUserName()
+        case .logoutActionButtonDidTap:
+            logout()
+        case .withdrawActionButtonDidTap:
+            withdraw()
         }
     }
 }
@@ -38,10 +52,14 @@ final class MyPageViewModel: ViewModelType {
 extension MyPageViewModel {
     enum Input {
         case viewWillAppear
+        case logoutActionButtonDidTap
+        case withdrawActionButtonDidTap
     }
     
     struct Output {
         let userResult: AnyPublisher<Result<String, ByeBooError>, Never>
+        let logoutResult: AnyPublisher<Result<Void, ByeBooError>, Never>
+        let withdrawResult: AnyPublisher<Result<Void, ByeBooError>, Never>
     }
 }
 
@@ -49,5 +67,35 @@ extension MyPageViewModel {
     private func getUserName() {
         let name = getUserNameUseCase.execute()
         userResultSubject.send(.success(name))
+    }
+    
+    private func logout() {
+        Task {
+            do {
+                try await logoutUseCase.execute()
+                logoutResultSubject.send(.success(()))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                ByeBooLogger.error(error as ByeBooError)
+                logoutResultSubject.send(.failure(error))
+            }
+        }
+    }
+    
+    private func withdraw() {
+        Task {
+            do {
+                try await withdrawUseCase.execute()
+                withdrawResultSubject.send(.success(()))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                ByeBooLogger.error(error as ByeBooError)
+                withdrawResultSubject.send(.failure(error))
+            }
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -143,7 +143,19 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: MyPageViewModel.self) { container in
-            return MyPageViewModel(getUserNameUseCase: getUserNameUseCase)
+            guard let getUserNameUseCase = container.resolve(type: GetUserNameUseCase.self),
+                  let logoutUseCase = container.resolve(type: LogoutUseCase.self),
+                  let withdrawUseCase = container.resolve(type: WithdrawUseCase.self)
+            else {
+                ByeBooLogger.error(ByeBooError.DIFailedError)
+                return
+            }
+            
+            return MyPageViewModel(
+                getUserNameUseCase: getUserNameUseCase,
+                logoutUseCase: logoutUseCase,
+                withdrawUseCase: withdrawUseCase
+            )
         }
         
         DIContainer.shared.register(type: LookBackJourneyViewModel.self) { container in

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ModalProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/ModalProtocol.swift
@@ -10,4 +10,5 @@ import UIKit
 protocol ModalProtocol {
     var actionButton: ByeBooButton { get }
     var dismissButton: ByeBooButton? { get }
+    var modalType: ConfirmModalType? { get }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #218

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그아웃, 회원탈퇴 구현 완료했습니다

|    구현 내용    |   애플 로그아웃  |   애플 회원탈퇴   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/5d47b69a-1050-4ebe-bc4d-3bb9dfd4e9e6" width ="250"> | <img src = "https://github.com/user-attachments/assets/e2768d03-b21a-42e7-9543-0347e77a1b1e" width ="250"> |
|    구현 내용    |   카카오 로그아웃  |   카카오 회원탈퇴   |
| GIF | <img src = "https://github.com/user-attachments/assets/ce94a26c-87fd-4f59-833f-c5c5e5d7a4ab" width ="250"> | <img src = "https://github.com/user-attachments/assets/cf4e6d92-4b4b-446b-ac3d-f6bf525b574a" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`AuthRepository`
- 원래는 애플 로그인 처음 시도할때 키체인에 그때 authorization code를 저장했었는데, 알고보니 이게 시간이 되게 짧더라구요 그래서 굳이 로그인할 때는 저장할 필요 없을 것 같아서.. 탈퇴 시에 appleRequest를 한번 더 불러서 그때 키체인에 저장하고 헤더에 넣어서 사용하는 것으로 바꾸었습니다!
- 그래서 위의 로직을 수행하기 위해서는 로그인했을 때 어떻게 했는지 알아야겠더라구요... 그래서 유저디폴트에 로그인 플랫폼 키를 추가했습니다 
```swift
func withdraw() async throws {
// 유저디폴트에서 로그인 플랫폼을 가져옵니다 
        let loginPlatform: String? = userDefaultsService.load(key: .loginPlatcform)
        guard let loginPlatform = loginPlatform else { return }
        
        switch loginPlatform {
        case "KAKAO":
            return try await network.request(AuthAPI.withdraw)
        case "APPLE":
            let (_, authorizationCode) = try await network.appleRequest()
            keychainService.save(key: .authorizationCode, token: authorizationCode)
            return try await network.request(AuthAPI.withdraw)
        default :
            return
        }
    }
```

Mypave vc에서 로그아웃모달인지, 탈퇴모달인지 구분하기 위해 Modal Type을 추가했습니다
근데 이걸 막상 switch case에서 쓰려니 Modal protocol에도 추가를 해야하더라구요
그래서 모달 프로토콜에 일단 logout과 withdraw라는 모달 타입을 추가해뒀습니다
고민인점은 quitmodal과 congratmodal도 어쨌든 모달 프로토콜을 채택하고 있기 때문에 모달 타입을 정해줘야 하는데요
모달타입을 정하게 되면 마이페이지 뷰컨트롤러에서 switch case를 쓸 때 필요없는 quit과 congrat까지 case문을 작성해주어야 해서 일단 저 둘에서는 nil로 설정해두었습니다 이 부분은 고민을 좀 더 해보고.. quit modal을 confirm modal view로 갈아끼우면서 좀 더 생각을 해보겠습니당...
```swift
enum ConfirmModalType {
    case logout
    case withdraw
    
    var title: String {
        switch self {
        case .logout:
            return "로그아웃하시겠어요?"
        case .withdraw:
            return "정말 탈퇴하시겠어요?"
        }
    }
    
    var description: String? {
        switch self {
        case .logout:
            return nil
        case .withdraw:
            return "탈퇴 시 모든 데이터가 삭제됩니다."
        }
    }
}
```
이거 만들면서 승준오빠 모달 컨펌뷰를 좀 건드려봤습니다... 


