### PR TITLE
Refactor/#361 자동로그인 리뷰반영

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -45,7 +45,10 @@ actor DefaultTokenService: TokenService {
         ByeBooLogger.debug("토큰 재발급 시작")
         
         return try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self else { return }
+            guard let self else {
+                continuation.resume(throwing: ByeBooError.unknownError)
+                return          
+            }
             
             AF.request(
                 endPoint.requestURL,
@@ -55,8 +58,14 @@ actor DefaultTokenService: TokenService {
                 headers: endPoint.headers.value
             )
             .validate()
-            .responseDecodable(of: BaseResponse<TokenReissueResponseDTO>.self) { [weak self] response in
-                guard let self else { return }
+            .responseDecodable(
+                of: BaseResponse<TokenReissueResponseDTO>.self,
+                queue: DispatchQueue.global()
+            ) { [weak self] response in
+                guard let self else {
+                    continuation.resume(throwing: ByeBooError.unknownError)
+                    return
+                }
                 ByeBooLogger.debug("💡Reissue \(response)")
                 
                 switch response.result {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -68,13 +68,13 @@ actor DefaultTokenService: TokenService {
                     }
                     
                     Task {
-                        await self.debugTokenReissueSuccess(data)
+                        await self.tokenReissueSuccess(data)
                         continuation.resume(returning: ())
                     }
                     
                 case .failure(let error):
                     Task {
-                        await self.debugTokenReissueFailure()
+                        await self.tokenReissueFail()
                         continuation.resume(throwing: error)
                     }
                 }
@@ -82,16 +82,16 @@ actor DefaultTokenService: TokenService {
         }
     }
     
-    private func debugTokenReissueSuccess(_ data: TokenReissueResponseDTO) {
+    private func tokenReissueSuccess(_ data: TokenReissueResponseDTO) {
         ByeBooLogger.debug("토큰 재발급 완료")
         self.keychainService.save(key: .accessToken, token: data.accessToken)
         self.keychainService.save(key: .refreshToken, token: data.refreshToken)
     }
     
-    private func debugTokenReissueFailure() {
+    private func tokenReissueFail() {
         ByeBooLogger.debug("토큰 재발급 실패, 키체인 삭제 후 로그인으로 이동")
         clearKeychain()
-        DispatchQueue.main.async {
+        Task { @MainActor in
             NotificationCenter.default.post(name: .navigateLoginViewController, object: nil)
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -41,17 +41,18 @@ actor DefaultTokenService: TokenService {
     
     private func fetchAuthReissue() async throws {
         let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .refreshToken))
+        let endPoint: EndPoint = AuthAPI.reissue(header: header)
         ByeBooLogger.debug("토큰 재발급 시작")
         
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self else { return }
             
             AF.request(
-                AuthAPI.reissue(header: header).requestURL,
-                method: AuthAPI.reissue(header: header).method,
-                parameters: AuthAPI.reissue(header: header).bodyParameters,
-                encoding: AuthAPI.reissue(header: header).parameterEncoding,
-                headers: AuthAPI.reissue(header: header).headers.value
+                endPoint.requestURL,
+                method: endPoint.method,
+                parameters: endPoint.bodyParameters,
+                encoding: endPoint.parameterEncoding,
+                headers: endPoint.headers.value
             )
             .validate()
             .responseDecodable(of: BaseResponse<TokenReissueResponseDTO>.self) { [weak self] response in


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #361

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- #355 의 리뷰를 반영했습니다.

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### actor의 메인 스레드 실행 

개맹 님의 코드리뷰 중 .. 

<img width="794" height="306" alt="image" src="https://github.com/user-attachments/assets/8eb85231-b31a-4f40-9ee9-0853f04c5aae" />

일단 로그를 찍어서 확인했는데 메인 스레드에서 실행되고 있는게 맞았습니다 !!    
**액터 외부에서 실행되는게 아닌가**에 대해서는 제가 생각을 해봤는데요 ..    


> actor내에 정의된
> - stored, computed instance properties 
> - instance methods 
> - instance subscripts 는 기본적으로 모두 actor-isolated 상태이다. 

라고 합니다. 현재 TokenService actor 내에 선언된 건 var task, let keychain(상수라 논외), reissue 관련 인스턴스 메소드들입니다. 그래서 actor isolated 상태라고 생각했고, 그래서 메인 스레드에서 실행된다고 해서 액터 외부로 빠지는건 아니라고 생각했습니다. ....... (정확하지않음) 

하지만 그래도 메인 스레드를 점유하고 있는 것보다는 백그라운드에서 실행되는게 좋을 것 같아서 바꿔주었습니다.
근데 이 부분 코드를 건드리다보니 sendable 관련 경고가 사라져있더라구요..??? NetworkService에는 아직 이 경고가 남아있어서 확인해보면 조을 것 같습니다 ... 


## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://zeddios.tistory.com/1303

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
저 코드리뷰 보다가 저능통 느껴서 콩코롱시 강의 그냥 결제 갈겼습니다... 개강 전에 들어볼 수 있으면 좋겠네요.... 
