### PR TITLE
Feat/#313 퀘스트수정 api 연결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/EditQuestActiveRequestDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/EditQuestActiveRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  EditQeustRequestDTO.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 11/25/25.
+//
+
+import Foundation
+
+struct EditQuestActiveRequestDTO: Encodable {
+    var imageKey: String
+    var answer: String
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/EditQuestRequestDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/EditQuestRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  EditQeustRequestDTO.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 11/25/25.
+//
+
+import Foundation
+
+struct EditQuestRequestDTO: Encodable {
+    var answer: String
+}
+

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/QuestAnswerResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/QuestAnswerResponseDTO.swift
@@ -15,6 +15,7 @@ struct QuestAnswerResponseDTO: Decodable {
     var answer: String?
     var questEmotionState: String
     var imageUrl: String?
+    var imageKey: String?
     var emotionDescription: String
 }
 
@@ -28,6 +29,7 @@ extension QuestAnswerResponseDTO {
             answer: answer ?? "",
             questEmotionState: questEmotionState,
             imageUrl: imageUrl ?? "",
+            imageKey: imageKey ?? "",
             emotionDescription: emotionDescription
         )
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/QuestAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/QuestAPI.swift
@@ -20,6 +20,8 @@ enum QuestAPI {
     case fetchCompletedJourney
     case postJourney(journey: JourneyType)
     case completedQuests(journey: JourneyType)
+    case editRecording(questID: Int, request: EditQuestRequestDTO)
+    case editActive(questID: Int, request: EditQuestActiveRequestDTO)
 }
 
 extension QuestAPI: EndPoint {
@@ -32,9 +34,9 @@ extension QuestAPI: EndPoint {
         switch self {
         case .checkQuest(let questID):
             return "/\(questID)"
-        case .recording(let questID, _):
+        case .recording(let questID, _), .editRecording(let questID, _):
             return "/\(questID)/recording"
-        case .active(let questID, _):
+        case .active(let questID, _), .editActive(let questID, _):
             return "/\(questID)/active"
         case .images:
             return "/images/signed-url"
@@ -57,13 +59,15 @@ extension QuestAPI: EndPoint {
             return .get
         case .recording, .active, .images, .postJourney:
             return .post
+        case .editRecording, .editActive:
+            return .patch
         }
     }
     
     var headers: HeaderType {
         switch self {
         case .checkQuest, .recording, .active, .tip, .images, .answer, .progressingQuests, .fetchCompletedJourney,
-                .postJourney, .completedQuests:
+                .postJourney, .completedQuests, .editRecording, .editActive:
             let keychainService = DefaultKeychainService()
             return .withAuth(acessToken: keychainService.load(key: .accessToken))
         }
@@ -73,7 +77,7 @@ extension QuestAPI: EndPoint {
         switch self {
         case .checkQuest, .tip, .answer, .progressingQuests, .fetchCompletedJourney, .postJourney, .completedQuests:
             return URLEncoding.default
-        case .recording, .active, .images:
+        case .recording, .active, .images, .editRecording, .editActive:
             return JSONEncoding.default
         }
     }
@@ -94,6 +98,10 @@ extension QuestAPI: EndPoint {
         case let .active(_, dto):
             return try? dto.toDictionary()
         case let .images(dto):
+            return try? dto.toDictionary()
+        case let .editRecording(_, dto):
+            return try? dto.toDictionary()
+        case let .editActive(_, dto):
             return try? dto.toDictionary()
         case .checkQuest, .tip, .answer, .progressingQuests, .fetchCompletedJourney, .postJourney, .completedQuests:
             return nil

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestsRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestsRepository.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct DefaultQuestRepository: QuestsInterface {
-
     private let network: NetworkService
     private let userDefaultsService: UserDefaultService
     
@@ -54,7 +53,7 @@ struct DefaultQuestRepository: QuestsInterface {
     
     func postActiveQuest(questID: Int, answer: String, emotionState: String, image: Data, imageKey: String) async throws {
         let url = try await makeSignedURL(imageKey: imageKey)
-
+        
         try await putImage(signedURL: url, image: image)
         try await saveQuest(questID: questID, answer: answer, emotionState: emotionState, imageKey: imageKey)
     }
@@ -102,11 +101,28 @@ struct DefaultQuestRepository: QuestsInterface {
         return result.toEntity()
     }
     
+    func editQuestionQuest(questID: Int, answer: String) async throws {
+        let editQuestRequestDTO: EditQuestRequestDTO = .init(answer: answer)
+        
+        let _ = try await network.request(
+            QuestAPI.editRecording(questID: questID, request: editQuestRequestDTO)
+        )
+    }
+    
+    func editActiveQuest(questID: Int, answer: String, image: Data?, imageKey: String, isImageChanged: Bool) async throws {
+        if isImageChanged {
+            guard let image else { return }
+            let url = try await makeSignedURL(imageKey: imageKey)
+            try await putImage(signedURL: url, image: image)
+        }
+        try await editQuest(questID: questID, answer: answer, imageKey: imageKey)
+    }
+    
     // MARK: private function
     
     private func makeSignedURL(imageKey: String) async throws -> String {
         let signedURLRequestDTO = SignedURLRequestDTO(contentType: "image/jpeg", imageKey: imageKey)
-        
+        ByeBooLogger.debug(imageKey)
         let result = try await network.request(
             QuestAPI.images(request: signedURLRequestDTO),
             decodingType: SignedURLResponseDTO.self
@@ -135,6 +151,21 @@ struct DefaultQuestRepository: QuestsInterface {
             QuestAPI.active(questID: questID, request: saveQuestActiveDTO)
         )
     }
+    
+    private func editQuest(
+        questID: Int,
+        answer: String,
+        imageKey: String
+    ) async throws {
+        let editQuestActiveDTO = EditQuestActiveRequestDTO(
+            imageKey: imageKey,
+            answer: answer
+        )
+        
+        let _ = try await network.request(
+            QuestAPI.editActive(questID: questID, request: editQuestActiveDTO)
+        )
+    }
 }
 
 final class MockQuestsRepository: QuestsInterface {
@@ -142,6 +173,8 @@ final class MockQuestsRepository: QuestsInterface {
     private(set) var postActiveQuestCalled = false
     private(set) var postQuestionQuestCalled = false
     private(set) var postNewJourneyCalled = false
+    private(set) var editQuestionQuestCalled = false
+    private(set) var editActiveQuestCalled = false
     
     func fetchProgressingQuests() async throws -> ProgressingQuestsEntity {
         return .stub()
@@ -181,5 +214,13 @@ final class MockQuestsRepository: QuestsInterface {
     
     func fetchCompletedQuests(journey: JourneyType) async throws -> CompletedQuestsEntity {
         return .stub()
+    }
+    
+    func editQuestionQuest(questID: Int, answer: String) async throws {
+        self.editQuestionQuestCalled = true
+    }
+    
+    func editActiveQuest(questID: Int, answer: String, image: Data?, imageKey: String, isImageChanged: Bool) async throws {
+        self.editActiveQuestCalled = true
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -108,6 +108,14 @@ struct DomainDependencyAssembler: DependencyAssembler {
             return DefaultFetchNewJourneyUseCase(fetchNewJourneyRepository: questRepository)
         }
         
+        DIContainer.shared.register(type: EditQuestTypeUseCase.self) { _ in
+            return DefaultEditQuestTypeUseCase(repository: questRepository)
+        }
+        
+        DIContainer.shared.register(type: EditQuestActiveUseCase.self) { _ in
+            return DefaultEditQuestActiveUseCase(repository: questRepository)
+        }
+        
         DIContainer.shared.register(type: SocialLoginUseCase.self) { _ in
             return DefaultSocialLoginUseCase(repository: authRepository)
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/QuestAnswerEntity.swift
@@ -15,6 +15,7 @@ struct QuestAnswerEntity {
     var answer: String
     var questEmotionState: String
     var imageUrl: String?
+    var imageKey: String?
     var emotionDescription: String
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/QuestsInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/QuestsInterface.swift
@@ -23,4 +23,11 @@ protocol QuestsInterface {
     func getNewJourney() async throws -> LookBackJourneyEntity
     func postNewJourney(journey: JourneyType) async throws
     func fetchCompletedQuests(journey: JourneyType) async throws -> CompletedQuestsEntity
+    func editQuestionQuest(questID: Int, answer: String) async throws
+    func editActiveQuest(
+        questID: Int,
+        answer: String,
+        image: Data?,
+        imageKey: String,
+        isImageChanged: Bool) async throws
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/EditActiveQuestUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/EditActiveQuestUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  EditActiveTypeQuestUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 11/25/25.
+//
+
+import Foundation
+
+protocol EditQuestActiveUseCase {
+    func execute(questID: Int, answer: String,image: Data?, imageKey: String, isImageChanged: Bool) async throws
+}
+
+struct DefaultEditQuestActiveUseCase: EditQuestActiveUseCase {
+    private let repository: QuestsInterface
+    
+    init(repository: QuestsInterface) {
+        self.repository = repository
+    }
+    
+    func execute(questID: Int, answer: String, image: Data?, imageKey: String, isImageChanged: Bool) async throws {
+        try await repository.editActiveQuest(
+            questID: questID,
+            answer: answer,
+            image: image,
+            imageKey: imageKey,
+            isImageChanged: isImageChanged
+        )
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/EditQuestTypeUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/EditQuestTypeUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  EditQuestTypeUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 11/25/25.
+//
+
+protocol EditQuestTypeUseCase {
+    func execute(questID: Int, answer: String) async throws
+}
+
+struct DefaultEditQuestTypeUseCase: EditQuestTypeUseCase {
+    private let repository: QuestsInterface
+    
+    init(repository: QuestsInterface) {
+        self.repository = repository
+    }
+    
+    func execute(questID: Int, answer: String) async throws {
+        try await repository.editQuestionQuest(
+            questID: questID,
+            answer: answer
+        )
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
@@ -59,7 +59,6 @@ extension ArchiveQuestViewController: ToastPresentable, ToastErrorHandler {
             .sink { [weak self] result in
                 switch result {
                 case .success(let entity):
-                    self?.questID = entity.questNumber
                     ByeBooLogger.debug("퀘스트 아이디 \(self?.questID)")
                     self?.rootView.updateUI(entity)
                 case .failure(let error):
@@ -86,7 +85,18 @@ extension ArchiveQuestViewController: ToastPresentable, ToastErrorHandler {
 
 extension ArchiveQuestViewController: Dismissible {
     func close() {
-        self.navigationController?.popViewController(animated: false)
+        let viewController = BottomNavigationViewController()
+        viewController.selectedIndex = 1
+        
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+            
+            ViewControllerUtils.setRootViewController(
+                window: window,
+                viewController: viewController,
+                withAnimation: true
+            )
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
@@ -59,6 +59,8 @@ extension ArchiveQuestViewController: ToastPresentable, ToastErrorHandler {
             .sink { [weak self] result in
                 switch result {
                 case .success(let entity):
+                    self?.questID = entity.questNumber
+                    ByeBooLogger.debug("퀘스트 아이디 \(self?.questID)")
                     self?.rootView.updateUI(entity)
                 case .failure(let error):
                     self?.handleError(error)
@@ -104,7 +106,7 @@ extension ArchiveQuestViewController {
         var viewController: ( BaseViewController & EditQuestProtocol )
         viewController = setNavigateViewController(type: rootView.type)
         viewController.questMode = .edit
-        viewController.getExistingQuest(questID: self.viewModel.questID ,quest: entity.answer, image: entity.imageUrl)
+        viewController.getExistingQuest(questID: self.viewModel.questID ,quest: entity.answer, image: entity.imageUrl, imageKey: entity.imageKey)
         viewController.tabBarController?.tabBar.isHidden = true
         self.navigationController?.pushViewController(viewController, animated: false)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
@@ -105,5 +105,6 @@ extension QuestTextField: UITextViewDelegate {
         count = textView.text.count
         textCount.text = "(\(count)/\(limitCount))"
         delegate?.changeStyle(count: count)
+        delegate?.changeStyleWhenEditing(changedText: textView.text)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/CompleteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/CompleteActiveTypeQuestViewController.swift
@@ -14,7 +14,7 @@ final class CompleteActiveTypeQuestViewController: BaseViewController {
     private var viewModel: CompleteQuestViewModel
     private var cancellables = Set<AnyCancellable>()
     
-    private var questID: Int = 1
+    private var questID: Int = 31
     private var questNumber: Int = 1
     
     override func loadView() {
@@ -55,6 +55,7 @@ extension CompleteActiveTypeQuestViewController: ToastPresentable, ToastErrorHan
             .sink { [weak self] result in
                 switch result {
                 case .success(let entity):
+                    self?.questNumber = entity.questNumber
                     self?.rootView.bind(with: entity)
                 case .failure(let error):
                     self?.handleError(error)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/CompleteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/CompleteQuestionTypeQuestViewController.swift
@@ -55,6 +55,7 @@ extension CompleteQuestionTypeQuestViewController: ToastPresentable, ToastErrorH
             .sink { [weak self] result in
                 switch result {
                 case .success(let entity):
+                    self?.questNumber = entity.questNumber
                     self?.rootView.bind(with: entity)
                 case .failure(let error):
                     self?.handleError(error)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -18,7 +18,7 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
     private var cancellables = Set<AnyCancellable>()
     var questMode: QuestMode = .write
     
-    private var questID: Int = 1
+    private var questID: Int = 31
     private var questType: QuestType = .activation
     private var questNumber: Int = 1
     
@@ -26,6 +26,8 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
     private var emotionState: String = ""
     private var image: UIImage = UIImage()
     private var isKeyboardUsed: Bool = false
+    private var isImageChanged: Bool = false
+    private var originalImageKey: String = ""
     
     private let bottomSheetViewController = EmotionBottomSheetViewController()
     
@@ -66,6 +68,7 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
         )
         
         setGesture()
+        setDelegate()
         bind()
         presentPhotoPicker()
         
@@ -92,6 +95,10 @@ final class WriteActiveTypeQuestViewController: BaseViewController {
     
     override func setAddTarget() {
         rootView.confirmButton.addTarget(self, action: #selector(confirmButtonDidTap), for: .touchUpInside)
+    }
+    
+    override func setDelegate() {
+        rootView.questTextField.delegate = self
     }
     
     private func setGesture() {
@@ -154,15 +161,20 @@ extension WriteActiveTypeQuestViewController {
             answerText = rootView.questTextField.textView.text
         }
         
-        bottomSheetViewController.bind(questNumber: questNumber, questType: questType)
-        bottomSheetViewController.delegate = self
-        if let sheet =  bottomSheetViewController.sheetPresentationController{
-            sheet.detents = [.custom { _ in 471.adjustedH }]
-            sheet.prefersGrabberVisible = true
-            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-            sheet.preferredCornerRadius = 8
+        if questMode == .edit {
+            saveQuest()
+        } else {
+            ByeBooLogger.debug(questID)
+            bottomSheetViewController.bind(questNumber: questID, questType: questType)
+            bottomSheetViewController.delegate = self
+            if let sheet =  bottomSheetViewController.sheetPresentationController{
+                sheet.detents = [.custom { _ in 471.adjustedH }]
+                sheet.prefersGrabberVisible = true
+                sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+                sheet.preferredCornerRadius = 8
+            }
+            self.present(bottomSheetViewController, animated: true)
         }
-        self.present(bottomSheetViewController, animated: true)
         
         let property = QuestEvents.QuestWriteFinishProperty(
             questLength: rootView.questTextField.textView.text.count,
@@ -198,6 +210,7 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
             .sink { [weak self] result in
                 switch result {
                 case .success(let quest):
+                    self?.questNumber = quest.questNumber
                     self?.rootView.updateQuestTitle(
                         step: quest.step,
                         stepNum: quest.stepNumber,
@@ -216,6 +229,7 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
             .sink { [weak self] result in
                 switch result {
                 case .success(()):
+                    ByeBooLogger.debug("퀘스트 아이디 \(self?.questID)")
                     let viewController = ViewControllerFactory.shared.makeCompleteActiveTypeQuestViewController()
                     viewController.configure(questID: self?.questID ?? 1, questNumber: self?.questNumber ?? 1)
                     self?.bottomSheetViewController.dismiss(animated: true)
@@ -238,6 +252,21 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
                         questStyle: quest.questStyle,
                         question: quest.question
                     )
+                case .failure(let error):
+                    self?.handleError(error)
+                }
+            }
+            .store(in: &cancellables)
+        
+        viewModel.output.didSuccessEditPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(()):
+                    ByeBooLogger.debug("퀘스트 아이디 \(self?.questID)")
+                    let viewController = ViewControllerFactory.shared.makeCompleteActiveTypeQuestViewController()
+                    viewController.configure(questID: self?.questID ?? 1, questNumber: self?.questNumber ?? 1)
+                    self?.navigationController?.pushViewController(viewController, animated: true)
                 case .failure(let error):
                     self?.handleError(error)
                 }
@@ -290,6 +319,7 @@ extension WriteActiveTypeQuestViewController: UIImagePickerControllerDelegate, U
             rootView.updateImageCountLabel(count: rootView.imgCount)
             rootView.changeStyle(count: rootView.imgCount)
             self.image = image
+            isImageChanged = questMode == .edit ? true : false
         }
         dismiss(animated: true, completion: nil)
     }
@@ -301,14 +331,28 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
     }
     
     func saveQuest() {
-        let uuidKey = UUID().uuidString
-        ByeBooLogger.debug("UUID: \(uuidKey)")
+        var finalImageKey: String = ""
+        
+        if questMode == .edit && isImageChanged {
+            finalImageKey = UUID().uuidString
+        } else if questMode == .write {
+            originalImageKey = UUID().uuidString
+        }
+        
+        ByeBooLogger.debug("퀘스트 아이디 \(questID)")
+        ByeBooLogger.debug("텍스트 \(answerText)")
+        ByeBooLogger.debug("원래 이미지 키 \(originalImageKey)")
+        ByeBooLogger.debug("수정된 이미지 키 \(finalImageKey)")
+        
         self.viewModel.action(.didTapCompleteButton(
             questID: self.questID,
             answer: self.answerText,
             emotionState: self.emotionState,
             image: self.image,
-            imageKey: uuidKey)
+            imageKey: finalImageKey.isEmpty ? originalImageKey : finalImageKey,
+            isEdit: questMode == .edit ? true : false,
+            isImageChanged: isImageChanged
+        )
         )
     }
 }
@@ -322,10 +366,19 @@ extension WriteActiveTypeQuestViewController {
 }
 
 extension WriteActiveTypeQuestViewController: EditQuestProtocol {
-    func getExistingQuest(questID: Int, quest: String?, image: String?) {
+    func getExistingQuest(questID: Int, quest: String?, image: String?, imageKey: String?) {
         self.viewModel.action(.navigateFromArchiveViewController(questID: questID))
-        guard let quest = quest, let image = image else { return }
-        rootView.imageContainer.selectedImageView.kf.setImage(with: URL(string: image))
+        guard let quest = quest, let image = image, let imageKey = imageKey else { return }
+        self.originalImageKey = imageKey
+        rootView.imageContainer.selectedImageView.kf.setImage(with: URL(string: image)) { result in
+            switch result {
+            case .success(let value):
+                self.image = value.image
+            case .failure(let error):
+                print(error)
+            }
+        }
+        
         rootView.updateImageCountLabel(count: 1)
         rootView.imageContainer.changeIconHidden()
         
@@ -336,6 +389,18 @@ extension WriteActiveTypeQuestViewController: EditQuestProtocol {
             rootView.questTextField.textView.text = quest
             rootView.questTextField.textCount.text = "(\(quest.count)/\(rootView.questTextField.limitCount))"
             rootView.questTextField.isPlaceholderActive = false
+            rootView.questTextField.textViewDidChange(rootView.questTextField.textView)
+        }
+    }
+}
+
+extension WriteActiveTypeQuestViewController: QuestCompleteProtocol {
+    func changeStyleWhenEditing(changedText: String) {
+        if answerText != changedText {
+            rootView.confirmButton.updateType(.enabled)
+            self.answerText = changedText
+        } else {
+            rootView.confirmButton.updateType(.disabled)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -229,11 +229,12 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
             .sink { [weak self] result in
                 switch result {
                 case .success(()):
-                    ByeBooLogger.debug("퀘스트 아이디 \(self?.questID)")
+                    guard let self else { return }
+                    ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
                     let viewController = ViewControllerFactory.shared.makeCompleteActiveTypeQuestViewController()
-                    viewController.configure(questID: self?.questID ?? 1, questNumber: self?.questNumber ?? 1)
-                    self?.bottomSheetViewController.dismiss(animated: true)
-                    self?.navigationController?.pushViewController(viewController, animated: true)
+                    viewController.configure(questID: self.questID, questNumber: self.questNumber)
+                    self.bottomSheetViewController.dismiss(animated: true)
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 case .failure(let error):
                     self?.handleError(error)
                 }
@@ -263,10 +264,11 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
             .sink { [weak self] result in
                 switch result {
                 case .success(()):
-                    ByeBooLogger.debug("퀘스트 아이디 \(self?.questID)")
-                    let viewController = ViewControllerFactory.shared.makeCompleteActiveTypeQuestViewController()
-                    viewController.configure(questID: self?.questID ?? 1, questNumber: self?.questNumber ?? 1)
-                    self?.navigationController?.pushViewController(viewController, animated: true)
+                    guard let self else { return }
+                    ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
+                    let viewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
+                    viewController.configure(questID: self.questID, questType: .activation)
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 case .failure(let error):
                     self?.handleError(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -367,6 +367,7 @@ extension WriteActiveTypeQuestViewController {
 
 extension WriteActiveTypeQuestViewController: EditQuestProtocol {
     func getExistingQuest(questID: Int, quest: String?, image: String?, imageKey: String?) {
+        self.questID = questID
         self.viewModel.action(.navigateFromArchiveViewController(questID: questID))
         guard let quest = quest, let image = image, let imageKey = imageKey else { return }
         self.originalImageKey = imageKey

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -375,7 +375,7 @@ extension WriteActiveTypeQuestViewController: EditQuestProtocol {
             case .success(let value):
                 self.image = value.image
             case .failure(let error):
-                print(error)
+                ByeBooLogger.debug(error)
             }
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -212,9 +212,10 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
             .sink { [weak self] result in
                 switch result {
                 case .success(()):
-                    let viewController = ViewControllerFactory.shared.makeCompleteQuestionTypeQuestViewController()
-                    viewController.configure(questID: self?.questID ?? 1, questNumber: self?.questNumber ?? 1)
-                    self?.navigationController?.pushViewController(viewController, animated: true)
+                    guard let self else { return }
+                    let viewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
+                    viewController.configure(questID: self.questID, questType: .question)
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 case .failure(let error):
                     self?.handleError(error)
                 }
@@ -270,6 +271,7 @@ extension WriteQuestionTypeQuestViewController {
 
 extension WriteQuestionTypeQuestViewController: EditQuestProtocol {
     func getExistingQuest(questID: Int, quest: String?, image: String?, imageKey: String?) {
+        self.questID = questID
         self.viewModel.action(.viewDidLoadWhenEditMode(questID: questID))
         guard let quest = quest else { return }
         self.answerText = quest

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -64,9 +64,10 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
         )
         
         bind()
+        setDelegate()
         
         if questMode == .write {
-            viewModel.action(.viewDidLoad(quesetID: questID))
+            viewModel.action(.viewDidLoad(quesetID: self.questID))
         }
         
         let property = QuestEvents.QuestWriteStartProperty(
@@ -97,6 +98,10 @@ final class WriteQuestionTypeQuestViewController: BaseViewController {
     override func viewDidDisappear(_ animated: Bool) {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    override func setDelegate() {
+        rootView.questTextField.delegate = self
     }
 }
 
@@ -130,15 +135,19 @@ extension WriteQuestionTypeQuestViewController {
     private func confirmButtonDidTap() {
         answerText = rootView.questTextField.textView.text
         
-        bottomSheetViewController.bind(questNumber: questNumber, questType: questType)
-        bottomSheetViewController.delegate = self
-        if let sheet = bottomSheetViewController.sheetPresentationController{
-            sheet.detents = [.custom { _ in 471.adjustedH }]
-            sheet.prefersGrabberVisible = true
-            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-            sheet.preferredCornerRadius = 8
+        if questMode == .edit {
+            saveQuest()
+        } else {
+            bottomSheetViewController.bind(questNumber: questNumber, questType: questType)
+            bottomSheetViewController.delegate = self
+            if let sheet = bottomSheetViewController.sheetPresentationController{
+                sheet.detents = [.custom { _ in 471.adjustedH }]
+                sheet.prefersGrabberVisible = true
+                sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+                sheet.preferredCornerRadius = 8
+            }
+            self.present(bottomSheetViewController, animated: true)
         }
-        self.present(bottomSheetViewController, animated: true)
         
         let property = QuestEvents.QuestWriteFinishProperty(
             questLength: rootView.questTextField.textView.text.count,
@@ -169,6 +178,7 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
             .sink { [weak self] result in
                 switch result {
                 case .success(let quest):
+                    self?.questNumber = quest.questNumber
                     self?.rootView.updateQuestTitle(
                         step: quest.step,
                         stepNum: quest.stepNumber,
@@ -197,19 +207,14 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
             }
             .store(in: &cancellables)
         
-        viewModel.output.questInfoResultPublisher
+        viewModel.output.didSuccessEditPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 switch result {
-                case .success(let quest):
-                    ByeBooLogger.debug(quest)
-                    self?.rootView.updateQuestTitle(
-                        step: quest.step,
-                        stepNum: quest.stepNumber,
-                        questNumber: quest.questNumber,
-                        questStyle: quest.questStyle,
-                        question: quest.question
-                    )
+                case .success(()):
+                    let viewController = ViewControllerFactory.shared.makeCompleteQuestionTypeQuestViewController()
+                    viewController.configure(questID: self?.questID ?? 1, questNumber: self?.questNumber ?? 1)
+                    self?.navigationController?.pushViewController(viewController, animated: true)
                 case .failure(let error):
                     self?.handleError(error)
                 }
@@ -248,7 +253,8 @@ extension WriteQuestionTypeQuestViewController: BottomSheetProtocol {
         viewModel.action(.presentCompleteView(
             questID: questID,
             answer: answerText,
-            emotionState: emotionState
+            emotionState: emotionState,
+            isEdit: questMode == .edit ? true : false
         )
         )
     }
@@ -263,7 +269,7 @@ extension WriteQuestionTypeQuestViewController {
 }
 
 extension WriteQuestionTypeQuestViewController: EditQuestProtocol {
-    func getExistingQuest(questID: Int, quest: String?, image: String?) {
+    func getExistingQuest(questID: Int, quest: String?, image: String?, imageKey: String?) {
         self.viewModel.action(.viewDidLoadWhenEditMode(questID: questID))
         guard let quest = quest else { return }
         self.answerText = quest
@@ -273,5 +279,16 @@ extension WriteQuestionTypeQuestViewController: EditQuestProtocol {
         rootView.questTextField.textCount.text = "(\(textCount)/\(rootView.questTextField.limitCount))"
         rootView.questTextField.isPlaceholderActive = false
         rootView.changeStyle(count: Int(textCount))
+        rootView.questTextField.textViewDidChange(rootView.questTextField.textView)
+    }
+}
+
+extension WriteQuestionTypeQuestViewController: QuestCompleteProtocol {
+    func changeStyleWhenEditing(changedText: String) {
+        if answerText != changedText {
+            rootView.confirmButton.updateType(.enabled)
+        } else {
+            rootView.confirmButton.updateType(.disabled)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteActiveTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteActiveTypeViewModel.swift
@@ -18,24 +18,29 @@ struct WriteActiveTypeViewModel: ViewModelType {
     private let saveQuestTypeUseCase: SaveQuestTypeUseCase
     private let saveActiveQuestUseCase: SaveQuestActiveUseCase
     private let getQuestInfoUseCase: GetQuestInfoUseCase
+    private let editActiveQuestUseCase: EditQuestActiveUseCase
     
     private let questInfoResultSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let questActiveResultSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private let didSuccessPostSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+    private let didSuccessEditSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     
     init(
         saveQuestTypeUseCase:  SaveQuestTypeUseCase,
         saveActiveTypeUseCase: SaveQuestActiveUseCase,
-        getQuestInfoUseCase: GetQuestInfoUseCase
+        getQuestInfoUseCase: GetQuestInfoUseCase,
+        editActiveQuestUseCase: EditQuestActiveUseCase
     ){
         self.saveQuestTypeUseCase = saveQuestTypeUseCase
         self.saveActiveQuestUseCase = saveActiveTypeUseCase
         self.getQuestInfoUseCase = getQuestInfoUseCase
+        self.editActiveQuestUseCase = editActiveQuestUseCase
         
         output = Output(
             questInfoResultPublisher: questInfoResultSubject.eraseToAnyPublisher(),
             didSuccessPostPublisher: didSuccessPostSubject.eraseToAnyPublisher(),
-            questInfoWhenEditModeResultPublisher: questInfoResultSubject.eraseToAnyPublisher()
+            questInfoWhenEditModeResultPublisher: questInfoResultSubject.eraseToAnyPublisher(),
+            didSuccessEditPublisher: didSuccessEditSubject.eraseToAnyPublisher()
         )
     }
     
@@ -48,15 +53,23 @@ struct WriteActiveTypeViewModel: ViewModelType {
             let answer,
             let emotionState,
             let image,
-            let imageKey
+            let imageKey,
+            let isEdit,
+            let isImageChanged
         ):
-            postActiveType(
-                questID: questID,
-                answer: answer,
-                emotionState: emotionState,
-                image: image,
-                imageKey: imageKey
-            )
+            if isEdit {
+                guard let image else { return }
+                editActiveType(questID: questID, answer: answer, image: image, imageKey: imageKey, isImageChanged: isImageChanged)
+            } else {
+                guard let emotionState = emotionState, let image = image else { return }
+                postActiveType(
+                    questID: questID,
+                    answer: answer,
+                    emotionState: emotionState,
+                    image: image,
+                    imageKey: imageKey
+                )
+            }
         }
     }
 }
@@ -67,9 +80,11 @@ extension WriteActiveTypeViewModel {
         case didTapCompleteButton(
             questID: Int,
             answer: String,
-            emotionState: String,
-            image: UIImage,
-            imageKey: String
+            emotionState: String?,
+            image: UIImage?,
+            imageKey: String,
+            isEdit: Bool,
+            isImageChanged: Bool
         )
         case navigateFromArchiveViewController(questID: Int)
     }
@@ -78,6 +93,7 @@ extension WriteActiveTypeViewModel {
         let questInfoResultPublisher: AnyPublisher<Result<QuestInfoEntity, ByeBooError>, Never>
         let didSuccessPostPublisher:  AnyPublisher<Result<Void, ByeBooError>, Never>
         let questInfoWhenEditModeResultPublisher: AnyPublisher<Result<QuestInfoEntity, ByeBooError>, Never>
+        let didSuccessEditPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
     }
 }
 
@@ -127,4 +143,32 @@ extension WriteActiveTypeViewModel {
             }
         }
     }
+    
+    private func editActiveType(
+        questID: Int,
+        answer: String,
+        image: UIImage?,
+        imageKey: String,
+        isImageChanged: Bool
+    ){
+        Task {
+            do {
+                ByeBooLogger.debug("data size: \(image?.size)")
+                if let jpegImage = image?.jpegData(compressionQuality: 0.1) {
+                    try await editActiveQuestUseCase.execute(
+                        questID: questID,
+                        answer: answer,
+                        image: isImageChanged ? jpegImage : nil,
+                        imageKey: imageKey,
+                        isImageChanged: isImageChanged
+                    )
+                    didSuccessEditSubject.send(.success(()))
+                } else {
+                    ByeBooLogger.error(ByeBooError.noData)
+                }
+            }
+            
+        }
+    }
 }
+

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteQuestTypeViewModel.swift
@@ -16,23 +16,28 @@ struct WriteQuestionTypeViewModel: ViewModelType {
     
     private let saveQuestTypeUseCase: SaveQuestTypeUseCase
     private let getQuestInfoUseCase: GetQuestInfoUseCase
+    private let editQuestTypeUseCase: EditQuestTypeUseCase
     
     private let questInfoResultSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let questInfoWhenEditModeSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let didSuccessPostSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+    private let didSuccessEditSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     
     init(
         saveQuestTypeUseCase:  SaveQuestTypeUseCase,
-        getQuestInfoUseCase: GetQuestInfoUseCase
+        getQuestInfoUseCase: GetQuestInfoUseCase,
+        editQuestTypeUseCase: EditQuestTypeUseCase
         
     ){
         self.saveQuestTypeUseCase = saveQuestTypeUseCase
         self.getQuestInfoUseCase = getQuestInfoUseCase
+        self.editQuestTypeUseCase = editQuestTypeUseCase
         
         output = Output(
             questInfoResultPublisher: questInfoResultSubject.eraseToAnyPublisher(),
             didSuccessPostPublisher: didSuccessPostSubject.eraseToAnyPublisher(),
-            questInfoWhenEditModeResultPublisher: questInfoWhenEditModeSubject.eraseToAnyPublisher()
+            questInfoWhenEditModeResultPublisher: questInfoWhenEditModeSubject.eraseToAnyPublisher(),
+            didSuccessEditPublisher: didSuccessEditSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -40,7 +45,7 @@ struct WriteQuestionTypeViewModel: ViewModelType {
 extension WriteQuestionTypeViewModel {
     enum Input {
         case viewDidLoad(quesetID: Int)
-        case presentCompleteView(questID: Int, answer: String, emotionState: String)
+        case presentCompleteView(questID: Int, answer: String, emotionState: String?, isEdit: Bool)
         case viewDidLoadWhenEditMode(questID: Int)
     }
     
@@ -48,6 +53,7 @@ extension WriteQuestionTypeViewModel {
         let questInfoResultPublisher: AnyPublisher<Result<QuestInfoEntity, ByeBooError>, Never>
         let didSuccessPostPublisher:  AnyPublisher<Result<Void, ByeBooError>, Never>
         let questInfoWhenEditModeResultPublisher: AnyPublisher<Result<QuestInfoEntity, ByeBooError>, Never>
+        let didSuccessEditPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -57,9 +63,15 @@ extension WriteQuestionTypeViewModel {
         case let .presentCompleteView(
             questID,
             answer,
-            emotionState
+            emotionState,
+            isEdit
         ):
-            postQuestType(questID: questID, answer: answer, emotionState: emotionState)
+            if isEdit {
+                editQuestType(questID: questID, answer: answer)
+            } else {
+                guard let emotionState = emotionState else { return }
+                postQuestType(questID: questID, answer: answer, emotionState: emotionState)
+            }
         }
     }
 }
@@ -89,6 +101,21 @@ extension WriteQuestionTypeViewModel {
                     return
                 }
                 didSuccessPostSubject.send(.failure(error as ByeBooError))
+                ByeBooLogger.error(error)
+            }
+        }
+    }
+    
+    private func editQuestType(questID: Int, answer: String) {
+        Task {
+            do {
+                try await editQuestTypeUseCase.execute(questID: questID, answer: answer)
+                didSuccessEditSubject.send(.success(()))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                didSuccessEditSubject.send(.failure(error as ByeBooError))
                 ByeBooLogger.error(error)
             }
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -32,27 +32,31 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         
         DIContainer.shared.register(type: WriteQuestionTypeViewModel.self) { container in
             guard let getQuestInfoUseCase = container.resolve(type: GetQuestInfoUseCase.self),
-                  let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self) else {
+                  let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self),
+                  let editQuestTypeUseCase = container.resolve(type: EditQuestTypeUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             return WriteQuestionTypeViewModel(
                 saveQuestTypeUseCase: saveQuestTypeUseCase,
-                getQuestInfoUseCase: getQuestInfoUseCase
+                getQuestInfoUseCase: getQuestInfoUseCase,
+                editQuestTypeUseCase: editQuestTypeUseCase
             )
         }
         
         DIContainer.shared.register(type: WriteActiveTypeViewModel.self) { container in
             guard let getQuestInfoUseCase = container.resolve(type: GetQuestInfoUseCase.self),
                   let saveActiveTypeUseCase = container.resolve(type: SaveQuestActiveUseCase.self),
-                  let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self) else {
+                  let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self),
+                  let editActiveQuestType = container.resolve(type: EditQuestActiveUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             return WriteActiveTypeViewModel(
                 saveQuestTypeUseCase: saveQuestTypeUseCase,
                 saveActiveTypeUseCase: saveActiveTypeUseCase,
-                getQuestInfoUseCase: getQuestInfoUseCase
+                getQuestInfoUseCase: getQuestInfoUseCase,
+                editActiveQuestUseCase: editActiveQuestType
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/EditQuestProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/EditQuestProtocol.swift
@@ -7,5 +7,5 @@
 
 protocol EditQuestProtocol {
     var questMode: QuestMode { get set }
-    func getExistingQuest(questID: Int, quest: String?, image: String?)
+    func getExistingQuest(questID: Int, quest: String?, image: String?, imageKey: String?)
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/QuestCompleteProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/QuestCompleteProtocol.swift
@@ -7,4 +7,10 @@
 
 protocol QuestCompleteProtocol: AnyObject {
     func changeStyle(count: Int)
+    func changeStyleWhenEditing(changedText: String)
+}
+
+extension QuestCompleteProtocol {
+    func changeStyle(count: Int) { return }
+    func changeStyleWhenEditing(changedText: String) { return }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #313

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 퀘스트 수정 API 연결했습니다.
- 코드가 더러워요 .. (........) QA하면서 같이 리팩토링하겠습니다 .. 

|    구현 내용    |   행동형 (텍스트 수정)   |   행동형 (이미지 수정)  |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/408b2a80-f20c-42bf-9ddd-8e01a7cb3809" width ="250"> | <img src = "https://github.com/user-attachments/assets/ea4d67b2-136f-48ff-9975-6d94265faac1" width ="250"> |

|    구현 내용    |         질문형       |   
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/070578af-8e23-420d-a139-0a726f001f86" width ="250"> | 

- 좀 멈칫하는 부분은 미처 제거하지 못한 브레이크포인트입니다 .. 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### 이미지를 수정하는 경우 분기처리 
`QuestReposiroty`
```swift
 func editActiveQuest(questID: Int, answer: String, image: Data?, imageKey: String, isImageChanged: Bool) async throws {
        if isImageChanged {
            guard let image else { return }
            let url = try await makeSignedURL(imageKey: imageKey)
            try await putImage(signedURL: url, image: image)
        }
        try await editQuest(questID: questID, answer: answer, imageKey: imageKey)
    }
```
isImageChanged라는 파라미터를 주어서 관리합니다. 이미지를 수정한 경우에만 presigned url을 만들어 버킷에 이미지를 저장합니다. 이미지를 변경하지 않은 경우에는 기존의 이미지키를 보내줍니다. 

이에 따라 아카이브 뷰에서 사용되던 퀘스트 상세조회 DTO가 변경되었습니다. 
기존에는 imageKey를 보내주지 않았는데, 이미지 변경 기능이 들어오면서 이미지가 변경되지 않는 경우에는 기존 이미지 key를 보내주어야 했습니다. 그래서 아카이브 뷰에서 내려받는 이미지키를 네비게이션하면서 같이 바인딩해줍니다. 

```
 func getExistingQuest(questID: Int, quest: String?, image: String?, imageKey: String?) {
        self.viewModel.action(.navigateFromArchiveViewController(questID: questID))
        guard let quest = quest, let image = image, let imageKey = imageKey else { return }
        self.originalImageKey = imageKey
        rootView.imageContainer.selectedImageView.kf.setImage(with: URL(string: image)) { result in
            switch result {
            case .success(let value):
                self.image = value.image
            case .failure(let error):
                ByeBooLogger.debug(error)
            }
        }
```
기존에 가지고 있던 이미지도 바인딩 시에 새롭게 바인딩해줍니다. 그래서 api 쏠 떄 같이 보낼 수 있게 됩니다. 

