### PR TITLE
[Fix] 진행 중인 퀘스트 API 반복 호출 문제 해결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/QuestCheckViewController.swift
@@ -15,11 +15,11 @@ final class QuestCheckViewController: BaseViewController {
     private static let lastStep = 5
     
     private let questsCheckView = QuestsCheckView()
-    private let viewModel: QuestsViewModel
+    private let viewModel: ProgressingQuestsViewModel
     var coordinator: QuestCheckCoordinating?
     private var cancellable = Set<AnyCancellable>()
     
-    init(viewModel: QuestsViewModel) {
+    init(viewModel: ProgressingQuestsViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         self.coordinator = QuestCheckCoordinator(rootViewController: self)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/ProgressingQuestsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/ProgressingQuestsViewModel.swift
@@ -85,6 +85,8 @@ final class ProgressingQuestsViewModel {
     }
     
     private func setQuestTimer() {
+        if !isQuestLocked { return }
+        
         var remainingSeconds = calculateRemainingTimeUseCase.calculateRemainingTime(
             questOpenTime: questsEntity?.questOpenTime,
             currentTime: questsEntity?.currentTime
@@ -203,9 +205,7 @@ extension ProgressingQuestsViewModel: ViewModelType {
             fetchUserJourney()
             fetchProgressingQuests()
         case .questOpen:
-            if isQuestLocked {
-                fetchProgressingQuests()
-            }
+            fetchProgressingQuests()
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/ProgressingQuestsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/ProgressingQuestsViewModel.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-final class QuestsViewModel {
+final class ProgressingQuestsViewModel {
     
     private let cancellables = Set<AnyCancellable>()
     private let nameSubject = PassthroughSubject<Result<String, ByeBooError>, Never>.init()
@@ -127,7 +127,7 @@ final class QuestsViewModel {
     }
 }
 
-extension QuestsViewModel {
+extension ProgressingQuestsViewModel {
     
     var steps: [StepEntity] { questsEntity?.steps ?? [] }
     var currentStep: Int { questsEntity?.currentStep ?? 0 }
@@ -180,7 +180,7 @@ extension QuestsViewModel {
     }
 }
 
-extension QuestsViewModel: ViewModelType {
+extension ProgressingQuestsViewModel: ViewModelType {
     
     enum Input {
         case questViewWillAppear

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/QuestsViewModel.swift
@@ -203,7 +203,9 @@ extension QuestsViewModel: ViewModelType {
             fetchUserJourney()
             fetchProgressingQuests()
         case .questOpen:
-            fetchProgressingQuests()
+            if isQuestLocked {
+                fetchProgressingQuests()
+            }
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -113,14 +113,14 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             )
         }
         
-        DIContainer.shared.register(type: QuestsViewModel.self) { container in
+        DIContainer.shared.register(type: ProgressingQuestsViewModel.self) { container in
             guard let progressingQuestsUseCase = container.resolve(type: GetProgressingQuestsUseCase.self),
                   let calculateRemainingTimeUseCase = container.resolve(type: CalculateRemainingTimeUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             
-            return QuestsViewModel(
+            return ProgressingQuestsViewModel(
                 progressingQuestsUseCase: progressingQuestsUseCase,
                 getUserNameUseCase: getUserNameUseCase,
                 fetchUserJourneyUseCase: fetchUserJourneyUseCase,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
@@ -41,7 +41,7 @@ final class ViewControllerFactory: ViewControllerFactoryProtocol {
     }
     
     func makeQuestViewController() -> QuestCheckViewController {
-        guard let viewModel = DIContainer.shared.resolve(type: QuestsViewModel.self) else {
+        guard let viewModel = DIContainer.shared.resolve(type: ProgressingQuestsViewModel.self) else {
             DIErrorHandle()
             fatalError()
         }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #228 

## 📄 작업 내용
- 진행 중인 퀘스트 API 반복 호출 문제를 해결했습니다.
- QuestsViewModel -> ProgressingQuestsViewModel로 네이밍 변경했습니다.


## ✅ Testing
- 테스트 목적과 상황
퀘스트가 열려있는 상태에서 진행 중인 퀘스트 API가 반복 호출되지 않는지 확인합니다.

## 💻 주요 코드 설명
`ProgressingQuestsViewModel`

[기존 문제점]
- 뷰모델의 fetchProgressingQuests 메서든 내부에서 setTimer를 호출합니다.
- setTimer에서 타이머가 종료된 경우에는 failure 케이스로 .endTimer를 방출합니다.
- 타이머를 구독하는 뷰컨트롤러가 .endTimer를 인식한 경우, .questOpen 케이스의 action을 호출합니다.
- .questOpen에서는 다시 fetchProgressingQuests 메서드를 호출합니다.

- 위 과정이 반복되어 퀘스트가 열려있는 상태에서는 진행 중인 퀘스트 API 반복 호출되는 오류가 있었습니다.

[해결]
- 타이머가 퀘스트가 잠겨있는 상태에서만 동작하도록 setTimer 메서드 내부 맨 첫 줄에 isQuestLocked를 확인하는 로직을 추가했습니다.
```swift
private func setQuestTimer() {
    // 이 부분!!
    if !isQuestLocked { return }
    
    var remainingSeconds = calculateRemainingTimeUseCase.calculateRemainingTime(
        questOpenTime: questsEntity?.questOpenTime,
        currentTime: questsEntity?.currentTime
    )

    timeCancellabels?.cancel()
    timeCancellabels = Timer.publish(every: 1.0, on: .main, in: .common)
        .autoconnect()
        .sink { [weak self] _ in
            guard let self = self else { return }

            if remainingSeconds > 0 {
                remainingSeconds -= 1
                let time = self.formatRemainingTime(seconds: remainingSeconds)
                self.timeSubject.send(.success(time))
                return
            }
            self.timeCancellabels?.cancel()
            self.timeSubject.send(.failure(.endTimer))
        }
}
```