### PR TITLE
Feat/#308 홈 api 연결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/DialogueResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/DialogueResponseDTO.swift
@@ -7,4 +7,14 @@
 
 struct DialogueResponseDTO: Decodable {
     let dialogue: String
+    let tapDialogue: String
+}
+
+extension DialogueResponseDTO {
+    func toEntity() -> DialogueEntity {
+        return .init(
+            dialogue: dialogue,
+            tapDialogue: tapDialogue
+        )
+    }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
@@ -47,13 +47,13 @@ struct DefaultUsersRepository: UsersInterface {
         return result.toEntity()
     }
     
-    func fetchCharacterDialogue() async throws -> String {
+    func fetchCharacterDialogue() async throws -> DialogueEntity {
         let result = try await network.request(
             UsersAPI.character,
             decodingType: DialogueResponseDTO.self
         )
         
-        return result.dialogue
+        return result.toEntity()
     }
     
     func fetchQuestStatus() async throws -> UserQuestStatusEntity {
@@ -157,8 +157,8 @@ struct MockUserRepository: UsersInterface {
         )
     }
     
-    func fetchCharacterDialogue() async throws -> String {
-        return "천천히, 하지만 분명하게. 오늘도 나아가 봐요."
+    func fetchCharacterDialogue() async throws -> DialogueEntity {
+        return .stub()
     }
     
     func fetchQuestStatus() async throws -> UserQuestStatusEntity {

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/DialogueEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/DialogueEntity.swift
@@ -1,0 +1,22 @@
+//
+//  DialogueEntity.swift
+//  ByeBoo-iOS
+//
+//  Created by 최주리 on 11/19/25.
+//
+
+import Foundation
+
+struct DialogueEntity {
+    let dialogue: String
+    let tapDialogue: String
+}
+
+extension DialogueEntity {
+    static func stub() -> Self {
+        return .init(
+            dialogue: "천천히, 하지만 분명하게 나아갈 거에요",
+            tapDialogue: "앗! 저를 부르셨나요?"
+        )
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/UsersInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/UsersInterface.swift
@@ -15,7 +15,7 @@ protocol UsersInterface {
     func getIsHelperShown() -> Bool?
     func fetchJourney() async throws -> JourneyEntity
     func sendUser(name: String, feeling: String, questStyle: String) async throws -> UserEntity
-    func fetchCharacterDialogue() async throws -> String
+    func fetchCharacterDialogue() async throws -> DialogueEntity
     func fetchQuestStatus() async throws -> UserQuestStatusEntity
     func startJourney() async throws
     func getIsRegistered() -> Bool

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchCharacterDialogueUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchCharacterDialogueUseCase.swift
@@ -6,7 +6,7 @@
 //
 
 protocol FetchCharacterDialogueUseCase {
-    func execute() async throws -> String
+    func execute() async throws -> DialogueEntity
 }
 
 struct DefaultFetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase {
@@ -16,7 +16,7 @@ struct DefaultFetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase {
         self.repository = repository
     }
     
-    func execute() async throws -> String {
+    func execute() async throws -> DialogueEntity {
         return try await repository.fetchCharacterDialogue()
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Home/HomeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Home/HomeView.swift
@@ -45,7 +45,7 @@ final class HomeView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(40.adjustedW)
             $0.width.equalTo(295.adjustedW)
             $0.height.equalTo(337.adjustedH)
-            $0.bottom.equalToSuperview().offset(-31.adjustedH)
+            $0.bottom.equalToSuperview().inset(31.adjustedH)
         }
         headerView.snp.makeConstraints {
             $0.top.equalToSuperview()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Home/HomeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Home/HomeView.swift
@@ -12,7 +12,7 @@ import Lottie
 final class HomeView: BaseView {
 
     private let backgroundImageView = UIImageView()
-    private let homeBori = LottieAnimationView(name: "bori_home")
+    private(set) var homeBori = LottieAnimationView(name: "bori_home")
     private(set) var headerView = HomeHeaderView()
     private let speechBoxView = SpeechTextBoxView(title: "")
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Home/HomeView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Home/HomeView.swift
@@ -43,14 +43,16 @@ final class HomeView: BaseView {
         }
         homeBori.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(40.adjustedW)
-            $0.bottom.equalToSuperview().offset(160.adjustedH)
+            $0.width.equalTo(295.adjustedW)
+            $0.height.equalTo(337.adjustedH)
+            $0.bottom.equalToSuperview().offset(-31.adjustedH)
         }
         headerView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
         speechBoxView.snp.makeConstraints {
-            $0.bottom.equalTo(homeBori.snp.top).offset(180.adjustedH)
+            $0.bottom.equalTo(homeBori.snp.top).offset(-40.adjustedH)
             $0.horizontalEdges.equalToSuperview()
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -65,10 +65,15 @@ final class HomeViewController: BaseViewController {
     }
     
     private func setGesture() {
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(headerDidTap))
-        tapGestureRecognizer.isEnabled = true
-        tapGestureRecognizer.cancelsTouchesInView = false
-        rootView.headerView.homeStateView.addGestureRecognizer(tapGestureRecognizer)
+        let headerTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(headerDidTap))
+        headerTapGestureRecognizer.isEnabled = true
+        headerTapGestureRecognizer.cancelsTouchesInView = false
+        rootView.headerView.homeStateView.addGestureRecognizer(headerTapGestureRecognizer)
+        
+        let boriTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(boriDidTap))
+        boriTapGestureRecognizer.isEnabled = true
+        boriTapGestureRecognizer.cancelsTouchesInView = false
+        rootView.homeBori.addGestureRecognizer(boriTapGestureRecognizer)
     }
 }
 
@@ -97,6 +102,17 @@ extension HomeViewController {
         tutorialViewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(tutorialViewController, animated: false)
     }
+    
+    @objc
+    private func boriDidTap() {
+        guard case .success(let dialogues) = viewModel.dialoguesResult else { return }
+
+        self.rootView.updateOnboardingText(dialogues.tapDialogue)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            self.rootView.updateOnboardingText(dialogues.dialogue)
+        }
+    }
 }
 
 extension HomeViewController: ToastPresentable, ToastErrorHandler {
@@ -105,8 +121,8 @@ extension HomeViewController: ToastPresentable, ToastErrorHandler {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 switch result {
-                case .success(let text):
-                    self?.rootView.updateOnboardingText(text)
+                case .success(let dialogues):
+                    self?.rootView.updateOnboardingText(dialogues.dialogue)
                 case .failure(let error):
                     self?.handleError(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -92,7 +92,7 @@ extension HomeViewController {
     
     @objc
     private func helperDidTap() {
-        viewModel.action(.helperTapped)
+        viewModel.action(.helperDidTap)
         rootView.helperDidTap()
         
         Mixpanel.mainInstance().track(event: HomeEvents.Name.tutorialIconClick)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -58,7 +58,7 @@ final class HomeViewModel {
 extension HomeViewModel: ViewModelType {
     enum Input {
         case viewWillAppear
-        case helperTapped
+        case helperDidTap
     }
     
     struct Output {
@@ -78,7 +78,7 @@ extension HomeViewModel: ViewModelType {
             fetchJourney()
             
             getUserResult()
-        case .helperTapped:
+        case .helperDidTap:
             setHelperShown()
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -12,8 +12,12 @@ final class HomeViewModel {
     
     private var cancellables = Set<AnyCancellable>()
     
+    var dialoguesResult: Result<DialogueEntity, ByeBooError> {
+        characterResultSubject.value
+    }
+    
     private(set) var output: Output
-    private var characterResultSubject = PassthroughSubject<Result<String, ByeBooError>, Never>()
+    private var characterResultSubject = CurrentValueSubject<Result<DialogueEntity, ByeBooError>, Never>(.failure(ByeBooError.noData))
     private var userResultSubject = CurrentValueSubject<String, Never>("하츠핑")
     private var isHelperShownResultSubject = CurrentValueSubject<Bool, Never>(true)
     private var homeStateResultSubject = PassthroughSubject<Result<UserQuestStatusEntity, ByeBooError>, Never>()
@@ -58,7 +62,7 @@ extension HomeViewModel: ViewModelType {
     }
     
     struct Output {
-        let characterResult: AnyPublisher<Result<String, ByeBooError>, Never>
+        let characterResult: AnyPublisher<Result<DialogueEntity, ByeBooError>, Never>
         let userResult: AnyPublisher<String, Never>
         let helperResult: AnyPublisher<Bool, Never>
         let homeStateResult: AnyPublisher<Result<UserQuestStatusEntity, ByeBooError>, Never>
@@ -84,8 +88,8 @@ extension HomeViewModel {
     private func fetchDialogue() {
         Task {
             do {
-                let dialogue = try await fetchCharacterDialogueUseCase.execute()
-                characterResultSubject.send(.success(dialogue))
+                let dialogues = try await fetchCharacterDialogueUseCase.execute()
+                characterResultSubject.send(.success(dialogues))
             } catch {
                 characterResultSubject.send(
                     .failure(

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Offboarding/ViewController/FinishJourneyViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Offboarding/ViewController/FinishJourneyViewController.swift
@@ -109,8 +109,6 @@ extension FinishJourneyViewController: Dismissible {
 extension FinishJourneyViewController {
     @objc
     private func startButtonDidTap() {
-        ByeBooLogger.debug("starbuttontapped")
-        
         let viewController = ViewControllerFactory.shared.makeNewJourneySelectViewController()
         viewController.hidesBottomBarWhenPushed = true
         
@@ -123,8 +121,6 @@ extension FinishJourneyViewController {
     
     @objc
     private func lookBackButtonDidTap() {
-        ByeBooLogger.debug("lookBackButtonTapped")
-        
         let viewController = ViewControllerFactory.shared.makeLookBackJourneyViewController()
         viewController.hidesBottomBarWhenPushed = true
         
@@ -137,7 +133,6 @@ extension FinishJourneyViewController {
     
     @objc
     private func homeLabelDidTap() {
-        ByeBooLogger.debug("homeLabelTapped")
         guard let navigationController else {
             ByeBooLogger.error(ByeBooError.navigationControllerMissing)
             return


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #308 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 보리 인터렉션 적용 했습니다

|    구현 내용    |   IPhone 16 pro   | 
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/cfbf021f-a136-4df5-b5f4-94c91ef3cf01" width ="250"> | 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`HomeViewModel`
- 정보인 dialogue는 ViewModel에서 저장하고 있는게 적절하다고 생각했고, 인터렉션과 같이 view가 변하는 것은 viewController에서 다루는게 적절하다고 생각했습니다.
- dialogue를 저장하기 위해 상태값을 저장하는 CurrentValueSubject로 변경했습니다.
- `characterResultSubject`는 private이고 `dialoguesResult`는 연산속성이기 때문에 `dialoguesResult`에 private이 없어도 캡슐화가 지켜집니다! 
```swift
var dialoguesResult: Result<DialogueEntity, ByeBooError> {
        characterResultSubject.value
    }
private var characterResultSubject = CurrentValueSubject<Result<DialogueEntity, ByeBooError>, Never>(.failure(ByeBooError.noData))
```
