### PR TITLE
Fix/#289 키보드 오류 수정

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         DIContainer.shared.dependencyInject()
-      
+        
         let viewController = ViewControllerFactory.shared.makeSplashViewController()
         let navigationController = UINavigationController(rootViewController: viewController)
         let window = UIWindow(windowScene: windowScene)
@@ -41,13 +41,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
     
-    func sceneDidDisconnect(_ scene: UIScene) { }
+    func sceneDidDisconnect(_ scene: UIScene) {
+        NotificationCenter.default.removeObserver(self, name: .appWillEnterForeground, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .navigateLoginViewController, object: nil)
+    }
     
     func sceneDidBecomeActive(_ scene: UIScene) { }
     
     func sceneWillResignActive(_ scene: UIScene) { }
     
-    func sceneWillEnterForeground(_ scene: UIScene) { }
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        NotificationCenter.default.post(name: .appWillEnterForeground, object: nil)
+    }
     
     func sceneDidEnterBackground(_ scene: UIScene) { }
     
@@ -58,9 +63,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             name: .navigateLoginViewController,
             object: nil
         )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(resetKeyboardAndViewTransform),
+            name: .appWillEnterForeground,
+            object: nil
+        )
     }
     
-    @objc private func navigateLoginViewController() {
+    @objc
+    private func navigateLoginViewController() {
         guard let window = window else { return }
         let viewController = ViewControllerFactory.shared.makeLoginViewController()
         
@@ -73,5 +86,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 withAnimation: true
             )
         }
+    }
+    
+    @objc
+    private func resetKeyboardAndViewTransform() {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
+        
+        window.endEditing(true)
+        window.rootViewController?.view.transform = .identity
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/Extension/Notification+.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/Extension/Notification+.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let navigateLoginViewController = Notification.Name("navigateLoginViewController")
+    static let appWillEnterForeground = Notification.Name("appWillEnterForeground")
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
@@ -14,7 +14,6 @@ final class LoginViewModel: NSObject {
     private var socialLoginAuthSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var isRegisteredSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
     private var getUserIDSubject: PassthroughSubject<Int, Never> = .init()
-    private let keychainService = DefaultKeychainService()
     
     var output: Output {
         Output(

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -51,11 +51,7 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
             selector: #selector(textViewMoveDown),
             name: UIResponder.keyboardWillHideNotification, object: nil
         )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(appWillEnterForeground),
-            name: UIApplication.willEnterForegroundNotification, object: nil
-        )
+        isKeyboardUsed = false
     }
     
     override func viewDidLoad() {
@@ -87,7 +83,6 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
         super.viewWillDisappear(animated)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     override func setAddTarget() {
@@ -136,14 +131,7 @@ extension WriteActiveTypeQuestViewController {
         self.isKeyboardUsed = false
         self.view.transform = .identity
     }
-    
-    @objc
-    private func appWillEnterForeground() {
-        self.view.endEditing(true)
-        self.view.transform = .identity
-        self.isKeyboardUsed = false
-    }
-    
+        
     @objc
     private func confirmButtonDidTap() {
         if rootView.questTextField.textView.text == rootView.questTextField.placeholder ||

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -115,23 +115,30 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
 extension WriteActiveTypeQuestViewController {
     @objc
     private func textViewMoveUp(_ notification: NSNotification) {
-        if !self.isKeyboardUsed {
-            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-                UIView.animate(withDuration: 0.3, animations: {
-                    let offsetY = keyboardSize.height
+        if self.view.window?.frame.origin.y == 0 && !isKeyboardUsed{
+            if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+                let keyboardHeight = keyboardFrame.cgRectValue.height
+                let safeAreaBottom = view.safeAreaInsets.bottom
+                let offsetY = keyboardHeight - safeAreaBottom
+                
+                UIView.animate(withDuration: 0.3) {
                     self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
-                })
-                self.isKeyboardUsed = true
+                }
+                
+                isKeyboardUsed = true
             }
         }
+        
     }
     
     @objc
-    private func textViewMoveDown() {
-        self.isKeyboardUsed = false
-        self.view.transform = .identity
+    private func textViewMoveDown(_ notification: NSNotification) {
+        UIView.animate(withDuration: 0.3) {
+            self.rootView.transform = .identity
+        }
+        isKeyboardUsed = false
     }
-        
+    
     @objc
     private func confirmButtonDidTap() {
         if rootView.questTextField.textView.text == rootView.questTextField.placeholder ||

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -51,6 +51,11 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
             selector: #selector(textViewMoveDown),
             name: UIResponder.keyboardWillHideNotification, object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification, object: nil
+        )
     }
     
     override func viewDidLoad() {
@@ -76,6 +81,13 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
             event: QuestEvents.Name.questWritePageView,
             properties: property.dictionary
         )
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     override func setAddTarget() {
@@ -123,6 +135,13 @@ extension WriteActiveTypeQuestViewController {
     private func textViewMoveDown() {
         self.isKeyboardUsed = false
         self.view.transform = .identity
+    }
+    
+    @objc
+    private func appWillEnterForeground() {
+        self.view.endEditing(true)
+        self.view.transform = .identity
+        self.isKeyboardUsed = false
     }
     
     @objc

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -50,11 +50,7 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
             selector: #selector(textViewMoveDown),
             name: UIResponder.keyboardWillHideNotification, object: nil
         )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(appWillEnterForeground),
-            name: UIApplication.willEnterForegroundNotification, object: nil
-        )
+        isKeyboardUsed = false
     }
     
     override func viewDidLoad() {
@@ -84,7 +80,6 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
         super.viewWillDisappear(animated)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     override func setAddTarget() {
@@ -120,14 +115,7 @@ extension WriteQuestionTypeQuestViewController {
         isKeyboardUsed = false
         self.rootView.transform = .identity
     }
-    
-    @objc
-    private func appWillEnterForeground() {
-        self.view.endEditing(true)
-        self.view.transform = .identity
-        self.isKeyboardUsed = false
-    }
-    
+
     @objc
     private func confirmButtonDidTap() {
         answerText = rootView.questTextField.textView.text

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -39,7 +39,7 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
         view = rootView
     }
     
-    override func viewWillAppear(_ animated: Bool) {        
+    override func viewWillAppear(_ animated: Bool) {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(textViewMoveUp),
@@ -99,23 +99,29 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
 extension WriteQuestionTypeQuestViewController {
     @objc
     private func textViewMoveUp(_ notification: NSNotification) {
-        if !self.isKeyboardUsed{
-            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-                UIView.animate(withDuration: 0.3, animations: {
-                    let offsetY = keyboardSize.height - self.rootView.safeAreaInsets.bottom * 4
-                    self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY)
-                    self.isKeyboardUsed = true
-                })
+        if self.view.window?.frame.origin.y == 0 && !isKeyboardUsed{
+            if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+                let keyboardHeight = keyboardFrame.cgRectValue.height
+                let safeAreaBottom = view.safeAreaInsets.bottom
+                let offsetY = keyboardHeight - safeAreaBottom
+                
+                UIView.animate(withDuration: 0.3) {
+                    self.rootView.transform = CGAffineTransform(translationX: 0, y: -offsetY * 0.5)
+                }
+                
+                isKeyboardUsed = true
             }
         }
     }
     
     @objc
-    private func textViewMoveDown() {
+    private func textViewMoveDown(_ notification: NSNotification) {
+        UIView.animate(withDuration: 0.3) {
+            self.rootView.transform = .identity
+        }
         isKeyboardUsed = false
-        self.rootView.transform = .identity
     }
-
+    
     @objc
     private func confirmButtonDidTap() {
         answerText = rootView.questTextField.textView.text
@@ -220,7 +226,7 @@ extension WriteQuestionTypeQuestViewController: BottomSheetProtocol {
             questID: questID,
             answer: answerText,
             emotionState: emotionState
-            )
+        )
         )
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -50,6 +50,11 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
             selector: #selector(textViewMoveDown),
             name: UIResponder.keyboardWillHideNotification, object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification, object: nil
+        )
     }
     
     override func viewDidLoad() {
@@ -73,6 +78,13 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
             event: QuestEvents.Name.questWritePageView,
             properties: property.dictionary
         )
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     override func setAddTarget() {
@@ -107,6 +119,13 @@ extension WriteQuestionTypeQuestViewController {
     private func textViewMoveDown() {
         isKeyboardUsed = false
         self.rootView.transform = .identity
+    }
+    
+    @objc
+    private func appWillEnterForeground() {
+        self.view.endEditing(true)
+        self.view.transform = .identity
+        self.isKeyboardUsed = false
     }
     
     @objc


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #289

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 키보드가 올라간 채로 백그라운드에 갔다가, 다시 포그라운드에 진입할 시 키보드로 인해 뷰가 내려가는 문제를 해결했습니다 

|    구현 내용    |  active   |  question   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/a178b89e-a119-4e4f-a35c-af6c60d1226f" width ="250"> | <img src = "https://github.com/user-attachments/assets/ff0475b4-4257-4467-9bc1-90d8f3cdce52" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
일단 옵저버를 해제하는 코드를 viewWillDisappear에 추가했습니다.
또한 notification에 포그라운드로 진입하는 옵저버를 하나 추가해서,포그라운드로 진입할 시 뷰를 원래 상태로 되돌리고 키보드를 내려주는 코드를 추가했습니다 

```swift
override func viewWillAppear(_ animated: Bool) {        
        NotificationCenter.default.addObserver(
            self,
            selector: #selector(textViewMoveUp),
            name: UIResponder.keyboardWillShowNotification, object: nil
        )
        NotificationCenter.default.addObserver(
            self,
            selector: #selector(textViewMoveDown),
            name: UIResponder.keyboardWillHideNotification, object: nil
        )
        NotificationCenter.default.addObserver(
            self,
            selector: #selector(appWillEnterForeground),
            name: UIApplication.willEnterForegroundNotification, object: nil //여기를 수정함
        ) 
    }
```
```swift
@objc
    private func appWillEnterForeground() {
        self.view.endEditing(true)
        self.view.transform = .identity
        self.isKeyboardUsed = false
    }
```