### PR TITLE
Fix/#328 마이페이지 진입 여부 구독 관리

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/MyPage/ViewController/MyPageViewController.swift
@@ -36,8 +36,8 @@ final class MyPageViewController: BaseViewController {
         super.viewWillAppear(animated)
         
         viewModel.action(.viewWillAppear)
+        viewModel.action(.checkHasEnterMyPage)
         rootView.scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
-        checkHasEnterMyPage()
     }
     
     override func viewDidLoad() {
@@ -104,6 +104,7 @@ extension MyPageViewController {
         bindLogoutResult()
         bindWithdrawResult()
         bindNotificationResult()
+        bindHasEnterMyPage()
     }
     
     private func bindUserResult() {
@@ -166,12 +167,8 @@ extension MyPageViewController {
             }
             .store(in: &cancellables)
     }
-}
-
-extension MyPageViewController {
     
-    private func checkHasEnterMyPage() {
-        viewModel.action(.checkHasEnterMyPage)
+    private func bindHasEnterMyPage() {
         viewModel.output.hasEnterMyPageResult
             .sink { [weak self] result in
                 switch result {
@@ -187,6 +184,9 @@ extension MyPageViewController {
             }
             .store(in: &cancellables)
     }
+}
+
+extension MyPageViewController {
     
     @objc
     private func checkNoticeAuthorizationWhenFirst() {


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #328 

## 📄 작업 내용
- 퀘스트 알림 토글이 정상적으로 작동하도록 마이페이지 진입 여부 구독 관리 로직을 수정했습니다.

## 💻 주요 코드 설명
`MyPageViewController`
- 초기에는 viewWillAppear에서 특정 함수를 호출하고, 해당 함수에서 action과 구독을 모두 실행했습니다.
- 이를 해결하기 위해 action은 viewWillAppear에서 호출하고, bind 함수 내부에서 마이페이지 진입 여부를 구독하는 함수를 호출했습니다 (bind 함수는 viewDidLoad에서 호출)