### PR TITLE
[Feat] 닉네임 수정 뷰 진입 시 키보드 애니메이션 추가

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/ModifyNicknameViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/ModifyNicknameViewController.swift
@@ -39,6 +39,7 @@ final class ModifyNicknameViewController: BaseViewController {
         )
         
         bind()
+        focusTextField()
     }
     
     override func setAddTarget() {
@@ -47,6 +48,12 @@ final class ModifyNicknameViewController: BaseViewController {
             action: #selector(confirmButtonDidTap),
             for: .touchUpInside
         )
+    }
+    
+    private func focusTextField() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            self.rootView.nicknameTextField.nicknameField.becomeFirstResponder()
+        }
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #230 

## 📄 작업 내용
- 닉네임 수정 뷰 진입 시 키보드가 자동으로 올라오도록 설정했습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/d9126e2e-e687-4eb2-91de-86e0d154aff8" width ="250"> | <img src = "https://github.com/user-attachments/assets/9c51d396-237f-447b-9192-9a54a7577567" width ="250"> |


## ✅ Testing
- 테스트 목적과 상황
닉네임 수정 뷰 진입 시 키보드가 자동으로 올라오는지 확인
- 시나리오 진행에 필요한 값
N/A
- 시나리오 진행에 필요한 조건
N/A
- 시나리오 완료 시 보장하는 결과
닉네임 수정 뷰 진입 시 키보드가 자동으로 올라옴

## 💻 주요 코드 설명
`ModifyNicknameViewController`
- 닉네임 텍스트필드에 becomeFirstResponder 메서드를 호출하였습니다.
- 단, 해당 메서드가 뷰 진입 후 0.7초 후 실행되도록 만들었습니다.
```swift
override func viewDidLoad() {
    super.viewDidLoad()
    
    ByeBooNavigationBar.makeNavigationBar(
        navigationItem: self.navigationItem,
        navigationController: self.navigationController,
        type: .titleAndBack("프로필 수정", header: .clear),
        action: #selector(back)
    )
    
    bind()
    // 키보드가 자동으로 올라오도록 만드는 함수
    focusTextField()
}

private func focusTextField() {
    DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
        self.rootView.nicknameTextField.nicknameField.becomeFirstResponder()
    }
}
```