### PR TITLE
Refactor/#303 로거 개선

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooLogger.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooLogger.swift
@@ -73,7 +73,7 @@ enum LogLevel {
     
     var shouldShowLogInRelease: Bool {
         switch self {
-        case .error(let error):
+        case .error:
             true
         default:
             false

--- a/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooLogger.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooLogger.swift
@@ -73,11 +73,15 @@ enum LogLevel {
 }
 
 struct ByeBooLogger {
-    static let dateFormatter = DateFormatter()
-    static var date: String {
-        dateFormatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        return dateFormatter.string(from: Date())
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+    
+    private static var timestamp: String {
+        dateFormatter.string(from: Date())
     }
     
     private static func log(
@@ -92,15 +96,15 @@ struct ByeBooLogger {
     
         switch level {
         case .network:
-            logger.log("[🛜 Network] [Date: \(date)] [\(fileName) -> \(function)]: \(logMessage)")
+            logger.log("[🛜 Network] [Date: \(timestamp)] [\(fileName) -> \(function)]: \(logMessage)")
         case .lifeCycle:
-            logger.log("[🔄 LifeCycle] [Date: \(date)] [\(fileName) -> \(function)]: \(logMessage)")
+            logger.log("[🔄 LifeCycle] [Date: \(timestamp)] [\(fileName) -> \(function)]: \(logMessage)")
         case .debug:
-            logger.debug("[🐛 Debug] [Date: \(date)] [\(fileName) -> \(function)]: \(logMessage)")
+            logger.debug("[🐛 Debug] [Date: \(timestamp)] [\(fileName) -> \(function)]: \(logMessage)")
         case .data:
-            logger.info("[📊 Data] [Date: \(date)] [\(fileName) -> \(function)]: \(logMessage)")
+            logger.info("[📊 Data] [Date: \(timestamp)] [\(fileName) -> \(function)]: \(logMessage)")
         case .error(let error):
-            logger.error("[❌ Error] [Date: \(date)] [\(fileName) -> \(function)]: \(error.localizedDescription)")
+            logger.error("[❌ Error] [Date: \(timestamp)] [\(fileName) -> \(function)]: \(error.localizedDescription)")
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooLogger.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooLogger.swift
@@ -70,9 +70,32 @@ enum LogLevel {
                 .error
         }
     }
+    
+    var shouldShowLogInRelease: Bool {
+        switch self {
+        case .error(let error):
+            true
+        default:
+            false
+        }
+    }
 }
 
 struct ByeBooLogger {
+    private static var isDebugMode: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+    
+    private static func shouldShowLog(level: LogLevel) -> Bool {
+        if isDebugMode { return true }
+      
+        return level.shouldShowLogInRelease
+    }
+    
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
@@ -90,6 +113,8 @@ struct ByeBooLogger {
         file: String,
         function: String
     ) {
+        guard shouldShowLog(level: level) else { return }
+        
         let logger = Logger(subsystem: OSLog.subsystem, category: level.category)
         let logMessage = "\(message)"
         let fileName = (file as NSString).lastPathComponent


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #303 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- dateFormatter 의 설정을 로그를 호출할 때마다 중복으로 실행 -> 한번만 실행하도록 변경
- release 모드일 때 불필요한 로그 출력 제거

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`dateFormatter`
- before
```swift
static let dateFormatter = DateFormatter()
static var date: String {
        dateFormatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
        return dateFormatter.string(from: Date())
}
```

- after
```swift
    private static let dateFormatter: DateFormatter = {
        let formatter = DateFormatter()
        formatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
        formatter.locale = Locale(identifier: "en_US_POSIX")
        return formatter
    }()
    
    private static var timestamp: String {
        dateFormatter.string(from: Date())
    }
```

기존에는 로그가 호출될 때마다 date가 호출되어 dateFormat과 locale 설정하는 부분도 불필요하게 호출됨
-> dateFormatter 설정은 초기 한 번만 호출되도록 변경


`shouldShowLog`
- 디버그 모드일 때와 릴리즈 모드일 때 로그 출력 제어
```swift
    private static var isDebugMode: Bool {
        #if DEBUG
        return true
        #else
        return false
        #endif
    }
    
    private static func shouldShowLog(level: LogLevel) -> Bool {
        if isDebugMode { return true }
      
        return level.shouldShowLogInRelease
    }
```


