### PR TITLE
Refactor/#350 유저중복저장 버그 리팩토링

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-Dev.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -294,11 +294,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.heartz.ByeBoo-iOS";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -317,9 +317,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-Prod.entitlements";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -336,11 +336,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.heartz.ByeBoo-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -480,7 +480,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MACOSX_DEPLOYMENT_TARGET = 15.2;
@@ -502,7 +502,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MACOSX_DEPLOYMENT_TARGET = 15.2;

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -9,20 +9,37 @@ import Foundation
 
 import Alamofire
 
-protocol TokenService {
+protocol TokenService: Sendable {
     func reissue() async throws
 }
 
-final class DefaultTokenService: TokenService {
+
+actor DefaultTokenService: TokenService {
+    private var tokenTask: Task<Void, Error>?
     private let keychainService: KeychainService
     
-    init(
-        keychainService: KeychainService
-    ) {
+    
+    init(keychainService: KeychainService) {
         self.keychainService = keychainService
     }
     
     func reissue() async throws {
+        
+        if let task = tokenTask {
+            return try await task.value
+        }
+        
+        let task = Task {
+            try await fetchAuthReissue()
+        }
+        
+        tokenTask = task
+        defer { tokenTask = nil }
+        
+        return try await task.value
+    }
+    
+    private func fetchAuthReissue() async throws {
         let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .refreshToken))
         ByeBooLogger.debug("토큰 재발급 시작")
         
@@ -39,6 +56,8 @@ final class DefaultTokenService: TokenService {
             .validate()
             .responseDecodable(of: BaseResponse<TokenReissueResponseDTO>.self) { [weak self] response in
                 guard let self else { return }
+                ByeBooLogger.debug("!!Reissue \(response)")
+                
                 switch response.result {
                 case .success(let data):
                     guard let data = data.data else {
@@ -46,39 +65,45 @@ final class DefaultTokenService: TokenService {
                         continuation.resume(throwing: ByeBooError.noData)
                         return
                     }
-                    ByeBooLogger.debug("토큰 재발급 완료")
-                    self.keychainService.save(key: .accessToken, token: data.accessToken)
-                    self.keychainService.save(key: .refreshToken, token: data.refreshToken)
-                    continuation.resume(returning: ())
-                case .failure(let error):
-                    ByeBooLogger.debug("토큰 재발급 실패, 키체인 삭제 후 로그인으로 이동")
-                    self.clearKeychain()
-                    DispatchQueue.main.async {
-                        NotificationCenter.default.post(name: .navigateLoginViewController, object: nil)
+                    
+                    Task {
+                        await self.debugTokenReissueSuccess(data)
+                        continuation.resume(returning: ())
                     }
-                    if let data = response.data,
-                       let statusCode = response.response?.statusCode,
-                       let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
-                        ByeBooLogger.error(error)
+                    
+                case .failure(let error):
+                    Task {
+                        await self.debugTokenReissueFailure()
                         continuation.resume(throwing: error)
-                    } else {
-                        ByeBooLogger.error(ByeBooError.decodingError)
-                        continuation.resume(throwing: ByeBooError.decodingError)
                     }
                 }
             }
         }
     }
-}
-
-extension DefaultTokenService {
+    
+    private func debugTokenReissueSuccess(_ data: TokenReissueResponseDTO) {
+        ByeBooLogger.debug("토큰 재발급 완료")
+        self.keychainService.save(key: .accessToken, token: data.accessToken)
+        self.keychainService.save(key: .refreshToken, token: data.refreshToken)
+    }
+    
+    private func debugTokenReissueFailure() {
+        ByeBooLogger.debug("토큰 재발급 실패, 키체인 삭제 후 로그인으로 이동")
+        clearKeychain()
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .navigateLoginViewController, object: nil)
+        }
+    }
+    
     private func clearKeychain() {
+        ByeBooLogger.debug("clearKeychain() called (TokenService)\n\(Thread.callStackSymbols.joined(separator: "\n"))")
         for key in KeyType.allCases {
             let token = keychainService.load(key: key)
-                if !token.isEmpty {
-                    keychainService.delete(key: key)
-                    ByeBooLogger.debug("\(key) 삭제")
+            if !token.isEmpty {
+                keychainService.delete(key: key)
+                ByeBooLogger.debug("\(key) 삭제")
             }
         }
     }
+    
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -98,7 +98,7 @@ struct DefaultAuthRepository: AuthInterface {
     
     func autoLogin() async throws -> Bool {
         let isOnboardingCompleted: Bool = userDefaultsService.load(key: .isOnboardingCompleted) ?? false
-        ByeBooLogger.debug(isOnboardingCompleted)
+        ByeBooLogger.debug("온보딩 여부 \(isOnboardingCompleted)")
         
         if !keychainService.load(key: .accessToken).isEmpty
             && !keychainService.load(key: .refreshToken).isEmpty
@@ -214,7 +214,7 @@ final class MockAuthRepository: AuthInterface {
     func appleLogin(platform: LoginPlatform) async throws {
         appleLoginCalled = true
         
-        var (identityToken, authorizationCode) = try await network.appleRequest()
+        let (identityToken, authorizationCode) = try await network.appleRequest()
         let _ = userDefaultsService.save("APPLE", key: .loginPlatform)
         keychainService.save(key: .authorization, token: identityToken)
         keychainService.save(key: .authorizationCode, token: authorizationCode)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -43,12 +43,14 @@ final class LoginViewController: BaseViewController {
 extension LoginViewController{
     @objc
     private func kakaoLoginButtonDidTap() {
+        rootView.kakaoLoginButton.isUserInteractionEnabled = false
         self.platform = .KAKAO
         viewModel.action(.socialLoginButtonDidTap(platform: .KAKAO))
     }
     
     @objc
     private func appleLoginButtonDidTap() {
+        rootView.appleLoginButton.isUserInteractionEnabled = false
         self.platform = .APPLE
         viewModel.action(.socialLoginButtonDidTap(platform: .APPLE))
     }
@@ -57,12 +59,15 @@ extension LoginViewController{
 extension LoginViewController {
     private func bind() {
         viewModel.output.isRegisteredPublisher
-            .throttle(for: .seconds(1.0), scheduler: DispatchQueue.main, latest: false)
             .receive(on: DispatchQueue.main)
             .sink { result in
+                self.rootView.appleLoginButton.isUserInteractionEnabled = true
+                self.rootView.kakaoLoginButton.isUserInteractionEnabled = true
+                
                 switch result {
                 case .success(let isRegisterd):
-                    ByeBooLogger.debug(isRegisterd)
+                    ByeBooLogger.debug("온보딩 완료 여부 \(isRegisterd)")
+                    
                     let nextViewController: UIViewController
                     if isRegisterd {
                         nextViewController = ByeBooTabBar()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
@@ -64,6 +64,7 @@ extension SplashViewModel {
                 guard let error = error as? ByeBooError else {
                     return
                 }
+                autoLoginSubject.send(.failure((.noData)))
                 ByeBooLogger.debug(ByeBooError.networkConnect)
                 ByeBooLogger.error(error as ByeBooError)
             }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #350

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 원래는 회의 때 나온 자동로그인 이슈를 해결하려고 했는데요 .... 무엇이 원인인지 찾지 못했습니다 


**상황설명**
- 주리, 승준: 자동로그인 잘됨
- 나연, 효은, 고은: 자동로그인 풀림 
- 셋 모두 탈퇴후 재가입하니까 자동로그인잘됨  (??) 

제가 로그를 찍어보니까 userdefault에 있는 onboarding completed key가 계속 false로 떠서 자동로그인이 풀렸던 것 같아요 
근데 분명 온보딩을 했을텐데 ...... 
유저디폴트가 꼬였나... 저는 개발버전쓰다가 실제 스토어꺼 썼다가 그래서  그렇다쳐도? ... 스토어버전만 사용하는 효은언니와 고은이가 유저디폴트가 꼬일 일이 없을텐데... 라는 생각이 드네요 ... 
여튼 잘 모르겠어요 ... 요상함

그래서 이슈를 판 김에..  앱잼전에 작업해놓고 간 유저중복저장 버그를 다시 수정했습니다 


## 💻 주요 코드 설명
throttle를 썼는데 오늘 계속 실기기 테스트해보니까 효과가 없는 것 같아요 
그래서 처음부터 로그인버튼이 터치가 되면 아예 터치를 막아놓고, output을 받을 때 다시 인터랙션이 가능하도록 수정했습니다 

<img width="1163" height="610" alt="image" src="https://github.com/user-attachments/assets/452b40d0-98d2-496f-8093-2dafd7f712b6" />

그래서 버튼을 여러번 터치해도 소셜로그인유스케이스가 한번만 호출되는 것을 확인할 수 있었습니다  !! 
