### PR TITLE
Refactor/#336 2차스프린트 2차 QA 반영

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -152,6 +152,10 @@ struct DomainDependencyAssembler: DependencyAssembler {
             return DefaultCheckHasEnterMyPageUseCase(repository: userRepository)
         }
         
+        DIContainer.shared.register(type: IsValidQuestAnswerUseCase.self) { _ in
+            return DefaultIsValidQuestAnswerUseCase()
+        }
+        
         DIContainer.shared.register(type: CheckAlarmEnabledUseCase.self) { _ in
             return DefaultCheckAlarmEnabledUseCase(repository: userRepository)
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/isValidQuestAnswerUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/isValidQuestAnswerUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  isValidQuestAnswerUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 12/4/25.
+//
+
+import Foundation
+
+protocol IsValidQuestAnswerUseCase {
+    func execute(previousText: String, changingText: String) -> Bool
+}
+
+struct DefaultIsValidQuestAnswerUseCase: IsValidQuestAnswerUseCase {
+    func execute(previousText: String, changingText: String) -> Bool {
+        if previousText.isEmpty {
+            if isValidAnswerText(text: changingText) {
+                return true
+            } else {
+                return false
+            }
+        } else {
+            if previousText != changingText && isValidAnswerText(text: changingText) {
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+    
+    private func isValidAnswerText(text: String) -> Bool {
+        if (text.count >= 10) && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/Common/QuestTextField.swift
@@ -104,7 +104,6 @@ extension QuestTextField: UITextViewDelegate {
         }
         count = textView.text.count
         textCount.text = "(\(count)/\(limitCount))"
-        delegate?.changeStyle(count: count)
-        delegate?.changeStyleWhenEditing(changedText: textView.text)
+        delegate?.updateButtonWhenWriting(text: textView.text)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/WriteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/ActivationType/WriteActiveTypeQuestView.swift
@@ -183,11 +183,3 @@ extension WriteActiveTypeQuestView {
         )
     }
 }
-
-extension WriteActiveTypeQuestView: QuestCompleteProtocol {
-    func changeStyle(count: Int) {
-        if count == 1 {
-            confirmButton.updateType(.enabled)
-        }
-    }
-}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/QuestionType/WriteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/View/QuestionType/WriteQuestionTypeQuestView.swift
@@ -35,7 +35,6 @@ final class WriteQuestionTypeQuestView: BaseView {
             errorIcon,
             descriptionLabel
         )
-        setDelegate()
     }
     
     override func setStyle() {
@@ -57,10 +56,6 @@ final class WriteQuestionTypeQuestView: BaseView {
             $0.textColor = .grayscale400
             $0.textAlignment = .center
         }
-    }
-    
-    private func setDelegate() {
-        questTextField.delegate = self
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -106,16 +101,5 @@ extension WriteQuestionTypeQuestView {
             questNum: questNumber,
             title: question
         )
-    }
-}
-
-extension WriteQuestionTypeQuestView: QuestCompleteProtocol {
-    func changeStyle(count: Int) {
-        if (count >= 10) &&
-            (!questTextField.textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-            confirmButton.updateType(.enabled)
-        } else {
-            confirmButton.updateType(.disabled)
-        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -319,7 +319,7 @@ extension WriteActiveTypeQuestViewController: UIImagePickerControllerDelegate, U
             rootView.imageContainer.changeIconHidden()
             rootView.imgCount = 1
             rootView.updateImageCountLabel(count: rootView.imgCount)
-            rootView.changeStyle(count: rootView.imgCount)
+            changeCount(count: rootView.imgCount)
             self.image = image
             isImageChanged = questMode == .edit ? true : false
         }
@@ -399,8 +399,14 @@ extension WriteActiveTypeQuestViewController: EditQuestProtocol {
 }
 
 extension WriteActiveTypeQuestViewController: QuestCompleteProtocol {
-    func changeStyleWhenEditing(changedText: String) {
-        if answerText != changedText {
+    func changeCount(count: Int) {
+        if count == 1 {
+            rootView.confirmButton.updateType(.enabled)
+        }
+    }
+    
+    func updateButtonWhenWriting(text: String) {
+        if answerText != text {
             rootView.confirmButton.updateType(.enabled)
         } else {
             rootView.confirmButton.updateType(.disabled)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -406,7 +406,7 @@ extension WriteActiveTypeQuestViewController: QuestCompleteProtocol {
     }
     
     func updateButtonWhenWriting(text: String) {
-        if answerText != text {
+        if rootView.imgCount == 1 && answerText != text {
             rootView.confirmButton.updateType(.enabled)
         } else {
             rootView.confirmButton.updateType(.disabled)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -221,6 +221,18 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
                 }
             }
             .store(in: &cancellables)
+        
+        viewModel.output.isValidTextPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case true:
+                    self?.rootView.confirmButton.updateType(.enabled)
+                case false:
+                    self?.rootView.confirmButton.updateType(.disabled)
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -286,31 +298,6 @@ extension WriteQuestionTypeQuestViewController: EditQuestProtocol {
 
 extension WriteQuestionTypeQuestViewController: QuestCompleteProtocol {
     func updateButtonWhenWriting(text: String) {
-        switch questMode {
-        case .write:
-            if isValidAnswerText(text: text){
-                rootView.confirmButton.updateType(.enabled)
-            } else {
-                rootView.confirmButton.updateType(.disabled)
-            }
-            
-        case .edit:
-            if answerText != text && isValidAnswerText(text: text) {
-                rootView.confirmButton.updateType(.enabled)
-            } else {
-                rootView.confirmButton.updateType(.disabled)
-            }
-        }
-    }
-}
-
-extension WriteQuestionTypeQuestViewController {
-    private func isValidAnswerText(text: String) -> Bool {
-        if (text.count >= 10) &&
-            (!rootView.questTextField.textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-            return true
-        } else {
-            return false
-        }
+        viewModel.action(.textFieldEditing(answerText: self.answerText, text: text))
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -285,11 +285,32 @@ extension WriteQuestionTypeQuestViewController: EditQuestProtocol {
 }
 
 extension WriteQuestionTypeQuestViewController: QuestCompleteProtocol {
-    func changeStyleWhenEditing(changedText: String) {
-        if answerText != changedText {
-            rootView.confirmButton.updateType(.enabled)
+    func updateButtonWhenWriting(text: String) {
+        switch questMode {
+        case .write:
+            if isValidAnswerText(text: text){
+                rootView.confirmButton.updateType(.enabled)
+            } else {
+                rootView.confirmButton.updateType(.disabled)
+            }
+            
+        case .edit:
+            if answerText != text && isValidAnswerText(text: text) {
+                rootView.confirmButton.updateType(.enabled)
+            } else {
+                rootView.confirmButton.updateType(.disabled)
+            }
+        }
+    }
+}
+
+extension WriteQuestionTypeQuestViewController {
+    private func isValidAnswerText(text: String) -> Bool {
+        if (text.count >= 10) &&
+            (!rootView.questTextField.textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+            return true
         } else {
-            rootView.confirmButton.updateType(.disabled)
+            return false
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteQuestTypeViewModel.swift
@@ -131,10 +131,7 @@ extension WriteQuestionTypeViewModel {
     }
     
     private func isValidText(previousText: String, changingText: String) {
-        if isValidQuestAnswerUseCase.execute(previousText: previousText, changingText: changingText) {
-            isValidTextSubject.send(true)
-        } else {
-            isValidTextSubject.send(false)
-        }
+        let isValidText: Bool = isValidQuestAnswerUseCase.execute(previousText: previousText, changingText: changingText)
+        isValidTextSubject.send(isValidText)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/WriteQuest/ViewModel/WriteQuestTypeViewModel.swift
@@ -17,27 +17,32 @@ struct WriteQuestionTypeViewModel: ViewModelType {
     private let saveQuestTypeUseCase: SaveQuestTypeUseCase
     private let getQuestInfoUseCase: GetQuestInfoUseCase
     private let editQuestTypeUseCase: EditQuestTypeUseCase
+    private let isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase
     
     private let questInfoResultSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let questInfoWhenEditModeSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let didSuccessPostSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private let didSuccessEditSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
+    private let isValidTextSubject: PassthroughSubject<Bool, Never> = .init()
     
     init(
         saveQuestTypeUseCase:  SaveQuestTypeUseCase,
         getQuestInfoUseCase: GetQuestInfoUseCase,
-        editQuestTypeUseCase: EditQuestTypeUseCase
+        editQuestTypeUseCase: EditQuestTypeUseCase,
+        isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase
         
     ){
         self.saveQuestTypeUseCase = saveQuestTypeUseCase
         self.getQuestInfoUseCase = getQuestInfoUseCase
         self.editQuestTypeUseCase = editQuestTypeUseCase
+        self.isValidQuestAnswerUseCase = isValidQuestAnswerUseCase
         
         output = Output(
             questInfoResultPublisher: questInfoResultSubject.eraseToAnyPublisher(),
             didSuccessPostPublisher: didSuccessPostSubject.eraseToAnyPublisher(),
             questInfoWhenEditModeResultPublisher: questInfoWhenEditModeSubject.eraseToAnyPublisher(),
-            didSuccessEditPublisher: didSuccessEditSubject.eraseToAnyPublisher()
+            didSuccessEditPublisher: didSuccessEditSubject.eraseToAnyPublisher(),
+            isValidTextPublisher: isValidTextSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -47,6 +52,7 @@ extension WriteQuestionTypeViewModel {
         case viewDidLoad(quesetID: Int)
         case presentCompleteView(questID: Int, answer: String, emotionState: String?, isEdit: Bool)
         case viewDidLoadWhenEditMode(questID: Int)
+        case textFieldEditing(answerText: String, text: String)
     }
     
     struct Output {
@@ -54,6 +60,7 @@ extension WriteQuestionTypeViewModel {
         let didSuccessPostPublisher:  AnyPublisher<Result<Void, ByeBooError>, Never>
         let questInfoWhenEditModeResultPublisher: AnyPublisher<Result<QuestInfoEntity, ByeBooError>, Never>
         let didSuccessEditPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
+        let isValidTextPublisher: AnyPublisher<Bool, Never>
     }
     
     func action(_ trigger: Input) {
@@ -72,6 +79,8 @@ extension WriteQuestionTypeViewModel {
                 guard let emotionState = emotionState else { return }
                 postQuestType(questID: questID, answer: answer, emotionState: emotionState)
             }
+        case .textFieldEditing(let answerText, let text):
+            isValidText(previousText: answerText, changingText: text)
         }
     }
 }
@@ -118,6 +127,14 @@ extension WriteQuestionTypeViewModel {
                 didSuccessEditSubject.send(.failure(error as ByeBooError))
                 ByeBooLogger.error(error)
             }
+        }
+    }
+    
+    private func isValidText(previousText: String, changingText: String) {
+        if isValidQuestAnswerUseCase.execute(previousText: previousText, changingText: changingText) {
+            isValidTextSubject.send(true)
+        } else {
+            isValidTextSubject.send(false)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -33,14 +33,16 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: WriteQuestionTypeViewModel.self) { container in
             guard let getQuestInfoUseCase = container.resolve(type: GetQuestInfoUseCase.self),
                   let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self),
-                  let editQuestTypeUseCase = container.resolve(type: EditQuestTypeUseCase.self) else {
+                  let editQuestTypeUseCase = container.resolve(type: EditQuestTypeUseCase.self),
+                  let isValidQuestAnswerUseCase = container.resolve(type: IsValidQuestAnswerUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             return WriteQuestionTypeViewModel(
                 saveQuestTypeUseCase: saveQuestTypeUseCase,
                 getQuestInfoUseCase: getQuestInfoUseCase,
-                editQuestTypeUseCase: editQuestTypeUseCase
+                editQuestTypeUseCase: editQuestTypeUseCase,
+                isValidQuestAnswerUseCase: isValidQuestAnswerUseCase
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/QuestCompleteProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/QuestCompleteProtocol.swift
@@ -6,11 +6,10 @@
 //
 
 protocol QuestCompleteProtocol: AnyObject {
-    func changeStyle(count: Int)
-    func changeStyleWhenEditing(changedText: String)
+    func changeCount(count: Int)
+    func updateButtonWhenWriting(text: String)
 }
 
 extension QuestCompleteProtocol {
-    func changeStyle(count: Int) { return }
-    func changeStyleWhenEditing(changedText: String) { return }
+    func changeCount(count: Int) { return }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #336 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 2차스프린트의2차큐에이! 를 작업했습니다. 
- 퀘스트를 10자 이상 입력하지 않았는데 완료 버튼 enable 상태(최초 작성 상태/수정 상태 모두)
- 행동형 최초 작성 시 사진을 등록하지 않고 텍스트만 입력했는데 완료 버튼 enable 상태로 변경됨

|    구현 내용    |  질문형 큐에이 - 수정 |  질문형 큐에이 - 최초작성 |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/a31b2d7e-3a0c-445a-989c-8059a7d25ad8" width ="250"> | <img src = "https://github.com/user-attachments/assets/44cbffb8-9802-43d1-95ac-d98bb299d471" width ="250"> |

|    구현 내용    |  행동형 큐에이    |  
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/bd521d0d-0d13-4ff8-bbf2-d81462a8ba75" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
```swift
protocol QuestCompleteProtocol: AnyObject {
    func changeCount(count: Int) // 이미지 카운트를 변경할 때만 사용합니다. 
    func updateButtonWhenWriting(text: String) // 텍스트 관련 ui 업데이트 시 사용합니다 
}

extension QuestCompleteProtocol {
    func changeCount(count: Int) { return } // 질문형일때는 이 함수가 필요없으므로 익스텐션으로 리턴처리 해주었습니다 
}
```

```swift

extension WriteQuestionTypeQuestViewController: QuestCompleteProtocol {
    func updateButtonWhenWriting(text: String) {
        switch questMode {
        case .write:
            if isValidAnswerText(text: text){
                rootView.confirmButton.updateType(.enabled)
            } else {
                rootView.confirmButton.updateType(.disabled)
            }
            
        case .edit:
            if answerText != text && isValidAnswerText(text: text) {
                rootView.confirmButton.updateType(.enabled)
            } else {
                rootView.confirmButton.updateType(.disabled)
            }
        }
    }
}

extension WriteQuestionTypeQuestViewController {
    private func isValidAnswerText(text: String) -> Bool {
        if (text.count >= 10) &&
            (!rootView.questTextField.textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
            return true
        } else {
            return false
        }
    }
}
```
기존에 10자 이상 + 공백 제거 관련 조건이 뷰 코드에 있었는데 뷰보다는 뷰컨트롤러에 있는게 좀 더 맞다고 판단되어 뷰컨트롤러로 옮겼습니다.
프로토콜 관련 함수를 리팩토링하면서 질문형 뷰컨에 있던 함수도 같이 리팩토링했습니다. 
questmode에 따라 분기처리를 해주면서 버튼타입을 업데이트시켜줍니다. 

