### PR TITLE
[Fix] UI 문제 자체 QA

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuitModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/QuitModalView.swift
@@ -77,14 +77,12 @@ final class QuitModalView: BaseView, ModalProtocol {
             cancelButton.snp.makeConstraints {
                 $0.width.equalTo(107.adjustedW)
                 $0.height.equalTo(53.adjustedH)
-                $0.trailing.equalToSuperview()
             }
         }
         
         actionButton.snp.makeConstraints {
             $0.width.equalTo(107.adjustedW)
             $0.height.equalTo(53.adjustedH)
-            $0.leading.equalToSuperview()
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/QuestCheckViewController.swift
@@ -149,7 +149,7 @@ extension QuestCheckViewController {
         self.questsCheckView.questCollectionView.reloadData()
         
         guard let step = quests.steps.first else { return }
-        if quests.currentStep > step.quests.count {
+        if quests.currentStep < step.quests.count {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.scrollToStep()
             }
@@ -163,12 +163,8 @@ extension QuestCheckViewController {
             if let _ = step.quests.firstIndex(where: { $0.questNumber == viewModel.currentStep }) {
                 // MARK: - 마지막 스텝 진입 시 맨 아래로 스크롤
                 if step.stepNumber == QuestCheckViewController.lastStep {
-                    let maxOffsetY = collectionView.contentSize.height - collectionView.bounds.height + 30
-                    let bottomOffset = CGPoint(
-                        x: 0,
-                        y: max(maxOffsetY, 0)
-                    )
-                    collectionView.setContentOffset(bottomOffset, animated: true)
+                    let lastIndexPath = calculateLastIndexPath(collectionView: collectionView)
+                    collectionView.scrollToItem(at: lastIndexPath, at: .bottom, animated: true)
                     return
                 }
                 
@@ -177,6 +173,14 @@ extension QuestCheckViewController {
                 return
             }
         }
+    }
+    
+    private func calculateLastIndexPath(collectionView: UICollectionView) -> IndexPath {
+        let lastSection = collectionView.numberOfSections - 1
+        let lastItem = collectionView.numberOfItems(inSection: lastSection) - 1
+        let lastIndexPath = IndexPath(item: lastItem, section: lastSection)
+        
+        return lastIndexPath
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -206,7 +206,10 @@ extension WriteActiveTypeQuestViewController: BackNavigable {
     func back() {
         tabBarController?.tabBar.isHidden = true
         
-        let action: (() -> Void) = { self.navigationController?.popViewController(animated: true) }
+        let action: (() -> Void) = {
+            self.navigationController?.popViewController(animated: true)
+            self.tabBarController?.tabBar.isHidden = false
+        }
         
         ModalBuilder(
             modalView: QuitModalView(),

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -178,7 +178,10 @@ extension WriteQuestionTypeQuestViewController: BackNavigable {
     func back() {
         tabBarController?.tabBar.isHidden = true
         
-        let action: (() -> Void) = { self.navigationController?.popViewController(animated: true) }
+        let action: (() -> Void) = {
+            self.navigationController?.popViewController(animated: true)
+            self.tabBarController?.tabBar.isHidden = false
+        }
         
         ModalBuilder(
             modalView: QuitModalView(),


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #233

## 📄 작업 내용
- (1) 퀘스트 전체 조회 자동스크롤 정상화
- (2) 퀘스트 작성 중 뒤로가기 버튼 클릭 시 나오는 모달의 머무르기/나가기 버튼 중첩 문제 해결
- (3) 퀘스트 작성 중 뒤로 왔을 때, 퀘스트 전체 조회에서 바텀 바가 사라져있는 문제 해결

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| (1) | <img src = "https://github.com/user-attachments/assets/cfd66751-43aa-4b49-b2b0-f17710dd5ba6" width ="250"> | <img src = "" width ="250"> |
| (2) | <img src = "https://github.com/user-attachments/assets/e2589bb8-7ea1-404b-aaf0-daa7fa6dcc4e" width ="250"> | <img src = "" width ="250"> |
| (3) | <img src = "https://github.com/user-attachments/assets/8b18f493-a449-4107-b004-654332035566" width ="250"> | <img src = "" width ="250"> |
