### PR TITLE
Feat/#383 공통퀘스트 작성 API 연결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooError.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Core/ByeBooError.swift
@@ -27,6 +27,7 @@ enum ByeBooError: Error, LocalizedError, Equatable {
     case configError
     case fileNotFound
     case nicknameViolation
+    case questViolation
     
     var errorDescription: String? {
         switch self {
@@ -68,6 +69,8 @@ enum ByeBooError: Error, LocalizedError, Equatable {
             return "파일을 찾을 수 없음"
         case .nicknameViolation:
             return "비속어나 부적절한 단어가 포함된 닉네임"
+        case .questViolation:
+            return "비속어나 부적절한 단어가 포함된 답변"
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
@@ -47,6 +47,10 @@ struct DataDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: ForbiddenWordInterface.self) { _ in
             return DefaultForbiddenWordRepository()
         }
+        
+        DIContainer.shared.register(type: CommonQuestInterface.self) { _ in
+            return DefaultCommonQuestRepository(network: networkService)
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/SaveCommonQuestRequestDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/SaveCommonQuestRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  SaveCommonQuest.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 3/1/26.
+//
+
+import Foundation
+
+struct SaveCommonQuestRequestDTO: Encodable {
+    let answer: String
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/CommonQuestAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/CommonQuestAPI.swift
@@ -1,0 +1,61 @@
+//
+//  CommonQuestAPI.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 3/1/26.
+//
+
+import Foundation
+
+import Alamofire
+
+enum CommonQuestAPI {
+    case postCommonQuest(questID: Int, dto: SaveCommonQuestRequestDTO)
+}
+
+extension CommonQuestAPI: EndPoint {
+    
+    var basePath: String {
+        return "/api/v1/common-quests"
+    }
+    
+    var path: String {
+        switch self {
+        case .postCommonQuest(let questID, _):
+            return "/\(questID)"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .postCommonQuest:
+            return .post
+        }
+    }
+    
+    var headers: HeaderType {
+        switch self {
+        case .postCommonQuest:
+            let keychainService = DefaultKeychainService()
+            return .withAuth(acessToken: keychainService.load(key: .accessToken))
+        }
+    }
+    
+    var parameterEncoding: any ParameterEncoding {
+        switch self {
+        case .postCommonQuest:
+            return JSONEncoding.default
+        }
+    }
+    
+    var queryParameters: [String : String]? {
+      nil
+    }
+    
+    var bodyParameters: Parameters? {
+        switch self {
+        case .postCommonQuest(_, let dto):
+            return try? dto.toDictionary()
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
@@ -1,0 +1,26 @@
+//
+//  CommonQuestRepository.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 3/1/26.
+//
+
+import Foundation
+
+struct DefaultCommonQuestRepository: CommonQuestInterface {
+    private let network: NetworkService
+    
+    init(
+        network: NetworkService
+    ) {
+        self.network = network
+    }
+    
+    func saveCommonQuest(questID: Int, answer: String) async throws {
+        let saveCommonQuestRequestDTO: SaveCommonQuestRequestDTO = .init(answer: answer)
+        
+        let _ = try await network.request(
+            CommonQuestAPI.postCommonQuest(questID: questID, dto: saveCommonQuestRequestDTO)
+        )
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -21,10 +21,10 @@ struct DomainDependencyAssembler: DependencyAssembler {
               let questRepository = DIContainer.shared.resolve(type: QuestsInterface.self),
               let authRepository = DIContainer.shared.resolve(type: AuthInterface.self),
               let forbiddenWordRepository = DIContainer.shared.resolve(type: ForbiddenWordInterface.self)
-        else {
-            ByeBooLogger.error(ByeBooError.DIFailedError)
-            return
-        }
+              let commonQuestRepository = DIContainer.shared.resolve(type: CommonQuestInterface.self) else {
+                  ByeBooLogger.error(ByeBooError.DIFailedError)
+                  return
+              }
         
         DIContainer.shared.register(type: FetchUserJourneyUseCase.self) { _ in
             return DefaultFetchUserJourneyUseCase(repository: userRepository)
@@ -141,7 +141,7 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: FetchCommonQuestByDateUseCase.self) { _ in
             return DefaultFetchCommonQuestByDateUseCase(repository: questRepository)
         }
-              
+        
         DIContainer.shared.register(type: AutoLoginUseCase.self) { _ in
             return DefaultAutoLoginUseCase(repository: authRepository)
         }
@@ -168,6 +168,10 @@ struct DomainDependencyAssembler: DependencyAssembler {
         
         DIContainer.shared.register(type: IsForbiddenWordUseCase.self) { _ in
             return DefaultIsForbiddenWordUseCase(repository: forbiddenWordRepository)
+        }
+        
+        DIContainer.shared.register(type: SaveCommonQuestUseCase.self) { _ in
+            return DefaultSaveCommonQuestUseCase(repository: commonQuestRepository)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -20,7 +20,7 @@ struct DomainDependencyAssembler: DependencyAssembler {
         guard let userRepository = DIContainer.shared.resolve(type: UsersInterface.self),
               let questRepository = DIContainer.shared.resolve(type: QuestsInterface.self),
               let authRepository = DIContainer.shared.resolve(type: AuthInterface.self),
-              let forbiddenWordRepository = DIContainer.shared.resolve(type: ForbiddenWordInterface.self)
+              let forbiddenWordRepository = DIContainer.shared.resolve(type: ForbiddenWordInterface.self),
               let commonQuestRepository = DIContainer.shared.resolve(type: CommonQuestInterface.self) else {
                   ByeBooLogger.error(ByeBooError.DIFailedError)
                   return

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/CommonQuestAnswersEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/CommonQuestAnswersEntity.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct CommonQuestAnswersEntity {
     let question: String
+    let questID: Int
     let answerCount: Int
     let isAnswered: Bool
     let answers: [CommonQuestAnswerEntity]
@@ -26,6 +27,7 @@ extension CommonQuestAnswersEntity {
     static func stub() -> Self {
         .init(
             question: "연애에서 반복된 문제 패턴 3가지를 생각해보아요",
+            questID: 1,
             answerCount: 5,
             isAnswered: false,
             answers: [.stub(), .stub(), .stub(), .stub(), .stub()]

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/CommonQuestInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/CommonQuestInterface.swift
@@ -1,0 +1,12 @@
+//
+//  CommonQuestInterface.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 3/1/26.
+//
+
+import Foundation
+
+protocol CommonQuestInterface {
+    func saveCommonQuest(questID: Int, answer: String) async throws
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/SaveCommonQuestUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/SaveCommonQuestUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  SaveCommonQuestUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 3/3/26.
+//
+
+import Foundation
+
+protocol SaveCommonQuestUseCase {
+    func execute(questID: Int, answer: String) async throws
+}
+
+struct DefaultSaveCommonQuestUseCase: SaveCommonQuestUseCase {
+    private let repository: CommonQuestInterface
+    
+    init(repository: CommonQuestInterface) {
+        self.repository = repository
+    }
+    
+    func execute(questID: Int, answer: String) async throws {
+        try await repository.saveCommonQuest(questID: questID, answer: answer)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/BottomSheet/EmotionBottomSheet/EmotionBottomSheetViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/BottomSheet/EmotionBottomSheet/EmotionBottomSheetViewController.swift
@@ -78,7 +78,7 @@ final class EmotionBottomSheetViewController: BaseViewController {
         }
         
         self.delegate?.saveEmotionState(emotionState: selectedEmotion)
-        self.delegate?.saveQuest()
+        self.delegate?.saveQuest(isEdit: false, isCommonQuest: false)
         rootView.confirmButton.isEnabled = false
         
         let property = QuestEvents.QuestWriteFinishWithEmotionProperty(

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/ModalBuilder.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/ModalBuilder.swift
@@ -34,6 +34,6 @@ struct ModalBuilder {
     }
     
     func dismiss() {
-        modalViewController.dismiss(animated: false)
+        modalViewController.dismiss(animated: true)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/TopTabBar/TopTabBar.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/TopTabBar/TopTabBar.swift
@@ -54,7 +54,12 @@ final class TopTabBar: UIStackView {
 }
 
 extension TopTabBar {
-    
+    func select(index: Int) {
+         guard itemViews.indices.contains(index) else { return }
+         didTap?(index)
+         updateTabBar(tag: index)
+     }
+
     @objc
     private func barDidTap(_ sender: UITapGestureRecognizer) {
         guard let tag = sender.view?.tag else {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/TopTabBar/TopTabBar.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/TopTabBar/TopTabBar.swift
@@ -55,10 +55,9 @@ final class TopTabBar: UIStackView {
 
 extension TopTabBar {
     func select(index: Int) {
-         guard itemViews.indices.contains(index) else { return }
-         didTap?(index)
-         updateTabBar(tag: index)
-     }
+        guard itemViews.indices.contains(index) else { return }
+        updateTabBar(tag: index)
+    }
 
     @objc
     private func barDidTap(_ sender: UITapGestureRecognizer) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/Coordinator/QuestCheckCoordinator.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/Coordinator/QuestCheckCoordinator.swift
@@ -84,7 +84,7 @@ final class QuestCheckCoordinator: QuestCheckCoordinating {
     
     private func moveToWriteActivity(questID: Int, questNumber: Int, questType: QuestType) {
         let activationQuestViewController = ViewControllerFactory.shared.makeWriteActiveTypeQuestViewController()
-        activationQuestViewController.configure(questID, questNumber, questType)
+        activationQuestViewController.configure(questID, questNumber, questType, nil)
         rootViewController?.tabBarController?.tabBar.isHidden = true
         rootViewController?.navigationController?.pushViewController(activationQuestViewController, animated: false)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/Coordinator/QuestCheckCoordinator.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/Coordinator/QuestCheckCoordinator.swift
@@ -77,7 +77,7 @@ final class QuestCheckCoordinator: QuestCheckCoordinating {
     
     private func moveToWriteQuestion(questID: Int, questNumber: Int, questType: QuestType) {
         let questionQuestViewController = ViewControllerFactory.shared.makeWriteQuestionTypeQuestViewController()
-        questionQuestViewController.configure(questID, questNumber, questType)
+        questionQuestViewController.configure(questID, questNumber, questType, nil)
         rootViewController?.tabBarController?.tabBar.isHidden = true
         rootViewController?.navigationController?.pushViewController(questionQuestViewController, animated: false)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestHeaderView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestHeaderView.swift
@@ -75,7 +75,7 @@ final class ArchiveQuestHeaderView: BaseView {
                 color: .grayscale100,
                 numberOfLines: 0
             )
-            $0.lineBreakMode = .byWordWrapping
+            $0.lineBreakStrategy = .hangulWordPriority 
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestView.swift
@@ -88,8 +88,8 @@ final class ArchiveQuestView: BaseView {
         }
         
         contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.width.equalToSuperview()
+            $0.edges.equalTo(scrollView.contentLayoutGuide)
+            $0.width.equalTo(scrollView.frameLayoutGuide)
             $0.height.greaterThanOrEqualTo(scrollView.frameLayoutGuide)
         }
         
@@ -108,15 +108,13 @@ final class ArchiveQuestView: BaseView {
         
         textBoxView.snp.makeConstraints {
             if let photoBoxView {
-                if !descriptionText.isEmpty {
-                    $0.top.equalTo(photoBoxView.snp.bottom).offset(20.adjustedH)
-                }
+                $0.top.equalTo(photoBoxView.snp.bottom).offset(20.adjustedH)
             } else {
                 $0.top.equalTo(headerView.snp.bottom).offset(20.adjustedH)
             }
             $0.horizontalEdges.equalToSuperview().inset(24.adjustedW)
         }
-    
+        
         feelView.snp.makeConstraints {
             $0.top.equalTo(textBoxView.snp.bottom).offset(20.adjustedH)
             $0.horizontalEdges.equalToSuperview()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Archive/ArchiveQuestView.swift
@@ -148,9 +148,9 @@ extension ArchiveQuestView {
         case .activation:
             guard let photoBoxView else { return }
             
-            if let url = URL(string: entity.imageUrl!) {
-                photoBoxView.kf.setImage(with: url)
-            }
+            guard let imageUrl = entity.imageUrl,
+                let url = URL(string: imageUrl) else { return }
+            photoBoxView.kf.setImage(with: url)
             
             if entity.answer.isEmpty {
                 textBoxView.removeFromSuperview()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Cells/CommonQuestContentCell.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Cells/CommonQuestContentCell.swift
@@ -72,7 +72,7 @@ final class CommonQuestContentCell: UITableViewCell {
     }
     
     private func setUI() {
-       addSubviews(
+        contentView.addSubviews(
             questionView,
             guideTimeLabel,
             moveWriteAnswerButton,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/View/ActivationType/WriteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/View/ActivationType/WriteActiveTypeQuestView.swift
@@ -188,7 +188,6 @@ extension WriteActiveTypeQuestView {
     func updateQuestTitle(
         questScope: QuestScope? = nil,
         questNumber: Int,
-        questStyle: String,
         question: String
     ) {
         headerView.bind(

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/View/ActivationType/WriteActiveTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/View/ActivationType/WriteActiveTypeQuestView.swift
@@ -180,7 +180,7 @@ extension WriteActiveTypeQuestView: WriteQuestBaseProtocol {
         questTextField.textCountLabel
     }
     var tipTagView: UIView {
-        headerView.tipTag
+        headerView.tipTag ?? UIView()
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/View/QuestionType/WriteQuestionTypeQuestView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/View/QuestionType/WriteQuestionTypeQuestView.swift
@@ -14,7 +14,7 @@ final class WriteQuestionTypeQuestView: BaseView {
     private let questScope: QuestScope
     private(set) var scrollView = UIScrollView()
     private let contentView = UIView()
-    private(set) var headerView = WriteQuestTitleView(questScope: .personal, questNum: 0, title: "")
+    private(set) var headerView = WriteQuestTitleView(questNum: 0, title: "")
     private let divider = UIView()
     private(set) var questTextField = QuestTextField(type: .question)
     
@@ -100,7 +100,7 @@ extension WriteQuestionTypeQuestView: WriteQuestBaseProtocol {
         questTextField.textCountLabel
     }
     var tipTagView: UIView {
-        headerView.tipTag
+        headerView.tipTag ?? UIView()
     }
 }
 
@@ -108,7 +108,6 @@ extension WriteQuestionTypeQuestView {
     func updateQuestTitle(
         questScope: QuestScope,
         questNumber: Int,
-        questStyle: String,
         question: String
     ) {
         headerView.bind(

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/WriteQuestTitleView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/WriteQuestTitleView.swift
@@ -15,7 +15,7 @@ final class WriteQuestTitleView: BaseView {
     private var questNum: Int
     private let questNumLabel =  UILabel()
     private let titleLabel = UILabel()
-    private(set) var tipTag: ByeBooTipTag?
+    private(set) var tipTag = ByeBooTipTag(text: "작성 TIP")
     
     init(
         questScope: QuestScope? = nil,
@@ -30,13 +30,11 @@ final class WriteQuestTitleView: BaseView {
             switch questScope {
             case .common:
                 questNumLabel.text = "공통퀘스트"
-                tipTag = nil
             case .personal:
                 questNumLabel.text = "\(questNum)번째 퀘스트"
-                tipTag = ByeBooTipTag(text: "작성 TIP")
             }
         }
-    
+        
         super.init(frame: .zero)
     }
     
@@ -45,10 +43,7 @@ final class WriteQuestTitleView: BaseView {
     }
     
     override func setUI() {
-        addSubviews(questNumLabel, titleLabel)
-        if let tipTag {
-            addSubview(tipTag)
-        }
+        addSubviews(questNumLabel, titleLabel, tipTag)
     }
     
     override func setStyle() {
@@ -64,11 +59,16 @@ final class WriteQuestTitleView: BaseView {
             $0.lineBreakMode = .byWordWrapping
         }
         
-        if let tipTag {
-            tipTag.do {
-                $0.isUserInteractionEnabled = true
+        
+        tipTag.do {
+            $0.isUserInteractionEnabled = true
+            if questScope == .common {
+                $0.isHidden = true
+            } else {
+                $0.isHidden = false
             }
         }
+        
     }
     
     override func setLayout() {
@@ -81,20 +81,19 @@ final class WriteQuestTitleView: BaseView {
             $0.top.equalTo(questNumLabel.snp.bottom).offset(12.adjustedH)
             $0.width.equalTo(327.adjustedW)
             $0.centerX.equalToSuperview()
-            if tipTag == nil {
+            if questScope == .common {
                 $0.bottom.equalToSuperview().inset(16.adjustedH)
             }
         }
         
-        if let tipTag {
-            tipTag.snp.makeConstraints {
-                $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
-                $0.width.equalTo(76.adjustedW)
-                $0.height.equalTo(24.adjustedH)
-                $0.centerX.equalToSuperview()
-                $0.bottom.equalToSuperview().inset(16.adjustedH)
-            }
+        tipTag.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
+            $0.width.equalTo(76.adjustedW)
+            $0.height.equalTo(24.adjustedH)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(16.adjustedH)
         }
+        
     }
 }
 
@@ -104,16 +103,21 @@ extension WriteQuestTitleView {
         self.titleLabel.text = title
         
         if let questScope {
-            self.questNumLabel.text = {
-                switch questScope {
-                case .common:
-                    "공통퀘스트"
-                case .personal:
-                    "\(questNum)번째 퀘스트"
+            switch questScope {
+            case .common:
+                questNumLabel.text = "공통퀘스트"
+                tipTag.isHidden = true
+                
+                titleLabel.snp.makeConstraints {
+                    $0.top.equalTo(questNumLabel.snp.bottom).offset(12.adjustedH)
+                    $0.width.equalTo(327.adjustedW)
+                    $0.centerX.equalToSuperview()
+                    $0.bottom.equalToSuperview().inset(16.adjustedH)
                 }
-            }()
-        } else {
-            self.questNumLabel.text = "\(questNum)번째 퀘스트"
+            case .personal:
+                questNumLabel.text = "\(questNum)번째 퀘스트"
+                tipTag.isHidden = false
+            }
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/WriteQuestTitleView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/WriteQuestTitleView.swift
@@ -15,7 +15,7 @@ final class WriteQuestTitleView: BaseView {
     private var questNum: Int
     private let questNumLabel =  UILabel()
     private let titleLabel = UILabel()
-    let tipTag = ByeBooTipTag(text: "작성 TIP")
+    private(set) var tipTag: ByeBooTipTag?
     
     init(
         questScope: QuestScope? = nil,
@@ -27,25 +27,28 @@ final class WriteQuestTitleView: BaseView {
         self.titleLabel.text = title
         
         if let questScope {
-            self.questNumLabel.text = {
-                switch questScope {
-                case .common:
-                    "공통퀘스트"
-                case .personal:
-                    "\(questNum)번째 퀘스트"
-                }
-            }()
+            switch questScope {
+            case .common:
+                questNumLabel.text = "공통퀘스트"
+                tipTag = nil
+            case .personal:
+                questNumLabel.text = "\(questNum)번째 퀘스트"
+                tipTag = ByeBooTipTag(text: "작성 TIP")
+            }
         }
-        
+    
         super.init(frame: .zero)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override func setUI() {
-        addSubviews(questNumLabel, titleLabel, tipTag)
+        addSubviews(questNumLabel, titleLabel)
+        if let tipTag {
+            addSubview(tipTag)
+        }
     }
     
     override func setStyle() {
@@ -61,8 +64,10 @@ final class WriteQuestTitleView: BaseView {
             $0.lineBreakMode = .byWordWrapping
         }
         
-        tipTag.do {
-            $0.isUserInteractionEnabled = true
+        if let tipTag {
+            tipTag.do {
+                $0.isUserInteractionEnabled = true
+            }
         }
     }
     
@@ -76,14 +81,19 @@ final class WriteQuestTitleView: BaseView {
             $0.top.equalTo(questNumLabel.snp.bottom).offset(12.adjustedH)
             $0.width.equalTo(327.adjustedW)
             $0.centerX.equalToSuperview()
+            if tipTag == nil {
+                $0.bottom.equalToSuperview().inset(16.adjustedH)
+            }
         }
         
-        tipTag.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
-            $0.width.equalTo(76.adjustedW)
-            $0.height.equalTo(24.adjustedH)
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(16.adjustedH)
+        if let tipTag {
+            tipTag.snp.makeConstraints {
+                $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
+                $0.width.equalTo(76.adjustedW)
+                $0.height.equalTo(24.adjustedH)
+                $0.centerX.equalToSuperview()
+                $0.bottom.equalToSuperview().inset(16.adjustedH)
+            }
         }
     }
 }
@@ -105,5 +115,5 @@ extension WriteQuestTitleView {
         } else {
             self.questNumLabel.text = "\(questNum)번째 퀘스트"
         }
-   }
+    }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/WriteQuestTitleView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/Write/WriteQuestTitleView.swift
@@ -33,6 +33,8 @@ final class WriteQuestTitleView: BaseView {
             case .personal:
                 questNumLabel.text = "\(questNum)번째 퀘스트"
             }
+        } else {
+            questNumLabel.text = "\(questNum)번째 퀘스트"
         }
         
         super.init(frame: .zero)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
@@ -17,7 +17,7 @@ enum ArchiveViewControllerEntryPoint {
 
 final class ArchiveQuestViewController: BaseViewController {
         
-    private var rootView = ArchiveQuestView(type: .activation)
+    private var rootView = ArchiveQuestView(type: .question)
     private let viewModel: ArchiveQuestViewModel
     private var cancellables = Set<AnyCancellable>()
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
@@ -79,9 +79,14 @@ extension CommonQuestViewController: DateNavigatorDelegate {
     
     @objc
     private func moveWriteAnswerButtonDidTap() {
-        
+        let questID = viewModel.questID
+        let writeCommonQuestViewController = ViewControllerFactory.shared.makeWriteQuestionTypeQuestViewController()
+        writeCommonQuestViewController.navigationItem.hidesBackButton = true
+        writeCommonQuestViewController.questScope = .common
+        writeCommonQuestViewController.configure(questID, nil, QuestType.question, viewModel.question)
+        self.navigationController?.pushViewController(writeCommonQuestViewController, animated: false)
     }
-    
+
     func dateDidChanged(to date: String) {
         let _ = viewModel.action(
             .moveDateButtonDidTap(selectedDate: date)
@@ -91,7 +96,7 @@ extension CommonQuestViewController: DateNavigatorDelegate {
 }
 
 extension CommonQuestViewController: UITableViewDelegate {
-    
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.row == 0 || !viewModel.isExistAnswer {
             return

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
@@ -41,10 +41,16 @@ final class ParentQuestViewController<T: TabItem>: BaseViewController {
             containerView
         )
     }
+    
+    func selectTab(index: Int) {
+        guard controllers.indices.contains(index) else { return }
+        show(controllers[index])
+        tabBar.select(index: index)
+    }
 }
 
 extension ParentQuestViewController {
-
+    
     private func setLayout() {
         tabBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20.adjustedH)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -85,7 +85,7 @@ final class WriteActiveTypeQuestViewController: WriteQuestBaseViewController<Wri
         }
         
         if questMode == .edit {
-            saveQuest()
+            saveQuest(isEdit: true, isCommonQuest: nil)
         } else {
             ByeBooLogger.debug(questID)
             bottomSheetViewController.bind(questNumber: questID, questType: questType)
@@ -246,7 +246,7 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
         self.emotionState = emotionState.key
     }
     
-    func saveQuest() {
+    func saveQuest(isEdit: Bool, isCommonQuest: Bool?) {
         var finalImageKey: String = ""
         
         if questMode == .edit && isImageChanged {
@@ -266,7 +266,7 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
             emotionState: self.emotionState,
             image: self.image,
             imageKey: finalImageKey.isEmpty ? originalImageKey : finalImageKey,
-            isEdit: questMode == .edit ? true : false,
+            isEdit: isEdit,
             isImageChanged: isImageChanged
         )
         )

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -130,7 +130,6 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
                     self?.questNumber = quest.questNumber
                     self?.rootView.updateQuestTitle(
                         questNumber: quest.questNumber,
-                        questStyle: quest.questStyle,
                         question: quest.question
                     )
                 case .failure(let error):
@@ -176,7 +175,6 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
                 case .success(let quest):
                     self?.rootView.updateQuestTitle(
                         questNumber: quest.questNumber,
-                        questStyle: quest.questStyle,
                         question: quest.question
                     )
                 case .failure(let error):
@@ -274,10 +272,17 @@ extension WriteActiveTypeQuestViewController: BottomSheetProtocol {
 }
 
 extension WriteActiveTypeQuestViewController {
-    func configure(_ questID: Int, _ questNumber: Int, _ questType: QuestType) {
+    func configure(_ questID: Int, _ questNumber: Int, _ questType: QuestType, _ questionTitle: String?) {
         self.questID = questID
         self.questNumber = questNumber
         self.questType = questType
+        
+        self.questType = questType
+        rootView.updateQuestTitle(
+            questScope: .personal,
+            questNumber: self.questNumber,
+            question: questionTitle ?? ""
+        )
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -177,6 +177,17 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
             }
             .store(in: &cancellables)
         
+        viewModel.output.isForbiddenWordPublisher
+            .sink { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success:
+                    ByeBooLogger.debug("공통 퀘스트 비속어 없음")
+                case .failure(let error):
+                    presentToastMessage(type: .questViolation)
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -137,61 +137,9 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
                     guard let self else { return }
                     switch questScope {
                     case .personal:
-                        self.bottomSheetViewController.dismiss(animated: true)
-                        
-                        ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
-                        let viewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
-                        viewController.entryViewController = .writeQuest
-                        viewController.configure(questID: self.questID, questType: .question)
-                        
-                        CATransaction.begin()
-                        CATransaction.setCompletionBlock {
-                            let modal = ModalBuilder(
-                                modalView: QuestCompleteModal(),
-                                action: nil,
-                                rootViewController: self
-                            )
-                            modal.present()
-                            
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                modal.dismiss()
-                            }
-                        }
-                        self.navigationController?.pushViewController(viewController, animated: true)
-                        CATransaction.commit()
-                        
+                        personalQuestComplete()
                     case .common:
-                        let viewController = ByeBooTabBar()
-                        viewController.selectedIndex = 1
-                        guard let questMaintab = viewController.viewControllers?[1] as? UINavigationController,
-                              let commonQuestTab = questMaintab.viewControllers.first as? ParentQuestViewController<QuestTabItem> else { return }
-                        
-                        commonQuestTab.loadViewIfNeeded()
-                        commonQuestTab.selectTab(index: 1)
-                        
-                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                            
-                            ViewControllerUtils.setRootViewController(
-                                window: window,
-                                viewController: viewController,
-                                withAnimation: true
-                            )
-                        }
-                        
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
-                            let modal = ModalBuilder(
-                                modalView: QuestCompleteModal(),
-                                action: nil,
-                                rootViewController: viewController
-                            )
-                            modal.present()
-                            
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                modal.dismiss()
-                            }
-                        }
-                        
+                        commonQuestComplete()
                     }
                 case .failure(let error):
                     self?.handleError(error)
@@ -271,6 +219,64 @@ extension WriteQuestionTypeQuestViewController {
             questNumber: self.questNumber,
             question: questionTitle ?? ""
         )
+    }
+    
+    private func personalQuestComplete() {
+        ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
+    
+        bottomSheetViewController.dismiss(animated: true) {
+            let archiveViewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
+            archiveViewController.entryViewController = .writeQuest
+            archiveViewController.configure(questID: self.questID, questType: .question)
+            
+            CATransaction.begin()
+            CATransaction.setCompletionBlock {
+                let modal = ModalBuilder(
+                    modalView: QuestCompleteModal(),
+                    action: nil,
+                    rootViewController: self
+                )
+                modal.present()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    modal.dismiss()
+                }
+            }
+            self.navigationController?.pushViewController(archiveViewController, animated: true)
+            CATransaction.commit()
+        }
+    }
+    
+    private func commonQuestComplete() {
+        let viewController = ByeBooTabBar()
+        viewController.selectedIndex = 1
+        guard let questMaintab = viewController.viewControllers?[1] as? UINavigationController,
+              let commonQuestTab = questMaintab.viewControllers.first as? ParentQuestViewController<QuestTabItem> else { return }
+        
+        commonQuestTab.loadViewIfNeeded()
+        commonQuestTab.selectTab(index: 1)
+        
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+            
+            ViewControllerUtils.setRootViewController(
+                window: window,
+                viewController: viewController,
+                withAnimation: true
+            )
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+            let modal = ModalBuilder(
+                modalView: QuestCompleteModal(),
+                action: nil,
+                rootViewController: viewController
+            )
+            modal.present()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                modal.dismiss()
+            }
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -41,7 +41,7 @@ final class WriteQuestionTypeQuestViewController: WriteQuestBaseViewController<W
         bind()
         setDelegate()
         
-        if questMode == .write {
+        if questMode == .write && questScope == .personal {
             viewModel.action(.viewDidLoad(quesetID: self.questID))
         }
         
@@ -73,14 +73,16 @@ final class WriteQuestionTypeQuestViewController: WriteQuestBaseViewController<W
     override func confirmButtonDidTap() {
         answerText = rootView.questTextField.textView.text
         
-        if questMode == .edit {
-            saveQuest()
-        } else {
-            switch questScope {
-            case .common:
-                //TODO: 공통인 경우 뷰 연결
-                ByeBooLogger.debug("common 완료")
-            case .personal:
+        switch questScope {
+        case .common:
+            let isEdit = questMode == .edit ? true : false
+            saveQuest(isEdit: isEdit, isCommonQuest: true)
+            ByeBooLogger.debug("common quest 완료")
+            
+        case .personal:
+            if questMode == .edit {
+                saveQuest(isEdit: true, isCommonQuest: false)
+            } else {
                 bottomSheetViewController.bind(questNumber: questNumber, questType: questType)
                 bottomSheetViewController.delegate = self
                 if let sheet = bottomSheetViewController.sheetPresentationController{
@@ -119,7 +121,6 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
                     self.rootView.updateQuestTitle(
                         questScope: self.questScope,
                         questNumber: quest.questNumber,
-                        questStyle: quest.questStyle,
                         question: quest.question
                     )
                 case .failure(let error):
@@ -134,29 +135,70 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
                 switch result {
                 case .success(()):
                     guard let self else { return }
-                    self.bottomSheetViewController.dismiss(animated: true) {
-                        let modal = ModalBuilder(
-                            modalView: QuestCompleteModal(),
-                            action: nil,
-                            rootViewController: self
-                        )
-                        modal.present()
+                    switch questScope {
+                    case .personal:
+                        self.bottomSheetViewController.dismiss(animated: true)
                         
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            modal.dismiss()
+                        ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
+                        let viewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
+                        viewController.entryViewController = .writeQuest
+                        viewController.configure(questID: self.questID, questType: .question)
+                        
+                        CATransaction.begin()
+                        CATransaction.setCompletionBlock {
+                            let modal = ModalBuilder(
+                                modalView: QuestCompleteModal(),
+                                action: nil,
+                                rootViewController: self
+                            )
+                            modal.present()
                             
-                            ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
-                            let viewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
-                            viewController.entryViewController = .writeQuest
-                            viewController.configure(questID: self.questID, questType: .question)
-                            self.navigationController?.pushViewController(viewController, animated: true)
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                modal.dismiss()
+                            }
                         }
+                        self.navigationController?.pushViewController(viewController, animated: true)
+                        CATransaction.commit()
+                        
+                    case .common:
+                        let viewController = ByeBooTabBar()
+                        viewController.selectedIndex = 1
+                        guard let questMaintab = viewController.viewControllers?[1] as? UINavigationController,
+                              let commonQuestTab = questMaintab.viewControllers.first as? ParentQuestViewController<QuestTabItem> else { return }
+                        
+                        commonQuestTab.loadViewIfNeeded()
+                        commonQuestTab.selectTab(index: 1)
+                        
+                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                            
+                            ViewControllerUtils.setRootViewController(
+                                window: window,
+                                viewController: viewController,
+                                withAnimation: true
+                            )
+                        }
+                        
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                            let modal = ModalBuilder(
+                                modalView: QuestCompleteModal(),
+                                action: nil,
+                                rootViewController: viewController
+                            )
+                            modal.present()
+                            
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                modal.dismiss()
+                            }
+                        }
+                        
                     }
                 case .failure(let error):
                     self?.handleError(error)
                 }
             }
             .store(in: &cancellables)
+        
         
         viewModel.output.didSuccessEditPublisher
             .receive(on: DispatchQueue.main)
@@ -186,6 +228,7 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
                 }
             }
             .store(in: &cancellables)
+        
     }
 }
 
@@ -194,23 +237,25 @@ extension WriteQuestionTypeQuestViewController: BottomSheetProtocol {
         self.emotionState = emotionState.key
     }
     
-    func saveQuest() {
+    func saveQuest(isEdit: Bool, isCommonQuest: Bool?) {
         ByeBooLogger.debug("text: \(answerText)")
         ByeBooLogger.debug("emtionState: \(emotionState)")
         ByeBooLogger.debug("questID: \(questID)")
-        
-        viewModel.action(.presentCompleteView(
-            questID: questID,
-            answer: answerText,
-            emotionState: emotionState,
-            isEdit: questMode == .edit ? true : false
-        )
-        )
+        if let isCommonQuest = isCommonQuest {
+            viewModel.action(.saveQuest(
+                questID: questID,
+                answer: answerText,
+                emotionState: emotionState,
+                isEdit: isEdit,
+                isCommonQuest: isCommonQuest
+            )
+            )
+        }
     }
 }
 
 extension WriteQuestionTypeQuestViewController {
-    func configure(_ questID: Int, _ questNumber: Int?, _ questType: QuestType) {
+    func configure(_ questID: Int, _ questNumber: Int?, _ questType: QuestType, _ questionTitle: String?) {
         self.questID = questID
         
         if let questNumber {
@@ -221,6 +266,11 @@ extension WriteQuestionTypeQuestViewController {
         }
         
         self.questType = questType
+        rootView.updateQuestTitle(
+            questScope: self.questScope,
+            questNumber: self.questNumber,
+            question: questionTitle ?? ""
+        )
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -58,6 +58,10 @@ extension CommonQuestViewModel {
         commonQuest?.question ?? ""
     }
     
+    var questID: Int {
+        commonQuest?.questID ?? 1 
+    }
+    
     var answersCount: Int {
         commonQuest?.answerCount ?? 0
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/WriteQuestTypeViewModel.swift
@@ -19,33 +19,37 @@ struct WriteQuestionTypeViewModel: ViewModelType {
     private let editQuestTypeUseCase: EditQuestTypeUseCase
     private let isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase
     private let saveCommonQuestUseCase: SaveCommonQuestUseCase
+    private let isForbiddenWordUseCase: IsForbiddenWordUseCase
     
     private let questInfoResultSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let questInfoWhenEditModeSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let didSuccessPostSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private let didSuccessEditSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     private let isValidTextSubject: PassthroughSubject<Bool, Never> = .init()
+    private let isForbiddenWordSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
     
     init(
         saveQuestTypeUseCase:  SaveQuestTypeUseCase,
         getQuestInfoUseCase: GetQuestInfoUseCase,
         editQuestTypeUseCase: EditQuestTypeUseCase,
         isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase,
-        saveCommonQuestUseCase: SaveCommonQuestUseCase
-        
+        saveCommonQuestUseCase: SaveCommonQuestUseCase,
+        isForbiddenWordUseCase: IsForbiddenWordUseCase
     ){
         self.saveQuestTypeUseCase = saveQuestTypeUseCase
         self.getQuestInfoUseCase = getQuestInfoUseCase
         self.editQuestTypeUseCase = editQuestTypeUseCase
         self.isValidQuestAnswerUseCase = isValidQuestAnswerUseCase
         self.saveCommonQuestUseCase = saveCommonQuestUseCase
+        self.isForbiddenWordUseCase = isForbiddenWordUseCase
         
         output = Output(
             questInfoResultPublisher: questInfoResultSubject.eraseToAnyPublisher(),
             didSuccessPostPublisher: didSuccessPostSubject.eraseToAnyPublisher(),
             questInfoWhenEditModeResultPublisher: questInfoWhenEditModeSubject.eraseToAnyPublisher(),
             didSuccessEditPublisher: didSuccessEditSubject.eraseToAnyPublisher(),
-            isValidTextPublisher: isValidTextSubject.eraseToAnyPublisher()
+            isValidTextPublisher: isValidTextSubject.eraseToAnyPublisher(),
+            isForbiddenWordPublisher: isForbiddenWordSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -64,6 +68,7 @@ extension WriteQuestionTypeViewModel {
         let questInfoWhenEditModeResultPublisher: AnyPublisher<Result<QuestInfoEntity, ByeBooError>, Never>
         let didSuccessEditPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
         let isValidTextPublisher: AnyPublisher<Bool, Never>
+        let isForbiddenWordPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -77,6 +82,11 @@ extension WriteQuestionTypeViewModel {
             isEdit,
             isCommonQuest
         ):
+            if isCommonQuest && isForbiddenWordUseCase.execute(word: answer) {
+                  isForbiddenWordSubject.send(.failure(.questViolation))
+                  return
+              }
+            
             if isCommonQuest {
                 if isEdit {
                     // 수정 api 연결

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/WriteQuestTypeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/WriteQuestTypeViewModel.swift
@@ -18,6 +18,7 @@ struct WriteQuestionTypeViewModel: ViewModelType {
     private let getQuestInfoUseCase: GetQuestInfoUseCase
     private let editQuestTypeUseCase: EditQuestTypeUseCase
     private let isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase
+    private let saveCommonQuestUseCase: SaveCommonQuestUseCase
     
     private let questInfoResultSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
     private let questInfoWhenEditModeSubject: PassthroughSubject<Result<QuestInfoEntity, ByeBooError>, Never> = .init()
@@ -29,13 +30,15 @@ struct WriteQuestionTypeViewModel: ViewModelType {
         saveQuestTypeUseCase:  SaveQuestTypeUseCase,
         getQuestInfoUseCase: GetQuestInfoUseCase,
         editQuestTypeUseCase: EditQuestTypeUseCase,
-        isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase
+        isValidQuestAnswerUseCase: IsValidQuestAnswerUseCase,
+        saveCommonQuestUseCase: SaveCommonQuestUseCase
         
     ){
         self.saveQuestTypeUseCase = saveQuestTypeUseCase
         self.getQuestInfoUseCase = getQuestInfoUseCase
         self.editQuestTypeUseCase = editQuestTypeUseCase
         self.isValidQuestAnswerUseCase = isValidQuestAnswerUseCase
+        self.saveCommonQuestUseCase = saveCommonQuestUseCase
         
         output = Output(
             questInfoResultPublisher: questInfoResultSubject.eraseToAnyPublisher(),
@@ -50,7 +53,7 @@ struct WriteQuestionTypeViewModel: ViewModelType {
 extension WriteQuestionTypeViewModel {
     enum Input {
         case viewDidLoad(quesetID: Int)
-        case presentCompleteView(questID: Int, answer: String, emotionState: String?, isEdit: Bool)
+        case saveQuest(questID: Int, answer: String, emotionState: String?, isEdit: Bool, isCommonQuest: Bool)
         case viewDidLoadWhenEditMode(questID: Int)
         case textFieldEditing(answerText: String, text: String)
     }
@@ -67,18 +70,31 @@ extension WriteQuestionTypeViewModel {
         switch trigger {
         case .viewDidLoad(let questID), .viewDidLoadWhenEditMode(let questID):
             getQuestInfo(questID: questID)
-        case let .presentCompleteView(
+        case let .saveQuest(
             questID,
             answer,
             emotionState,
-            isEdit
+            isEdit,
+            isCommonQuest
         ):
+            if isCommonQuest {
+                if isEdit {
+                    // 수정 api 연결
+                } else {
+                    saveCommonQuest(questID: questID, answer: answer)
+                }
+                return
+            }
+            
             if isEdit {
                 editQuestType(questID: questID, answer: answer)
-            } else {
-                guard let emotionState = emotionState else { return }
-                postQuestType(questID: questID, answer: answer, emotionState: emotionState)
+                return
             }
+            
+            guard let emotionState else { return }
+            postQuestType(questID: questID, answer: answer, emotionState: emotionState)
+            
+            
         case .textFieldEditing(let answerText, let text):
             isValidText(previousText: answerText, changingText: text)
         }
@@ -125,6 +141,21 @@ extension WriteQuestionTypeViewModel {
                     return
                 }
                 didSuccessEditSubject.send(.failure(error as ByeBooError))
+                ByeBooLogger.error(error)
+            }
+        }
+    }
+    
+    private func saveCommonQuest(questID: Int, answer: String) {
+        Task {
+            do {
+                try await saveCommonQuestUseCase.execute(questID: questID, answer: answer)
+                didSuccessPostSubject.send(.success(()))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                didSuccessPostSubject.send(.failure(error as ByeBooError))
                 ByeBooLogger.error(error)
             }
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -37,7 +37,9 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                   let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self),
                   let editQuestTypeUseCase = container.resolve(type: EditQuestTypeUseCase.self),
                   let isValidQuestAnswerUseCase = container.resolve(type: IsValidQuestAnswerUseCase.self),
-                  let saveCommonQuestUseCase = container.resolve(type: SaveCommonQuestUseCase.self) else {
+                  let saveCommonQuestUseCase = container.resolve(type: SaveCommonQuestUseCase.self),
+                  let isForbbidenWordUseCoase = container.resolve(type: IsForbiddenWordUseCase.self)
+            else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
@@ -46,7 +48,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 getQuestInfoUseCase: getQuestInfoUseCase,
                 editQuestTypeUseCase: editQuestTypeUseCase,
                 isValidQuestAnswerUseCase: isValidQuestAnswerUseCase,
-                saveCommonQuestUseCase: saveCommonQuestUseCase
+                saveCommonQuestUseCase: saveCommonQuestUseCase,
+                isForbiddenWordUseCase: isForbiddenWordUseCase
                 
             )
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -36,7 +36,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             guard let getQuestInfoUseCase = container.resolve(type: GetQuestInfoUseCase.self),
                   let saveQuestTypeUseCase = container.resolve(type: SaveQuestTypeUseCase.self),
                   let editQuestTypeUseCase = container.resolve(type: EditQuestTypeUseCase.self),
-                  let isValidQuestAnswerUseCase = container.resolve(type: IsValidQuestAnswerUseCase.self) else {
+                  let isValidQuestAnswerUseCase = container.resolve(type: IsValidQuestAnswerUseCase.self),
+                  let saveCommonQuestUseCase = container.resolve(type: SaveCommonQuestUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
@@ -44,7 +45,9 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 saveQuestTypeUseCase: saveQuestTypeUseCase,
                 getQuestInfoUseCase: getQuestInfoUseCase,
                 editQuestTypeUseCase: editQuestTypeUseCase,
-                isValidQuestAnswerUseCase: isValidQuestAnswerUseCase
+                isValidQuestAnswerUseCase: isValidQuestAnswerUseCase,
+                saveCommonQuestUseCase: saveCommonQuestUseCase
+                
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/BottomSheetProtocol.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Protocol/BottomSheetProtocol.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol BottomSheetProtocol: AnyObject {
     func saveEmotionState(emotionState: ByeBooEmotion)
-    func saveQuest()
+    func saveQuest(isEdit: Bool, isCommonQuest: Bool?)
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #383 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 공통퀘스트 작성 API 연결했습니다. 
- 금칙어 필터링을 걸었습니다.

|    구현 내용    |  공통 퀘스트 작성   |  개별 퀘스트 작성  |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/016e2cf5-c9cb-4dd3-9d88-c47f72ed1a45" width ="250"> | <img src = "https://github.com/user-attachments/assets/f6d93e75-e651-4a23-836b-8bd32d2035dc" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
공통퀘스트 관련 API가 모여져 있는 CommonQuestAPI, CommonQuestRepository를 만들었습니당. 
현재 전체 조회가 연결이 되어있지 않아서 questID는 직접 바인딩해야 확인가능합니다! (3월3일 기준 questID 69) 

### 공통퀘스트 완료 후 퀘스트 공통여정 탭으로 이동 
승준오빠 코드좀 건드렷어요 .. 
`ParentQuest~VC`
```swift
func selectTab(index: Int) {
        guard controllers.indices.contains(index) else { return }
        show(controllers[index]) // 실제 보여지는 vc 교체 
        tabBar.select(index: index) // 상단 탭 ui 변경 
    }
```
외부에서는 이것만 사용합니다!

`TopTabBar~`
```swift
func select(index: Int) {
         guard itemViews.indices.contains(index) else { return }
         updateTabBar(tag: index) // 상단 ui 변경
}
```