### PR TITLE
Refactor/#277 퀘스트 완료 화면 타이틀 색상 변경

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/CongratSquare.swift
@@ -27,7 +27,10 @@ final class CongratSquare: BaseView {
         }
         
         titleLabel.do {
-            $0.attributedText = "QUEST\nCOMPLETE!".makeTitle(rangedText: "QUEST")
+            $0.attributedText = "QUEST\nCOMPLETE!".makeTitle(
+                rangedText: "QUEST",
+                originalTitleColor: .primary100
+            )
             $0.font = FontManager.head1M24.font
             $0.numberOfLines = 2
             $0.textAlignment = .center


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #277

## 📄 작업 내용
- 퀘스트 완료 화면 타이틀에서 "Complete!" 부분 색상 변경
 <img src = "https://github.com/user-attachments/assets/8c17cd5a-fc4f-4892-9b37-148ffd661779" width ="250">