### PR TITLE
Feat/#218 자동로그인 및 토큰 재발급

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         DIContainer.shared.dependencyInject()
       
-        let viewController = ViewControllerFactory.shared.makeLoginViewController()
+        let viewController = ViewControllerFactory.shared.makeSplashViewController()
         let navigationController = UINavigationController(rootViewController: viewController)
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = navigationController

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/PostLoginResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/PostLoginResponseDTO.swift
@@ -9,4 +9,7 @@ struct PostLoginResponseDTO: Decodable {
     let accessToken: String
     let refreshToken: String
     let isRegistered: Bool
+    let name: String?
+    let journey: String?
+    let journeyStatus: String?
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/TokenReissueResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/TokenReissueResponseDTO.swift
@@ -1,0 +1,11 @@
+//
+//  TokenReissueResponseDTO.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 9/1/25.
+//
+
+struct TokenReissueResponseDTO: Decodable {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -210,8 +210,9 @@ final class DefaultNetworkService: NSObject, NetworkService {
     
     func tokenReissue() async throws {
         let keychainService = DefaultKeychainService()
+        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .refreshToken))
         let result = try await request(
-            AuthAPI.reissue,
+            AuthAPI.reissue(header: header),
             decodingType: PostLoginResponseDTO.self
         )
         keychainService.save(key: .accessToken, token: result.accessToken)

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -20,6 +20,7 @@ protocol NetworkService {
     func request(image: Data, signedURL: String) async throws
     func kakaoRequest() async throws -> String
     func appleRequest() async throws -> (String, String)
+    func tokenReissue() async throws
 }
 
 final class DefaultNetworkService: NSObject, NetworkService {
@@ -58,6 +59,28 @@ final class DefaultNetworkService: NSObject, NetworkService {
                        let statusCode = response.response?.statusCode,
                        let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
                         let error = self?.handleError(statusCode, errorResponse.message)
+                        
+                        if statusCode == 401 && endPoint.path != "/reissue" {
+                            Task {
+                                guard let self else { return }
+                                do {
+                                    try await self.tokenReissue()
+                                } catch {
+                                    ByeBooLogger.debug("tokenReissue 실패")
+                                    continuation.resume(throwing: error)
+                                    return
+                                }
+
+                                do {
+                                    let retried = try await self.request(endPoint, decodingType: decodingType)
+                                    continuation.resume(returning: retried)
+                                } catch {
+                                    continuation.resume(throwing: error)
+                                }
+                            }
+                            return
+                        }
+                        
                         ByeBooLogger.error(error ?? .unknownError)
                         continuation.resume(throwing: error ?? .unknownError)
                     } else {
@@ -95,6 +118,21 @@ final class DefaultNetworkService: NSObject, NetworkService {
                        let statusCode = response.response?.statusCode,
                        let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
                         let error = self?.handleError(statusCode, errorResponse.message)
+                        
+                        if statusCode == 401 {
+                            Task {
+                                do {
+                                    guard let self else { return }
+                                    try await self.tokenReissue()
+                                    try await self.request(endPoint)
+                                    continuation.resume(returning: ())
+                                } catch {
+                                    continuation.resume(throwing: error)
+                                }
+                            }
+                            return
+                        }
+                        
                         ByeBooLogger.error(error ?? .unknownError)
                         continuation.resume(throwing: error ?? .unknownError)
                     } else {
@@ -168,6 +206,16 @@ final class DefaultNetworkService: NSObject, NetworkService {
             controller.presentationContextProvider = self
             controller.performRequests()
         }
+    }
+    
+    func tokenReissue() async throws {
+        let keychainService = DefaultKeychainService()
+        let result = try await request(
+            AuthAPI.reissue,
+            decodingType: PostLoginResponseDTO.self
+        )
+        keychainService.save(key: .accessToken, token: result.accessToken)
+        keychainService.save(key: .refreshToken, token: result.refreshToken)
     }
     
     private func requestLogger(_ endPoint: EndPoint) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -213,7 +213,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
         let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .refreshToken))
         let result = try await request(
             AuthAPI.reissue(header: header),
-            decodingType: PostLoginResponseDTO.self
+            decodingType: TokenReissueResponseDTO.self
         )
         keychainService.save(key: .accessToken, token: result.accessToken)
         keychainService.save(key: .refreshToken, token: result.refreshToken)

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/KeychainManager.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/KeychainManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Security
 
-enum KeyType: String {
+enum KeyType: String, CaseIterable {
     case authorization
     case accessToken
     case refreshToken

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum UserDefaultsKey: String {
+enum UserDefaultsKey: String, CaseIterable {
     case userName
     case userID
     case isHelperShown

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
@@ -13,4 +13,6 @@ enum UserDefaultsKey: String {
     case isHelperShown
     case isRegistered
     case loginPlatform
+    case journey
+    case journeyStatus
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -52,6 +52,18 @@ struct DefaultAuthRepository: AuthInterface {
         keychainService.save(key: .refreshToken, token: result.refreshToken)
     }
     
+    func reissue() async throws {
+        try await network.tokenReissue()
+    }
+    
+    func hasTokens() -> Bool {
+        if !keychainService.load(key: .accessToken).isEmpty && !keychainService.load(key: .refreshToken).isEmpty {
+            return true
+        } else {
+            return false
+        }
+    }
+    
     func logout() async throws {
         let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
         try await network.request(
@@ -94,6 +106,13 @@ struct MockAuthRepository: AuthInterface {
     }
     
     func appleLogin(platform: LoginPlatform) async throws {
+    }
+    
+    func reissue() async throws {
+    }
+    
+    func hasTokens() -> Bool {
+        return false
     }
     
     func logout() async throws {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -72,6 +72,8 @@ struct DefaultAuthRepository: AuthInterface {
         try await network.request(
             AuthAPI.logout(header: header)
         )
+        
+        removeUserInfo()
     }
     
     func withdraw() async throws {
@@ -81,9 +83,10 @@ struct DefaultAuthRepository: AuthInterface {
         switch loginPlatform {
         case "KAKAO":
             let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
-            return try await network.request(
+            try await network.request(
                 AuthAPI.withdraw(header: header)
             )
+            removeUserInfo()
         case "APPLE":
             // TODO: - authroization code 서버에서 처리하기 
             let (_, authorizationCode) = try await network.appleRequest()
@@ -94,15 +97,27 @@ struct DefaultAuthRepository: AuthInterface {
                 authorizationCode: keychainService.load(key: .authorizationCode)
             )
             
-            return try await network.request(
+            try await network.request(
                 AuthAPI.withdraw(header: header)
             )
+            removeUserInfo()
         default :
             return
         }
     }
 }
 
+extension DefaultAuthRepository {
+    private func removeUserInfo() {
+        for key in KeyType.allCases {
+            keychainService.delete(key: key)
+        }
+        
+        for key in UserDefaultsKey.allCases {
+            _ = userDefaultsService.delete(key: key)
+        }
+    }
+}
 
 struct MockAuthRepository: AuthInterface {
     func kakaoLogin(platform: LoginPlatform) async throws  {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -61,8 +61,10 @@ struct DefaultAuthRepository: AuthInterface {
     
     func hasTokens() -> Bool {
         if !keychainService.load(key: .accessToken).isEmpty && !keychainService.load(key: .refreshToken).isEmpty {
+            ByeBooLogger.debug("정보 있음")
             return true
         } else {
+            ByeBooLogger.debug("정보 업음")
             return false
         }
     }
@@ -73,7 +75,7 @@ struct DefaultAuthRepository: AuthInterface {
             AuthAPI.logout(header: header)
         )
         
-        removeUserInfo()
+        removeTokenInfo()
     }
     
     func withdraw() async throws {
@@ -86,7 +88,7 @@ struct DefaultAuthRepository: AuthInterface {
             try await network.request(
                 AuthAPI.withdraw(header: header)
             )
-            removeUserInfo()
+            removeTokenInfo()
         case "APPLE":
             // TODO: - authroization code 서버에서 처리하기 
             let (_, authorizationCode) = try await network.appleRequest()
@@ -100,6 +102,7 @@ struct DefaultAuthRepository: AuthInterface {
             try await network.request(
                 AuthAPI.withdraw(header: header)
             )
+            removeTokenInfo()
             removeUserInfo()
         default :
             return
@@ -108,13 +111,19 @@ struct DefaultAuthRepository: AuthInterface {
 }
 
 extension DefaultAuthRepository {
-    private func removeUserInfo() {
+    private func removeTokenInfo() {
         for key in KeyType.allCases {
-            keychainService.delete(key: key)
+            let token = keychainService.load(key: key)
+                if !token.isEmpty {
+                    ByeBooLogger.debug("remove 실행: \(key.rawValue)")
+                    keychainService.delete(key: key)
+            }
         }
-        
+    }
+    
+    private func removeUserInfo() {
         for key in UserDefaultsKey.allCases {
-            _ = userDefaultsService.delete(key: key)
+            let _ = userDefaultsService.delete(key: key)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -48,6 +48,9 @@ struct DefaultAuthRepository: AuthInterface {
             decodingType: PostLoginResponseDTO.self
         )
         _ = userDefaultsService.save(result.isRegistered, key: .isRegistered)
+        _ = userDefaultsService.save(result.name ?? "" , key: .userName)
+        _ = userDefaultsService.save(result.journey ?? "", key: .journey)
+        _ = userDefaultsService.save(result.journeyStatus ?? "", key: .journeyStatus)
         keychainService.save(key: .accessToken, token: result.accessToken)
         keychainService.save(key: .refreshToken, token: result.refreshToken)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -119,5 +119,13 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: CalculateRemainingTimeUseCase.self) { _ in
             return DefaultCalculateRemainingTimeUseCase()
         }
+        
+        DIContainer.shared.register(type: TokenReissueUseCase.self) { _ in
+            return DefaultTokenReissueUseCase(repository: authRepository)
+        }
+        
+        DIContainer.shared.register(type: AutoLoginUseCase.self) { _ in
+            return DefaultAutoLoginUseCase(repository: authRepository)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/AuthInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/AuthInterface.swift
@@ -10,6 +10,8 @@ import Foundation
 protocol AuthInterface {
     func kakaoLogin(platform: LoginPlatform) async throws
     func appleLogin(platform: LoginPlatform) async throws
+    func reissue() async throws
+    func hasTokens() -> Bool
     func logout() async throws
     func withdraw() async throws
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/AutoLoginUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/AutoLoginUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  AutoLoginUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 8/30/25.
+//
+
+import Foundation
+
+protocol AutoLoginUseCase {
+    func execute() -> Bool
+}
+
+struct DefaultAutoLoginUseCase: AutoLoginUseCase {
+    private let repository: AuthInterface
+    
+    init(repository: AuthInterface) {
+        self.repository = repository
+    }
+    
+    func execute() -> Bool {
+        return repository.hasTokens()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/TokenReissueUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/TokenReissueUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  tokenReissueUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 8/30/25.
+//
+
+import Foundation
+
+protocol TokenReissueUseCase {
+    func execute() async throws
+}
+
+struct DefaultTokenReissueUseCase: TokenReissueUseCase  {
+    private let repository: AuthInterface
+    
+    init(repository: AuthInterface) {
+        self.repository = repository
+    }
+    
+    func execute() async throws {
+        return try await repository.reissue()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/View/SplashView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/View/SplashView.swift
@@ -1,0 +1,45 @@
+//
+//  SplashView.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 9/2/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+
+final class SplashView: BaseView {
+    private let backgroundImageView = UIImageView()
+    private let logoImageView = UIImageView()
+    
+    override func setStyle() {
+        backgroundImageView.do {
+            $0.image = .bgLight
+        }
+        
+        logoImageView.do {
+            $0.image = .logo
+        }
+    }
+    
+    override func setUI() {
+        addSubviews(
+            backgroundImageView,
+            logoImageView
+        )
+    }
+    
+    override func setLayout() {
+        backgroundImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        logoImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(265.adjustedH)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -27,7 +27,13 @@ final class LoginViewController: BaseViewController {
     override func viewDidLoad() {
         view = rootView
         setAddTarget()
+        
         bind()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.action(.viewDidLoad)
     }
     
     override func setAddTarget() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -30,12 +30,7 @@ final class LoginViewController: BaseViewController {
         
         bind()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.action(.viewDidLoad)
-    }
-    
+        
     override func setAddTarget() {
         rootView.kakaoLoginButton.addTarget(self, action: #selector(kakaoLoginButtonDidTap) , for: .touchUpInside)
         rootView.appleLoginButton.addTarget(self, action: #selector(appleLoginButtonDidTap), for: .touchUpInside)
@@ -58,7 +53,7 @@ extension LoginViewController {
     private func bind() {
         viewModel.output.isRegisteredPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] result in
+            .sink { result in
                 switch result {
                 case .success(let isRegisterd):
                     ByeBooLogger.debug(isRegisterd)
@@ -66,9 +61,19 @@ extension LoginViewController {
                     if isRegisterd {
                         nextViewController = BottomNavigationViewController()
                     } else {
-                        nextViewController = ViewControllerFactory.shared.makeInformationViewController()
+                        nextViewController = ViewControllerFactory.shared.makeTermsViewController()
                     }
-                    self?.navigationController?.setViewControllers([nextViewController], animated: false)
+                    
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                        
+                        ViewControllerUtils.setRootViewController(
+                            window: window,
+                            viewController: nextViewController,
+                            withAnimation: true
+                        )
+                    }
+                    
                 case .failure(let error):
                     ByeBooLogger.debug(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
@@ -1,0 +1,68 @@
+//
+//  SplashViewController.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 9/2/25.
+//
+
+import Combine
+import UIKit
+
+final class SplashViewController: BaseViewController {
+    
+    private let rootView = SplashView()
+    private let viewModel: SplashViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: SplashViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        view = rootView
+        viewModel.action(.viewDidLoad)
+        bind()
+    }
+}
+
+extension SplashViewController {
+    
+    private func bind() {
+        viewModel.output.autoLoginPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { result in
+                switch result {
+                case .success:
+                    let nextViewController = BottomNavigationViewController()
+                    
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                        
+                        ViewControllerUtils.setRootViewController(
+                            window: window,
+                            viewController: nextViewController,
+                            withAnimation: true
+                        )
+                    }
+                case .failure(_):
+                    let nextViewController = ViewControllerFactory.shared.makeLoginViewController()
+                    
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                        
+                        ViewControllerUtils.setRootViewController(
+                            window: window,
+                            viewController: nextViewController,
+                            withAnimation: true
+                        )
+                    }
+                }
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
@@ -12,7 +12,6 @@ import Foundation
 final class LoginViewModel: NSObject {
         
     private var socialLoginAuthSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
-//    private var postLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var isRegisteredSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
     private let keychainService = DefaultKeychainService()
     
@@ -26,26 +25,19 @@ final class LoginViewModel: NSObject {
     
     private let socialLoginUseCase: SocialLoginUseCase
     private let getIsRegisteredUseCase: GetIsRegisteredUseCase
-    private let tokenReissueUseCase: TokenReissueUseCase
-    private let autoLoginUseCase: AutoLoginUseCase
     
     init(
         socialLoginUseCase: SocialLoginUseCase,
-        getIsRegisteredUseCase: GetIsRegisteredUseCase,
-        tokenReissueUseCase: TokenReissueUseCase,
-        autoLoginUseCase: AutoLoginUseCase
+        getIsRegisteredUseCase: GetIsRegisteredUseCase
     ) {
         self.socialLoginUseCase = socialLoginUseCase
         self.getIsRegisteredUseCase = getIsRegisteredUseCase
-        self.tokenReissueUseCase = tokenReissueUseCase
-        self.autoLoginUseCase = autoLoginUseCase
     }
     
 }
 
 extension LoginViewModel {
     enum Input {
-        case viewDidLoad
         case socialLoginButtonDidTap(platform: LoginPlatform)
     }
     
@@ -55,8 +47,6 @@ extension LoginViewModel {
     
     func action(_ trigger: Input) {
         switch trigger {
-        case .viewDidLoad:
-            autoLogin()
         case .socialLoginButtonDidTap(let platform) :
             socialLogin(platform: platform)
         }
@@ -64,14 +54,6 @@ extension LoginViewModel {
 }
 
 extension LoginViewModel {
-    private func autoLogin()  {
-        if autoLoginUseCase.execute() {
-            socialLoginAuthSubject.send(.success(()))
-            getIsRegistered()
-            ByeBooLogger.debug("자동로그인 성공")
-        }
-    }
-    
     private func socialLogin(platform: LoginPlatform) {
         Task {
             do {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
@@ -12,8 +12,9 @@ import Foundation
 final class LoginViewModel: NSObject {
         
     private var socialLoginAuthSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
-    private var postLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+//    private var postLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var isRegisteredSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
+    private let keychainService = DefaultKeychainService()
     
     var output: Output {
         Output(
@@ -25,19 +26,26 @@ final class LoginViewModel: NSObject {
     
     private let socialLoginUseCase: SocialLoginUseCase
     private let getIsRegisteredUseCase: GetIsRegisteredUseCase
+    private let tokenReissueUseCase: TokenReissueUseCase
+    private let autoLoginUseCase: AutoLoginUseCase
     
     init(
         socialLoginUseCase: SocialLoginUseCase,
-        getIsRegisteredUseCase: GetIsRegisteredUseCase
+        getIsRegisteredUseCase: GetIsRegisteredUseCase,
+        tokenReissueUseCase: TokenReissueUseCase,
+        autoLoginUseCase: AutoLoginUseCase
     ) {
         self.socialLoginUseCase = socialLoginUseCase
         self.getIsRegisteredUseCase = getIsRegisteredUseCase
+        self.tokenReissueUseCase = tokenReissueUseCase
+        self.autoLoginUseCase = autoLoginUseCase
     }
     
 }
 
 extension LoginViewModel {
     enum Input {
+        case viewDidLoad
         case socialLoginButtonDidTap(platform: LoginPlatform)
     }
     
@@ -47,6 +55,8 @@ extension LoginViewModel {
     
     func action(_ trigger: Input) {
         switch trigger {
+        case .viewDidLoad:
+            autoLogin()
         case .socialLoginButtonDidTap(let platform) :
             socialLogin(platform: platform)
         }
@@ -54,6 +64,14 @@ extension LoginViewModel {
 }
 
 extension LoginViewModel {
+    private func autoLogin()  {
+        if autoLoginUseCase.execute() {
+            socialLoginAuthSubject.send(.success(()))
+            getIsRegistered()
+            ByeBooLogger.debug("자동로그인 성공")
+        }
+    }
+    
     private func socialLogin(platform: LoginPlatform) {
         Task {
             do {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  SplashViewModel.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 9/2/25.
+//
+
+import Combine
+import Foundation
+
+final class SplashViewModel {
+    
+    private var autoLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+    
+    var output: Output {
+        Output(
+            autoLoginPublisher: autoLoginSubject.eraseToAnyPublisher()
+        )
+    }
+    
+    private var cancellables = Set<AnyCancellable>()
+    private let autoLoginUseCase: AutoLoginUseCase
+    private let tokenReissueUseCase: TokenReissueUseCase
+    
+    init(
+        autoLoginUseCase: AutoLoginUseCase,
+        tokenReissueUseCase: TokenReissueUseCase
+    ) {
+        self.autoLoginUseCase = autoLoginUseCase
+        self.tokenReissueUseCase = tokenReissueUseCase
+    }
+}
+
+
+extension SplashViewModel {
+    enum Input {
+        case viewDidLoad
+    }
+    
+    struct Output {
+        let autoLoginPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
+    }
+    
+    func action(_ trigger: Input) {
+        switch trigger {
+        case .viewDidLoad:
+            autoLogin()
+        }
+    }
+    
+}
+
+extension SplashViewModel {
+    private func autoLogin()  {
+        ByeBooLogger.debug("자동로그인 실행")
+        Task {
+            do {
+                if autoLoginUseCase.execute() {
+                    try await tokenReissueUseCase.execute()
+                    autoLoginSubject.send(.success(()))
+                    ByeBooLogger.debug("자동로그인 성공")
+                }
+                else {
+                    ByeBooLogger.debug("자동로그인 실패")
+                    autoLoginSubject.send(.failure((.noData)))
+                }
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                ByeBooLogger.debug(ByeBooError.networkConnect)
+                ByeBooLogger.error(error as ByeBooError)
+            }
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -196,9 +196,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         DIContainer.shared.register(type: LoginViewModel.self) { container in
             guard let socialLoginUseCase = container.resolve(type: SocialLoginUseCase.self),
-                  let getIsRegisteredUseCase = container.resolve(type: GetIsRegisteredUseCase.self),
-                  let tokenReissueUseCase = container.resolve(type: TokenReissueUseCase.self),
-                  let autoLoginUseCase = container.resolve(type: AutoLoginUseCase.self)
+                  let getIsRegisteredUseCase = container.resolve(type: GetIsRegisteredUseCase.self)
             else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -206,10 +204,19 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             
             return LoginViewModel(
                 socialLoginUseCase: socialLoginUseCase,
-                getIsRegisteredUseCase: getIsRegisteredUseCase,
-                tokenReissueUseCase: tokenReissueUseCase,
-                autoLoginUseCase: autoLoginUseCase
+                getIsRegisteredUseCase: getIsRegisteredUseCase
             )
+        }
+        
+        DIContainer.shared.register(type: SplashViewModel.self) { container in
+            guard let tokenReissueUseCase = container.resolve(type: TokenReissueUseCase.self),
+                  let autoLoginUseCase = container.resolve(type: AutoLoginUseCase.self)
+            else {
+                ByeBooLogger.error(ByeBooError.DIFailedError)
+                return
+            }
+            
+            return SplashViewModel(autoLoginUseCase: autoLoginUseCase, tokenReissueUseCase: tokenReissueUseCase)
         }
         
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -196,7 +196,9 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         DIContainer.shared.register(type: LoginViewModel.self) { container in
             guard let socialLoginUseCase = container.resolve(type: SocialLoginUseCase.self),
-                  let getIsRegisteredUseCase = container.resolve(type: GetIsRegisteredUseCase.self)
+                  let getIsRegisteredUseCase = container.resolve(type: GetIsRegisteredUseCase.self),
+                  let tokenReissueUseCase = container.resolve(type: TokenReissueUseCase.self),
+                  let autoLoginUseCase = container.resolve(type: AutoLoginUseCase.self)
             else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -204,7 +206,9 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             
             return LoginViewModel(
                 socialLoginUseCase: socialLoginUseCase,
-                getIsRegisteredUseCase: getIsRegisteredUseCase
+                getIsRegisteredUseCase: getIsRegisteredUseCase,
+                tokenReissueUseCase: tokenReissueUseCase,
+                autoLoginUseCase: autoLoginUseCase
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
@@ -18,6 +18,8 @@ protocol ViewControllerFactoryProtocol {
     func makeNewJourneySelectViewController() -> NewJourneySelectViewController
     func makeLoginViewController() -> LoginViewController
     func makeModifyNicknameViewController() -> ModifyNicknameViewController
+    func makeTermsViewController() -> TermsViewController
+    func makeSplashViewController() -> SplashViewController
     func makeArchiveQuestViewController() -> ArchiveQuestViewController
     func makeQuestTipViewController() -> QuestTipViewController
     func makeWriteQuestionTypeQuestViewController() -> WriteQuestionTypeQuestViewController
@@ -109,6 +111,18 @@ final class ViewControllerFactory: ViewControllerFactoryProtocol {
             fatalError()
         }
         return ModifyNicknameViewController(viewModel: viewModel)
+    }
+    
+    func makeTermsViewController() -> TermsViewController {
+        return TermsViewController()
+    }
+    
+    func makeSplashViewController() -> SplashViewController {
+        guard let viewModel = DIContainer.shared.resolve(type: SplashViewModel.self) else {
+            DIErrorHandle()
+            fatalError()
+        }
+        return SplashViewController(viewModel: viewModel)
     }
     
     func makeArchiveQuestViewController() -> ArchiveQuestViewController {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #219 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 자동로그인을 구현했습니다. 
- 현재 저는 애플계정은 회원가입 되어있는 상태고, 카카오는 미회원이어서 두가지로 테스트했습니다
- 이외에 viewcontroller util로 수정해야할 부분을 수정했습니다

|    구현 내용    |   로그인 이력 있는 경우   |  로그인 이력 없는 경우   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/54ba6965-0a00-471e-88c8-eb40dd9b3be7" width ="250"> | <img src = "https://github.com/user-attachments/assets/e1542d2a-17db-4c65-9da0-35e4cf45a110" width ="250"> |



## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### 스플래시 분기처리
디코에 올라온 스플래시 어쩌구.. 변경사항을 반영하기 위해서
SplashViewController라는 것을 만들어 이곳에서 자동로그인 관련 로직을 처리합니다. 
뷰컨을 하나 더만든 이유는.. 씬델리게이트에서 관련 로직을 참조하기가 좀 그래서 만들었습니다...
사실 음.. 좋은 방법인진 모르겠어요.... 왜냐면 런치스크린이랑 먼가 ui가 묘하게 위치가 다른지 어색해요..................... 
애니메이션은 나중에 하겠습니다..

### 자동로그인
자동로그인 로직은 다음과 같습니다. 
1. 키체인에 액세스 토큰과 리프레시 토큰이 모두 있는지 확인합니다. 
2. 없다면 소셜로그인으로 넘어가고, 있다면 토큰을 갱신해줍니다 
3. 토큰 갱신이 성공하면 bottom navi vc로 넘어갑니다 
4. 로그아웃시에는 키체인을, 탈퇴시에는 키체인과 유저디폴트를 전부 삭제합니다 

### 토큰 재발급
토큰 재발급 함수 tokenReissue()는 Auth Repository에 있지 않고 network service에 있습니다 
네트워크 리퀘스트 함수 내에서 401 에러 발생 시 토큰 재발급을 위해 따로 함수를 분리했습니다.
저 여기 근데 네트워크서비스에서 401처리할 때 안에 Task로 비동기 처리를 하나 더 열었는데 이게 맞을까요..? 더 좋은 방법이 있을 것 같아요..... ㅜㅜ 많이 지적해주세요 일단 잘 되는건 확인했습니다

```swift
 case .failure:
                    if let data = response.data,
                       let statusCode = response.response?.statusCode,
                       let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
                        let error = self?.handleError(statusCode, errorResponse.message)
                        
                        if statusCode == 401 && endPoint.path != "/reissue" {
//// 요기!!!
                            Task {
                                guard let self else { return }
                                do {
                                    try await self.tokenReissue()
                                } catch {
                                    ByeBooLogger.debug("tokenReissue 실패")
                                    continuation.resume(throwing: error)
                                    return
                                }

                                do {
                                    let retried = try await self.request(endPoint, decodingType: decodingType)
                                    continuation.resume(returning: retried)
                                } catch {
                                    continuation.resume(throwing: error)
                                }
                            }
                            return
                        }
                        
                        ByeBooLogger.error(error ?? .unknownError)
                        continuation.resume(throwing: error ?? .unknownError)
                    } else {
                        ByeBooLogger.error(ByeBooError.decodingError)
                        continuation.resume(throwing: ByeBooError.decodingError)
                    }
                }
            }
```

