### PR TITLE
Fix/#319 유저 중복 저장 버그수정

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -57,11 +57,13 @@ extension LoginViewController{
 extension LoginViewController {
     private func bind() {
         viewModel.output.isRegisteredPublisher
+            .throttle(for: .seconds(1.0), scheduler: DispatchQueue.main, latest: false)
             .receive(on: DispatchQueue.main)
             .sink { result in
                 switch result {
                 case .success(let isRegisterd):
                     ByeBooLogger.debug(isRegisterd)
+                    ByeBooLogger.debug("한번만 호출되나")
                     let nextViewController: UIViewController
                     if isRegisterd {
                         nextViewController = ByeBooTabBar()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -63,7 +63,6 @@ extension LoginViewController {
                 switch result {
                 case .success(let isRegisterd):
                     ByeBooLogger.debug(isRegisterd)
-                    ByeBooLogger.debug("한번만 호출되나")
                     let nextViewController: UIViewController
                     if isRegisterd {
                         nextViewController = ByeBooTabBar()


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #319

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 유저 중복저장 버그 수정했습니다
- 지금 실기기 빌드가 안되어서 시뮬레이터로 테스트했는데.. 실기기 빌드 가능해지면 한번 더 봐야할 것 같아요! 

<img width="882" height="169" alt="image" src="https://github.com/user-attachments/assets/d366a9ae-eaff-459d-8ebc-8874b91e3dfe" />

<img width="850" height="147" alt="image" src="https://github.com/user-attachments/assets/5035048c-5c04-4910-9f15-12c5543aab56" />


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
로그인 뷰컨트롤러에 다음과 같은 코드를 추가했습니다. 
```swift
 viewModel.output.isRegisteredPublisher
      .throttle(for: .seconds(1.0), scheduler: DispatchQueue.main, latest: false)
      .receive(on: DispatchQueue.main)
.... 
```
throttle은 지정된 시간동안 연속으로 값이 방출되더라도 제일 처음/제일 마지막 중 하나만 방출된 값을 퍼블리시한다고 합니다 
latest false는 제일 처음에 쓴 걸 가져오기 위해서 false로 지정해주었습니다 !! 
