### PR TITLE
Refactor/#324 2차 스프린트 1차 QA 반영

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/App/AppDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/AppDelegate.swift
@@ -47,21 +47,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate: MessagingDelegate {
     
-    func messaging(
-        _ messaging: Messaging,
-        didReceiveRegistrationToken fcmToken: String?
-    ) {
-        guard let fcmToken,
-              let notificationRepository = DIContainer.shared.resolve(type: DefaultNotificationRepository.self)
-        else {
-            return
-        }
-        
-        Task {
-            try await notificationRepository.updateToken(token: fcmToken)
-        }
-    }
-    
     func application(
         _ application: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: Error
@@ -76,16 +61,26 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        let userDefaultsService = DefaultUserDefaultService()
+        guard let notificationRepository = DIContainer.shared.resolve(type: DefaultNotificationRepository.self) else {
+            return
+        }
         
         Messaging.messaging().apnsToken = deviceToken
-        
         Messaging.messaging().token { token, error in
             if let error {
                 ByeBooLogger.error(error)
+                return
             }
-            if let token {
-                let _ = userDefaultsService.save(token, key: .fcmToken)
+            guard let token else {
+                return
+            }
+            
+            Task {
+                do {
+                    try await notificationRepository.updateToken(token: token)
+                } catch (let error) {
+                    ByeBooLogger.error(error)
+                }
             }
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/ByeBoo-iOS.entitlements
+++ b/ByeBoo-iOS/ByeBoo-iOS/ByeBoo-iOS.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
@@ -17,4 +17,5 @@ enum UserDefaultsKey: String, CaseIterable {
     case journey
     case journeyStatus
     case fcmToken
+    case hasEnterMyPage
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -136,7 +136,7 @@ struct DefaultAuthRepository: AuthInterface {
         }
         
         clearKeychain()
-        removeUserInfo(excludedKeys: [.isOnboardingCompleted, .isHelperShown])
+        removeUserInfo(excludedKeys: [.isOnboardingCompleted, .isHelperShown, .hasEnterMyPage])
         
         return true
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -8,6 +8,9 @@
 import AuthenticationServices
 import Foundation
 
+import Firebase
+import FirebaseMessaging
+
 struct DefaultAuthRepository: AuthInterface {
     private let network: NetworkService
     private let keychainService: KeychainService
@@ -82,14 +85,14 @@ struct DefaultAuthRepository: AuthInterface {
         keychainService.delete(key: .authorization)
         keychainService.delete(key: .authorizationCode)
         
-        if let token: String = userDefaultsService.load(key: .fcmToken) {
-            do {
-                try await network.request(
-                    NotificationAPI.saveToken(accessToken: result.accessToken, dto: .init(token: token))
-                )
-            } catch (let error) {
-                ByeBooLogger.error(error)
-            }
+        do {
+            let fcmToken = try await Messaging.messaging().token()
+            let fcmTokenDTO = FCMTokenDTO(token: fcmToken)
+            try await network.request(
+                NotificationAPI.saveToken(accessToken: result.accessToken, dto: fcmTokenDTO)
+            )
+        } catch (let error) {
+            ByeBooLogger.error(error)
         }
     }
     
@@ -134,6 +137,7 @@ struct DefaultAuthRepository: AuthInterface {
         
         clearKeychain()
         removeUserInfo(excludedKeys: [.isOnboardingCompleted, .isHelperShown])
+        
         return true
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
@@ -30,6 +30,12 @@ struct DefaultNotificationRepository: NotificationInterface {
     
     func sendToken(token: String) async throws {
         let accessToken = keychainService.load(key: .accessToken)
+        
+        guard !accessToken.isEmpty else {
+            saveToken(token: token)
+            return
+        }
+        
         let fcmTokenDTO = createDTO(token: token)
         try await network.request(
             NotificationAPI.saveToken(accessToken: accessToken, dto: fcmTokenDTO)
@@ -37,21 +43,22 @@ struct DefaultNotificationRepository: NotificationInterface {
         saveToken(token: token)
     }
     
-    func saveToken(token: String) {
-        let _ = userDefaultsService.save(token, key: .fcmToken)
-    }
-    
     func updateToken(token: String) async throws {
-        guard let originalToken: String = userDefaultsService.load(key: .fcmToken),
-              originalToken != token else {
+        let accessToken = keychainService.load(key: .accessToken)
+        
+        guard !accessToken.isEmpty else {
+            saveToken(token: token)
             return
         }
         
-        let accessToken = keychainService.load(key: .accessToken)
         let fcmTokenDTO = createDTO(token: token)
         try await network.request(
             NotificationAPI.updateToken(accessToken: accessToken, dto: fcmTokenDTO)
         )
+        saveToken(token: token)
+    }
+    
+    func saveToken(token: String) {
         let _ = userDefaultsService.save(token, key: .fcmToken)
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
@@ -43,6 +43,7 @@ struct DefaultUsersRepository: UsersInterface {
         let _ = userDefaultsService.save(result.id, key: .userID)
         let _ = userDefaultsService.save(result.name, key: .userName)
         let _ = userDefaultsService.save(true, key: .isOnboardingCompleted)
+        let _ = userDefaultsService.save(false, key: .hasEnterMyPage)
         ByeBooLogger.debug("유저 정보 저장 완료")
         return result.toEntity()
     }
@@ -111,6 +112,16 @@ struct DefaultUsersRepository: UsersInterface {
             decodingType: AlarmEnabledResponseDTO.self
         )
         return result.alarmEnabled
+    }
+    
+    func checkHasEnterMyPage() -> Bool {
+        guard let hasEnterMyPage: Bool = userDefaultsService.load(key: .hasEnterMyPage) else {
+            return false
+        }
+        if !hasEnterMyPage {
+            let _ = userDefaultsService.save(true, key: .hasEnterMyPage)
+        }
+        return hasEnterMyPage
     }
 }
 
@@ -191,6 +202,10 @@ final class MockUserRepository: UsersInterface {
     func updateNotificationPermission() -> Bool {
         isAllowed.toggle()
         return isAllowed
+    }
+    
+    func checkHasEnterMyPage() -> Bool {
+        return true
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -147,5 +147,9 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: ChangeNotificationPermissionUseCase.self) { _ in
             return DefaultChangeNotificationPermissionUseCase(repository: userRepository)
         }
+        
+        DIContainer.shared.register(type: CheckHasEnterMyPageUseCase.self) { _ in
+            return DefaultCheckHasEnterMyPageUseCase(repository: userRepository)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/UsersInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/UsersInterface.swift
@@ -21,4 +21,5 @@ protocol UsersInterface {
     func getIsRegistered() -> Bool
     func getLastJourneyType() -> JourneyType
     func updateNotificationPermission() async throws -> Bool
+    func checkHasEnterMyPage() -> Bool
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckHasEnterMyPageUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckHasEnterMyPageUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  CheckHasEnterMyPageUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by APPLE on 11/30/25.
+//
+
+protocol CheckHasEnterMyPageUseCase {
+    func execute() -> Bool
+}
+
+struct DefaultCheckHasEnterMyPageUseCase: CheckHasEnterMyPageUseCase {
+    
+    private let repository: UsersInterface
+    
+    init(repository: UsersInterface) {
+        self.repository = repository
+    }
+    
+    func execute() -> Bool {
+        repository.checkHasEnterMyPage()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
@@ -37,7 +37,7 @@ final class MyPageViewController: BaseViewController {
         
         viewModel.action(.viewWillAppear)
         rootView.scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
-        checkNoticeAuthorizationWhenFirst()
+        checkHasEnterMyPage()
     }
     
     override func viewDidLoad() {
@@ -169,6 +169,24 @@ extension MyPageViewController {
 }
 
 extension MyPageViewController {
+    
+    private func checkHasEnterMyPage() {
+        viewModel.action(.checkHasEnterMyPage)
+        viewModel.output.hasEnterMyPageResult
+            .sink { [weak self] result in
+                switch result {
+                case .success(let hasEnter):
+                    if !hasEnter {
+                        self?.rootView.noticeView.noticeSwitch.setOn(false, animated: false)
+                        return
+                    }
+                    self?.checkNoticeAuthorizationWhenFirst()
+                case .failure:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+    }
     
     @objc
     private func checkNoticeAuthorizationWhenFirst() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
@@ -15,6 +15,7 @@ final class MyPageViewController: BaseViewController {
     private let viewModel: MyPageViewModel
     private var cancellables = Set<AnyCancellable>()
     private var name: String?
+    private var beforeNotificationStatus = false
     
     private let rootView = MyPageView()
     
@@ -36,7 +37,7 @@ final class MyPageViewController: BaseViewController {
         
         viewModel.action(.viewWillAppear)
         rootView.scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
-        checkNoticeAuthorization()
+        checkNoticeAuthorizationWhenFirst()
     }
     
     override func viewDidLoad() {
@@ -52,7 +53,7 @@ final class MyPageViewController: BaseViewController {
         
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(checkNoticeAuthorization),
+            selector: #selector(checkNoticeAuthorizationWhenBack),
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
@@ -155,6 +156,7 @@ extension MyPageViewController {
             .sink { [weak self] result in
                 switch result {
                 case .success(let alarmEnabled):
+                    self?.beforeNotificationStatus = alarmEnabled
                     DispatchQueue.main.async {
                         self?.rootView.noticeView.noticeSwitch.setOn(alarmEnabled, animated: false)
                     }
@@ -169,7 +171,7 @@ extension MyPageViewController {
 extension MyPageViewController {
     
     @objc
-    private func checkNoticeAuthorization() {
+    private func checkNoticeAuthorizationWhenFirst() {
         UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
             guard let self else { return }
             
@@ -177,13 +179,36 @@ extension MyPageViewController {
             switch settings.authorizationStatus {
             case .authorized, .provisional, .ephemeral:
                 isOn = true
-            case .notDetermined, .denied:
-                isOn = false
-            @unknown default:
+            default:
                 isOn = false
             }
+            beforeNotificationStatus = isOn
             DispatchQueue.main.async {
                 self.rootView.noticeView.noticeSwitch.setOn(isOn, animated: false)
+            }
+        }
+    }
+    
+    @objc
+    private func checkNoticeAuthorizationWhenBack() {
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            guard let self else { return }
+            
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                if !beforeNotificationStatus {
+                    self.viewModel.action(.notificationSwitchDidTap)
+                }
+                beforeNotificationStatus = true
+            default:
+                if beforeNotificationStatus {
+                    self.viewModel.action(.notificationSwitchDidTap)
+                } else {
+                    DispatchQueue.main.async {
+                        self.rootView.noticeView.noticeSwitch.setOn(false, animated: false)
+                    }
+                }
+                beforeNotificationStatus = false
             }
         }
     }
@@ -226,20 +251,15 @@ extension MyPageViewController {
     
     @objc
     private func noticeSwitchValueChanged(_ sender: UISwitch) {
-        sender.setOn(!sender.isOn, animated: true)
-        
         UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
             guard let self else { return }
-            
+                        
             DispatchQueue.main.async {
                 switch settings.authorizationStatus {
                 case .notDetermined:
                     self.requestNoticeAuthorization()
                 case .authorized, .provisional, .ephemeral:
-                    self.presentMoveSettingAlert(
-                        isOn: sender.isOn,
-                        status: .authorized
-                    )
+                    self.viewModel.action(.notificationSwitchDidTap)
                 case .denied:
                     self.presentMoveSettingAlert(
                         isOn: sender.isOn,
@@ -339,7 +359,7 @@ extension MyPageViewController {
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()
                 }
-                self?.checkNoticeAuthorization()
+                self?.checkNoticeAuthorizationWhenBack()
             }
         )
     }
@@ -348,6 +368,8 @@ extension MyPageViewController {
         isOn: Bool,
         status: NotificationPermissionStatus
     ) {
+        guard isOn else { return }
+        
         let alertController = createAlertController(status: status)
         alertController.addActions(
             createSuccessAlertAction(),
@@ -380,7 +402,11 @@ extension MyPageViewController {
         UIAlertAction(
             title: "취소",
             style: .cancel
-        )
+        ) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.rootView.noticeView.noticeSwitch.setOn(false, animated: true)
+            }
+        }
     }
     
     private func moveSetting() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewModel/MyPageViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewModel/MyPageViewModel.swift
@@ -15,30 +15,35 @@ final class MyPageViewModel: ViewModelType {
     private var logoutResultSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var withdrawResultSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private var notificationResultSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
+    private var hasEnterMyPageResultSubject: PassthroughSubject<Result<Bool, ByeBooError>, Never> = .init()
     
     private(set) var output: Output
 
     private let getUserNameUseCase: GetUserNameUseCase
     private let logoutUseCase: LogoutUseCase
     private let withdrawUseCase: WithdrawUseCase
+    private let checkHasEnterMyPageUseCase: CheckHasEnterMyPageUseCase
     private let changeNotificationPermissionUseCase: ChangeNotificationPermissionUseCase
     
     init(
         getUserNameUseCase: GetUserNameUseCase,
         logoutUseCase: LogoutUseCase,
         withdrawUseCase: WithdrawUseCase,
-        changeNotificationPermissionUseCase: ChangeNotificationPermissionUseCase
+        changeNotificationPermissionUseCase: ChangeNotificationPermissionUseCase,
+        checkHasEnterMyPageUseCase: CheckHasEnterMyPageUseCase
     ) {
         self.getUserNameUseCase = getUserNameUseCase
         self.logoutUseCase = logoutUseCase
         self.withdrawUseCase = withdrawUseCase
         self.changeNotificationPermissionUseCase = changeNotificationPermissionUseCase
+        self.checkHasEnterMyPageUseCase = checkHasEnterMyPageUseCase
         
         output = Output(
             userResult: userResultSubject.eraseToAnyPublisher(),
             logoutResult: logoutResultSubject.eraseToAnyPublisher(),
             withdrawResult: withdrawResultSubject.eraseToAnyPublisher(),
-            notificationResult: notificationResultSubject.eraseToAnyPublisher()
+            notificationResult: notificationResultSubject.eraseToAnyPublisher(),
+            hasEnterMyPageResult: hasEnterMyPageResultSubject.eraseToAnyPublisher()
         )
     }
     
@@ -52,6 +57,8 @@ final class MyPageViewModel: ViewModelType {
             withdraw()
         case .notificationSwitchDidTap:
             changeNotificationPermission()
+        case .checkHasEnterMyPage:
+            checkHasEnterMyPage()
         }
     }
 }
@@ -62,6 +69,7 @@ extension MyPageViewModel {
         case logoutActionButtonDidTap
         case withdrawActionButtonDidTap
         case notificationSwitchDidTap
+        case checkHasEnterMyPage
     }
     
     struct Output {
@@ -69,6 +77,7 @@ extension MyPageViewModel {
         let logoutResult: AnyPublisher<Result<Void, ByeBooError>, Never>
         let withdrawResult: AnyPublisher<Result<Void, ByeBooError>, Never>
         let notificationResult: AnyPublisher<Result<Bool, ByeBooError>, Never>
+        let hasEnterMyPageResult: AnyPublisher<Result<Bool, ByeBooError>, Never>
     }
 }
 
@@ -121,5 +130,10 @@ extension MyPageViewModel {
                 notificationResultSubject.send(.failure(error))
             }
         }
+    }
+    
+    private func checkHasEnterMyPage() {
+        let result = checkHasEnterMyPageUseCase.execute()
+        hasEnterMyPageResultSubject.send(.success(result))
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Tip/QuestTipView.swift
@@ -132,8 +132,9 @@ final class QuestTipView: BaseView {
         backgroundColor = .grayscale900
         
         navigationView.snp.makeConstraints {
-            $0.top.leading.trailing.equalTo(safeAreaLayoutGuide)
-            $0.height.equalTo(80.adjustedH)
+            $0.top.equalToSuperview().inset(72.adjustedH)
+            $0.leading.trailing.equalTo(safeAreaLayoutGuide)
+            $0.height.equalTo(24.adjustedH)
         }
         
         titleLabel.snp.makeConstraints {
@@ -147,7 +148,7 @@ final class QuestTipView: BaseView {
         }
         
         stepStackView.snp.makeConstraints {
-            $0.top.equalTo(navigationView.snp.bottom)
+            $0.top.equalTo(navigationView.snp.bottom).offset(28.adjustedH)
             $0.centerX.equalToSuperview()
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -152,7 +152,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             guard let getUserNameUseCase = container.resolve(type: GetUserNameUseCase.self),
                   let logoutUseCase = container.resolve(type: LogoutUseCase.self),
                   let withdrawUseCase = container.resolve(type: WithdrawUseCase.self),
-                  let changeNotificationPermissionUseCase = container.resolve(type: ChangeNotificationPermissionUseCase.self)
+                  let changeNotificationPermissionUseCase = container.resolve(type: ChangeNotificationPermissionUseCase.self),
+                  let checkHasEnterMyPageUseCase = container.resolve(type: CheckHasEnterMyPageUseCase.self)
             else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -162,7 +163,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 getUserNameUseCase: getUserNameUseCase,
                 logoutUseCase: logoutUseCase,
                 withdrawUseCase: withdrawUseCase,
-                changeNotificationPermissionUseCase: changeNotificationPermissionUseCase
+                changeNotificationPermissionUseCase: changeNotificationPermissionUseCase,
+                checkHasEnterMyPageUseCase: checkHasEnterMyPageUseCase
             )
         }
         


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #324 

## 📄 작업 내용
- FCM 토큰 저장 API -> 로그인 시 호출, 토큰 갱신 API -> 앱 실행 시 호출하도록 수정했습니다
- 아래 지침에 따라 퀘스트 알림 토글 시 작동을 수정했습니다
<img width="734" height="460" alt="스크린샷 2025-11-30 오후 9 58 21" src="https://github.com/user-attachments/assets/93d5b6bb-5426-4d14-8a19-ddb70b209920" />

- 퀘스트 작성 TIP 화면 내비게이션 바 위치를 소소하게 수정했습니다


## 💻 주요 코드 설명
`MyPageViewController`
- 퀘스트 알림 허용 여부 API를 호출해야 하는 경우는 아래 3가지입니다

1. 시스템 알림 설정을 허용한 상태에서, 퀘스트 알림 토글을 on / off하는 경우
2. 시스템 알림 설정으로 이동해서 알림을 비허용 -> 허용으로 바꾼 뒤 앱으로 돌아온 경우
3. 시스템 알림 설정으로 이동해서 알림을 허용 -> 비허용으로 바꾼 뒤 앱으로 돌아온 경우

- 여기서 2,3번 경우에 대응하기 위해서 이전 알림 허용 상태를 beforeNotificationStatus 변수에 저장하는 방법을 이용했습니다

```swift
@objc
private func checkNoticeAuthorizationWhenBack() {
    UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
        guard let self else { return }
        
        switch settings.authorizationStatus {
        case .authorized, .provisional, .ephemeral:
            if !beforeNotificationStatus {
                self.viewModel.action(.notificationSwitchDidTap)
            }
            beforeNotificationStatus = true
        default:
            if beforeNotificationStatus {
                self.viewModel.action(.notificationSwitchDidTap)
            } else {
                DispatchQueue.main.async {
                    self.rootView.noticeView.noticeSwitch.setOn(false, animated: false)
                }
            }
            beforeNotificationStatus = false
        }
    }
}
```

- 회원탈퇴를 했을 때도 별도 대응이 필요합니다
- 회원탈퇴를 해도 기존 시스템 알림 설정이 "허용" 상태였다면 퀘스트 알림 토글은 on 상태가 됩니다
- 반면 서버에서는 회원탈퇴를 했다가 재가입한 사용자에 대해서는 알림 허용 여부가 false로 저장되어있습니다
- 따라서 UserDefaults에 "마이페이지에 진입한 적이 있는지" 여부를 저장합니다. 앱에 첫 가입했을 때는 false로, 한 번이라도 진입했다면 true로 저장합니다. 이때 false라면 퀘스트 알림 토글은 무조건 off로 되어있습니다
```swift
extension MyPageViewController {
    
    private func checkHasEnterMyPage() {
        viewModel.action(.checkHasEnterMyPage)
        viewModel.output.hasEnterMyPageResult
            .sink { [weak self] result in
                switch result {
                case .success(let hasEnter):
                    if !hasEnter {
                        self?.rootView.noticeView.noticeSwitch.setOn(false, animated: false)
                        return
                    }
                    self?.checkNoticeAuthorizationWhenFirst()
                case .failure:
                    break
                }
            }
            .store(in: &cancellables)
    }
}

// UserRepository
func checkHasEnterMyPage() -> Bool {
    guard let hasEnterMyPage: Bool = userDefaultsService.load(key: .hasEnterMyPage) else {
        return false
    }
    if !hasEnterMyPage {
        let _ = userDefaultsService.save(true, key: .hasEnterMyPage)
    }
    return hasEnterMyPage
}
```

