### PR TITLE
Fix/#350 자동로그인 오류 해결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-Dev.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -294,11 +294,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.heartz.ByeBoo-iOS";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -317,9 +317,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-Prod.entitlements";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -336,11 +336,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.heartz.ByeBoo-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -480,7 +480,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MACOSX_DEPLOYMENT_TARGET = 15.2;
@@ -502,7 +502,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MACOSX_DEPLOYMENT_TARGET = 15.2;

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -9,20 +9,37 @@ import Foundation
 
 import Alamofire
 
-protocol TokenService {
+protocol TokenService: Sendable {
     func reissue() async throws
 }
 
-final class DefaultTokenService: TokenService {
+
+actor DefaultTokenService: TokenService {
+    private var tokenTask: Task<Void, Error>?
     private let keychainService: KeychainService
     
-    init(
-        keychainService: KeychainService
-    ) {
+    
+    init(keychainService: KeychainService) {
         self.keychainService = keychainService
     }
     
     func reissue() async throws {
+        
+        if let task = tokenTask {
+            return try await task.value
+        }
+        
+        let task = Task {
+            try await fetchAuthReissue()
+        }
+        
+        tokenTask = task
+        defer { tokenTask = nil }
+        
+        return try await task.value
+    }
+    
+    private func fetchAuthReissue() async throws {
         let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .refreshToken))
         ByeBooLogger.debug("토큰 재발급 시작")
         
@@ -39,6 +56,8 @@ final class DefaultTokenService: TokenService {
             .validate()
             .responseDecodable(of: BaseResponse<TokenReissueResponseDTO>.self) { [weak self] response in
                 guard let self else { return }
+                ByeBooLogger.debug("!!Reissue \(response)")
+                
                 switch response.result {
                 case .success(let data):
                     guard let data = data.data else {
@@ -46,39 +65,45 @@ final class DefaultTokenService: TokenService {
                         continuation.resume(throwing: ByeBooError.noData)
                         return
                     }
-                    ByeBooLogger.debug("토큰 재발급 완료")
-                    self.keychainService.save(key: .accessToken, token: data.accessToken)
-                    self.keychainService.save(key: .refreshToken, token: data.refreshToken)
-                    continuation.resume(returning: ())
-                case .failure(let error):
-                    ByeBooLogger.debug("토큰 재발급 실패, 키체인 삭제 후 로그인으로 이동")
-                    self.clearKeychain()
-                    DispatchQueue.main.async {
-                        NotificationCenter.default.post(name: .navigateLoginViewController, object: nil)
+                    
+                    Task {
+                        await self.debugTokenReissueSuccess(data)
+                        continuation.resume(returning: ())
                     }
-                    if let data = response.data,
-                       let statusCode = response.response?.statusCode,
-                       let errorResponse = try? JSONDecoder().decode(EmptyResponse.self, from: data) {
-                        ByeBooLogger.error(error)
+                    
+                case .failure(let error):
+                    Task {
+                        await self.debugTokenReissueFailure()
                         continuation.resume(throwing: error)
-                    } else {
-                        ByeBooLogger.error(ByeBooError.decodingError)
-                        continuation.resume(throwing: ByeBooError.decodingError)
                     }
                 }
             }
         }
     }
-}
-
-extension DefaultTokenService {
+    
+    private func debugTokenReissueSuccess(_ data: TokenReissueResponseDTO) {
+        ByeBooLogger.debug("토큰 재발급 완료")
+        self.keychainService.save(key: .accessToken, token: data.accessToken)
+        self.keychainService.save(key: .refreshToken, token: data.refreshToken)
+    }
+    
+    private func debugTokenReissueFailure() {
+        ByeBooLogger.debug("토큰 재발급 실패, 키체인 삭제 후 로그인으로 이동")
+        clearKeychain()
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .navigateLoginViewController, object: nil)
+        }
+    }
+    
     private func clearKeychain() {
+        ByeBooLogger.debug("clearKeychain() called (TokenService)\n\(Thread.callStackSymbols.joined(separator: "\n"))")
         for key in KeyType.allCases {
             let token = keychainService.load(key: key)
-                if !token.isEmpty {
-                    keychainService.delete(key: key)
-                    ByeBooLogger.debug("\(key) 삭제")
+            if !token.isEmpty {
+                keychainService.delete(key: key)
+                ByeBooLogger.debug("\(key) 삭제")
             }
         }
     }
+    
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -56,7 +56,7 @@ actor DefaultTokenService: TokenService {
             .validate()
             .responseDecodable(of: BaseResponse<TokenReissueResponseDTO>.self) { [weak self] response in
                 guard let self else { return }
-                ByeBooLogger.debug("!!Reissue \(response)")
+                ByeBooLogger.debug("💡Reissue \(response)")
                 
                 switch response.result {
                 case .success(let data):
@@ -96,7 +96,6 @@ actor DefaultTokenService: TokenService {
     }
     
     private func clearKeychain() {
-        ByeBooLogger.debug("clearKeychain() called (TokenService)\n\(Thread.callStackSymbols.joined(separator: "\n"))")
         for key in KeyType.allCases {
             let token = keychainService.load(key: key)
             if !token.isEmpty {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -98,7 +98,7 @@ struct DefaultAuthRepository: AuthInterface {
     
     func autoLogin() async throws -> Bool {
         let isOnboardingCompleted: Bool = userDefaultsService.load(key: .isOnboardingCompleted) ?? false
-        ByeBooLogger.debug(isOnboardingCompleted)
+        ByeBooLogger.debug("온보딩 여부 \(isOnboardingCompleted)")
         
         if !keychainService.load(key: .accessToken).isEmpty
             && !keychainService.load(key: .refreshToken).isEmpty
@@ -214,7 +214,7 @@ final class MockAuthRepository: AuthInterface {
     func appleLogin(platform: LoginPlatform) async throws {
         appleLoginCalled = true
         
-        var (identityToken, authorizationCode) = try await network.appleRequest()
+        let (identityToken, authorizationCode) = try await network.appleRequest()
         let _ = userDefaultsService.save("APPLE", key: .loginPlatform)
         keychainService.save(key: .authorization, token: identityToken)
         keychainService.save(key: .authorizationCode, token: authorizationCode)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -43,12 +43,14 @@ final class LoginViewController: BaseViewController {
 extension LoginViewController{
     @objc
     private func kakaoLoginButtonDidTap() {
+        rootView.kakaoLoginButton.isUserInteractionEnabled = false
         self.platform = .KAKAO
         viewModel.action(.socialLoginButtonDidTap(platform: .KAKAO))
     }
     
     @objc
     private func appleLoginButtonDidTap() {
+        rootView.appleLoginButton.isUserInteractionEnabled = false
         self.platform = .APPLE
         viewModel.action(.socialLoginButtonDidTap(platform: .APPLE))
     }
@@ -57,12 +59,15 @@ extension LoginViewController{
 extension LoginViewController {
     private func bind() {
         viewModel.output.isRegisteredPublisher
-            .throttle(for: .seconds(1.0), scheduler: DispatchQueue.main, latest: false)
             .receive(on: DispatchQueue.main)
             .sink { result in
+                self.rootView.appleLoginButton.isUserInteractionEnabled = true
+                self.rootView.kakaoLoginButton.isUserInteractionEnabled = true
+                
                 switch result {
                 case .success(let isRegisterd):
-                    ByeBooLogger.debug(isRegisterd)
+                    ByeBooLogger.debug("온보딩 완료 여부 \(isRegisterd)")
+                    
                     let nextViewController: UIViewController
                     if isRegisterd {
                         nextViewController = ByeBooTabBar()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
@@ -64,6 +64,7 @@ extension SplashViewModel {
                 guard let error = error as? ByeBooError else {
                     return
                 }
+                autoLoginSubject.send(.failure((.noData)))
                 ByeBooLogger.debug(ByeBooError.networkConnect)
                 ByeBooLogger.error(error as ByeBooError)
             }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #350 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 자동로그인 이슈 해결했습니다 !!!!!!!!!!!!!

![IMG_3570](https://github.com/user-attachments/assets/1f5e88e1-bd88-4bc7-aad8-0bf968de4485)


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### 문제 원인 분석 
<img width="1017" height="619" alt="image" src="https://github.com/user-attachments/assets/7ba6da2d-cc40-4bee-bd63-b13fc38b1295" />
문제 상황을 다시 재연해보니, 이틀 뒤, 30분 뒤.. 에 다시 들어갔을 때부터 자동로그인이 풀린다는 문제를 짚을 수 있었습니다
현재 액세스토큰 유효시간은 10분, 리프레시토큰은 2주입니다 !! 
그래서 저는 액세스토큰이 만료되었을 때 reissue가 잘 되는 것 같지 않다고 판단하고 로그를 찍어보았습니다 


<img width="648" height="173" alt="image" src="https://github.com/user-attachments/assets/5609efed-d31a-4cc3-a628-6c7b6a84c596" /> 


로그가 너무 길어서 ;; 요약으로 대체합니다 
여튼 요약하자면 autologin 함수에서 토큰 재발급을 잘 받았는데, 거의 동시에 호출되는 notification-tokens api에는 만료된 액세스토큰이 들어가게 되어 reissue를 호출하게 됩니다. 그러면 이미 새 토큰을 받았는데 만료된 토큰으로 reissue를 호출하게 되면 또 401에러가 나게 됩니다..  이때 clearKeychain이 실행되게 되면서 앞으로 자동로그인을 할 수 없게 됩니다 (키체인에 토큰이 있는지 확인하기 때문에)

동시성의 문제라고 판단하고 actor로 TokenService를 리팩토링했습니다 어렵더라구여 .. .. . 

### 코드 설명 
```swift
func reissue() async throws {
   // 이미 진행중인 토큰 태스크가 있다면 
    if let task = tokenTask {
        return try await task.value // 그 태스크 그냥 실행한다 
    }
    // 없으면 새로운 컨텍스트를 만든다 
    let task = Task {
        try await fetchAuthReissue()
    }

    // 토큰태스크에 새로만든 태스크 할당   
    tokenTask = task
    // 리이슈 끝나면 nil로 바꿔줌 
    defer { tokenTask = nil }
    
    // 결과를 리턴 
    return try await task.value
    }
```
아직 근데 너무 어렵네요 actor가 .. 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://dawning-record.tistory.com/132
https://sujinnaljin.medium.com/swift-actor-%EB%BF%8C%EC%8B%9C%EA%B8%B0-249aee2b732d
https://yunie-studylog.tistory.com/81