### PR TITLE
Refactor/#256 애플 계정 관련 헤더 수정 

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkService.swift
@@ -70,7 +70,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
                                     continuation.resume(throwing: error)
                                     return
                                 }
-
+                                
                                 do {
                                     let retried = try await self.request(endPoint, decodingType: decodingType)
                                     continuation.resume(returning: retried)
@@ -255,7 +255,7 @@ final class DefaultNetworkService: NSObject, NetworkService {
 }
 
 extension DefaultNetworkService: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
-
+    
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first
@@ -271,7 +271,10 @@ extension DefaultNetworkService: ASAuthorizationControllerDelegate, ASAuthorizat
     ) {
         guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
               let identityToken = credential.identityToken,
-              let authorizationCode = credential.authorizationCode else { return }
+              let authorizationCode = credential.authorizationCode else {
+            continuation?.resume(throwing: ByeBooError.appleLoginError)
+            return
+        }
         
         let identityTokenString = String(data: identityToken, encoding: .utf8) ?? ""
         let authorizationCodeString = String(data: authorizationCode, encoding: .utf8) ?? ""

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -50,10 +50,12 @@ struct DefaultAuthRepository: AuthInterface {
         
         switch loginPlatform {
         case "KAKAO":
+            ByeBooLogger.debug("카카오 post login")
             header = .withAuth(acessToken: keychainService.load(key: .authorization))
         case "APPLE":
+            ByeBooLogger.debug("apple post login")
             header = .withAuthCode(
-                acessToken: keychainService.load(key: .accessToken),
+                acessToken: keychainService.load(key: .authorization),
                 authorizationCode: keychainService.load(key: .authorizationCode)
             )
         default:

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -33,26 +33,48 @@ struct DefaultAuthRepository: AuthInterface {
     }
     
     func appleLogin(platform: LoginPlatform) async throws {
-        let (identityToken, _) = try await network.appleRequest()
+        let (identityToken, authorizationCode) = try await network.appleRequest()
         let _ = userDefaultsService.save("APPLE", key: .loginPlatform)
         keychainService.save(key: .authorization, token: identityToken)
+        keychainService.save(key: .authorizationCode, token: authorizationCode)
         try await postLogin(platform: platform)
     }
     
     
     private func postLogin(platform: LoginPlatform) async throws {
         let loginRequestDTO = LoginRequestDTO(platform: platform.rawValue)
-        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .authorization))
+        let header: HeaderType
+        
+        let loginPlatform: String? = userDefaultsService.load(key: .loginPlatform)
+        guard let loginPlatform = loginPlatform else { return }
+        
+        switch loginPlatform {
+        case "KAKAO":
+            header = .withAuth(acessToken: keychainService.load(key: .authorization))
+        case "APPLE":
+            header = .withAuthCode(
+                acessToken: keychainService.load(key: .accessToken),
+                authorizationCode: keychainService.load(key: .authorizationCode)
+            )
+        default:
+            return
+        }
+       
         let result = try await network.request(
             AuthAPI.login(header: header, requestDTO: loginRequestDTO),
             decodingType: PostLoginResponseDTO.self
         )
+        
         _ = userDefaultsService.save(result.isRegistered, key: .isRegistered)
         _ = userDefaultsService.save(result.name ?? "" , key: .userName)
         _ = userDefaultsService.save(result.journey ?? "", key: .journey)
         _ = userDefaultsService.save(result.journeyStatus ?? "", key: .journeyStatus)
+        
         keychainService.save(key: .accessToken, token: result.accessToken)
         keychainService.save(key: .refreshToken, token: result.refreshToken)
+        
+        keychainService.delete(key: .authorization)
+        keychainService.delete(key: .authorizationCode)
     }
     
     func reissue() async throws {
@@ -87,35 +109,12 @@ struct DefaultAuthRepository: AuthInterface {
     }
     
     func withdraw() async throws {
-        let loginPlatform: String? = userDefaultsService.load(key: .loginPlatform)
-        guard let loginPlatform = loginPlatform else { return }
-        
-        switch loginPlatform {
-        case "KAKAO":
-            let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
-            try await network.request(
-                AuthAPI.withdraw(header: header)
-            )
-            removeTokenInfo()
-            removeUserInfo()
-        case "APPLE":
-            // TODO: - authroization code 서버에서 처리하기 
-            let (_, authorizationCode) = try await network.appleRequest()
-            keychainService.save(key: .authorizationCode, token: authorizationCode)
-            
-            let header: HeaderType = .withAuthCode(
-                acessToken: keychainService.load(key: .accessToken),
-                authorizationCode: keychainService.load(key: .authorizationCode)
-            )
-            
-            try await network.request(
-                AuthAPI.withdraw(header: header)
-            )
-            removeTokenInfo()
-            removeUserInfo()
-        default :
-            return
-        }
+        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
+        try await network.request(
+            AuthAPI.withdraw(header: header)
+        )
+        removeTokenInfo()
+        removeUserInfo()
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #256

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 애플 탈퇴 시 authoriztion code를 받기 위해 로그인을 한 번 더 하는 것을 막기 위하여, 앱 진입 시 애플 로그인하면서 서버에 바로 authorizatinon code를 받아 보내주는 것으로 로직을 수정하였습니다 
- 이에 따라 탈퇴 시 유저디폴트에 저장된 Login platform으로 구분하는 로직을 post Login 함수로 옮겼습니다 

|    구현 내용    |   IPhone 13   |  
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/8fcde8b4-a28e-4779-8eee-043a738a5fcf" width ="250"> | 

