### PR TITLE
Refactor/#398 헤더에서 키체인 재생성 방지 리팩토링

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
@@ -16,7 +16,10 @@ struct DataDependencyAssembler: DependencyAssembler {
     
     init() {
         self.tokenService = DefaultTokenService(keychainService: keychainService)
-        self.interceptor = NetworkInterceptor(tokenService: tokenService)
+        self.interceptor = NetworkInterceptor(
+            tokenService: tokenService,
+            keychainService: keychainService
+        )
         self.networkService = DefaultNetworkService(interceptor: interceptor)
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/CommonQuestAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/CommonQuestAPI.swift
@@ -10,8 +10,8 @@ import Foundation
 import Alamofire
 
 enum CommonQuestAPI {
-    case postCommonQuest(accessToken: String, questID: Int, dto: SaveCommonQuestRequestDTO)
-    case fetchCommonQuest(accessToken: String, date: String, cursor: Int?)
+    case postCommonQuest(questID: Int, dto: SaveCommonQuestRequestDTO)
+    case fetchCommonQuest(date: String, cursor: Int?)
 }
 
 extension CommonQuestAPI: EndPoint {
@@ -22,7 +22,7 @@ extension CommonQuestAPI: EndPoint {
     
     var path: String {
         switch self {
-        case .postCommonQuest(_, let questID, _):
+        case .postCommonQuest(let questID, _):
             return "/\(questID)"
         case .fetchCommonQuest:
             return ""
@@ -40,9 +40,8 @@ extension CommonQuestAPI: EndPoint {
     
     var headers: HeaderType {
         switch self {
-        case .postCommonQuest(let accessToken, _, _),
-                .fetchCommonQuest(let accessToken, _, _):
-            return .withAuth(acessToken: accessToken)
+        case .postCommonQuest, .fetchCommonQuest:
+            return .withAuth
         }
     }
     
@@ -59,7 +58,7 @@ extension CommonQuestAPI: EndPoint {
         switch self {
         case .postCommonQuest:
             return nil
-        case .fetchCommonQuest(_, let date, let cursor):
+        case .fetchCommonQuest(let date, let cursor):
             if let cursor {
                 return [
                     "date": date,
@@ -72,7 +71,7 @@ extension CommonQuestAPI: EndPoint {
     
     var bodyParameters: Parameters? {
         switch self {
-        case .postCommonQuest(_, _, let dto):
+        case .postCommonQuest(_, let dto):
             return try? dto.toDictionary()
         case .fetchCommonQuest:
             return nil

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/EndPoint.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/EndPoint.swift
@@ -58,19 +58,26 @@ extension EndPoint {
 
 enum HeaderType {
     case basic
-    case withAuth(acessToken: String)
-    case withAuthCode(acessToken: String, authorizationCode: String)
+    case withAuth
+    case refresh(refreshToken: String)
+    case kakaoLoginHeader(accessToken: String)
+    case appleLoginHeader(acessToken: String, authorizationCode: String)
     
     var value: HTTPHeaders {
         switch self {
         case .basic:
             return ["Content-Type": "application/json"]
-        case .withAuth(let acessToken):
+        case .withAuth:
             return [
                 "Content-Type": "application/json",
-                "Authorization": "Bearer \(acessToken)"
+                "X-Requires-Auth": "true"
             ]
-        case .withAuthCode(let acessToken, let authorizationCode):
+        case .refresh(let token), .kakaoLoginHeader(let token):
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(token)"
+            ]
+        case .appleLoginHeader(let acessToken, let authorizationCode):
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(acessToken)",

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
@@ -10,9 +10,9 @@ import Foundation
 import Alamofire
 
 enum NotificationAPI {
-    case saveToken(accessToken: String, dto: FCMTokenDTO)
-    case updateToken(accessToken: String, dto: FCMTokenDTO)
-    case deleteToken(accessToken: String, dto: FCMTokenDTO)
+    case saveToken(dto: FCMTokenDTO)
+    case updateToken(dto: FCMTokenDTO)
+    case deleteToken(dto: FCMTokenDTO)
 }
 
 extension NotificationAPI: EndPoint {
@@ -41,8 +41,8 @@ extension NotificationAPI: EndPoint {
     
     var headers: HeaderType {
         switch self {
-        case .saveToken(let accessToken, _), .updateToken(let accessToken, _), .deleteToken(let accessToken, _):
-            return .withAuth(acessToken: accessToken)
+        case .saveToken, .updateToken, .deleteToken:
+            return .withAuth
         }
     }
     
@@ -62,7 +62,7 @@ extension NotificationAPI: EndPoint {
     
     var bodyParameters: Parameters? {
         switch self {
-        case .saveToken(_, let dto), .updateToken(_, let dto), .deleteToken(_, let dto):
+        case .saveToken(let dto), .updateToken(let dto), .deleteToken(let dto):
             return try? dto.toDictionary()
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/QuestAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/QuestAPI.swift
@@ -71,8 +71,7 @@ extension QuestAPI: EndPoint {
     var headers: HeaderType {
         switch self {
         default:
-            let keychainService = DefaultKeychainService()
-            return .withAuth(acessToken: keychainService.load(key: .accessToken))
+            return .withAuth
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/UsersAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/UsersAPI.swift
@@ -10,25 +10,25 @@ import Foundation
 import Alamofire
 
 enum UsersAPI {
-    case journey(accessToken: String)
-    case sendUser(accessToken: String, requestDTO: UserRequestDTO)
-    case character(accessToken: String)
-    case count(accessToken: String)
-    case start(accessToken: String)
-    case modifyName(accessToken: String, requestDTO: UserNameRequestDTO)
-    case updateNotificationPermission(accessToken: String)
-    case fetchCommonQuestAnswers(accessToken: String, cursor: Int?)
+    case journey
+    case sendUser(requestDTO: UserRequestDTO)
+    case character
+    case count
+    case start
+    case modifyName(requestDTO: UserNameRequestDTO)
+    case updateNotificationPermission
+    case fetchCommonQuestAnswers(cursor: Int?)
 }
 
 extension UsersAPI: EndPoint {
     var basePath: String {
         return "/api/v1/users"
-
-//        switch self {
-//        case .journey, .character, .count, .start, .modifyName, .updateNotificationPermission:
-//        case .sendUser:
-//            return "/api/v2/users"
-//        }
+        
+        //        switch self {
+        //        case .journey, .character, .count, .start, .modifyName, .updateNotificationPermission:
+        //        case .sendUser:
+        //            return "/api/v2/users"
+        //        }
     }
     
     var path: String {
@@ -47,7 +47,7 @@ extension UsersAPI: EndPoint {
             return "/name"
         case .updateNotificationPermission:
             return "/alarm"
-        case .fetchCommonQuestAnswers(accessToken: let accessToken, cursor: let cursor):
+        case .fetchCommonQuestAnswers(cursor: let cursor):
             return "/me/common-quests"
         }
     }
@@ -63,15 +63,10 @@ extension UsersAPI: EndPoint {
     
     var headers: HeaderType {
         switch self {
-        case .journey(let accessToken),
-                .sendUser(let accessToken, _),
-                .character(let accessToken),
-                .count(let accessToken),
-                .start(let accessToken),
-                .modifyName(let accessToken, _),
-                .updateNotificationPermission(let accessToken),
-                .fetchCommonQuestAnswers(let accessToken, _):
-            return .withAuth(acessToken: accessToken)
+        case .journey,.sendUser, .character, .count,
+                .start,.modifyName,.updateNotificationPermission,
+                .fetchCommonQuestAnswers:
+            return .withAuth
         }
     }
     
@@ -86,7 +81,7 @@ extension UsersAPI: EndPoint {
     
     var queryParameters: [String : String]? {
         switch self {
-        case .fetchCommonQuestAnswers(_, let cursor):
+        case .fetchCommonQuestAnswers(let cursor):
             return cursor.map { ["cursor": "\($0)"] }
         default:
             return nil
@@ -97,9 +92,9 @@ extension UsersAPI: EndPoint {
         switch self {
         case .journey, .character, .count, .start, .updateNotificationPermission, .fetchCommonQuestAnswers:
             return nil
-        case .sendUser(_, let dto):
+        case .sendUser(let dto):
             return try? dto.toDictionary()
-        case .modifyName(_, let dto):
+        case .modifyName(let dto):
             return try? dto.toDictionary()
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkInterceptor.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/Service/NetworkInterceptor.swift
@@ -11,19 +11,31 @@ import Alamofire
 
 final class NetworkInterceptor: RequestInterceptor {
     private let tokenService: TokenService
+    private let keychainService: KeychainService
     private let retryLimit = 3
     
     init(
-        tokenService: TokenService
+        tokenService: TokenService,
+        keychainService: KeychainService
     ) {
         self.tokenService = tokenService
+        self.keychainService = keychainService
     }
     
     func adapt(
         _ urlRequest: URLRequest,
         for session: Alamofire.Session,
         completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
-            completion(.success(urlRequest))
+            var request = urlRequest
+            guard request.value(forHTTPHeaderField: "X-Requires-Auth") == "true" else {
+                completion(.success(request))
+                return
+            }
+            request.headers.remove(name: "X-Requires-Auth")
+            
+            let accessToken = keychainService.load(key: .accessToken)
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            completion(.success(request))
         }
     
     func retry(

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/KeychainService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/KeychainService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol KeychainService {
+protocol KeychainService: Sendable {
     func save(key: KeyType, token: String)
     func load(key: KeyType) -> String
     func delete(key: KeyType)

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/TokenService.swift
@@ -40,7 +40,7 @@ actor DefaultTokenService: TokenService {
     }
     
     private func fetchAuthReissue() async throws {
-        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .refreshToken))
+        let header: HeaderType = .refresh(refreshToken: keychainService.load(key: .refreshToken))
         let endPoint: EndPoint = AuthAPI.reissue(header: header)
         ByeBooLogger.debug("토큰 재발급 시작")
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -57,10 +57,10 @@ struct DefaultAuthRepository: AuthInterface {
         switch loginPlatform {
         case "KAKAO":
             ByeBooLogger.debug("카카오 post login")
-            header = .withAuth(acessToken: keychainService.load(key: .authorization))
+            header = .kakaoLoginHeader(accessToken: keychainService.load(key: .authorization))
         case "APPLE":
             ByeBooLogger.debug("apple post login")
-            header = .withAuthCode(
+            header = .appleLoginHeader(
                 acessToken: keychainService.load(key: .authorization),
                 authorizationCode: keychainService.load(key: .authorizationCode)
             )
@@ -89,7 +89,7 @@ struct DefaultAuthRepository: AuthInterface {
             let fcmToken = try await Messaging.messaging().token()
             let fcmTokenDTO = FCMTokenDTO(token: fcmToken)
             try await network.request(
-                NotificationAPI.saveToken(accessToken: result.accessToken, dto: fcmTokenDTO)
+                NotificationAPI.saveToken(dto: fcmTokenDTO)
             )
         } catch (let error) {
             ByeBooLogger.error(error)
@@ -116,7 +116,7 @@ struct DefaultAuthRepository: AuthInterface {
     
     func logout() async throws -> Bool {
         let accessToken = keychainService.load(key: .accessToken)
-        let header: HeaderType = .withAuth(acessToken: accessToken)
+        let header: HeaderType = .withAuth
         
         do {
             try await network.request(
@@ -127,7 +127,7 @@ struct DefaultAuthRepository: AuthInterface {
                 return false
             }
             try await network.request(
-                NotificationAPI.deleteToken(accessToken: accessToken, dto: .init(token: fcmToken))
+                NotificationAPI.deleteToken(dto: .init(token: fcmToken))
             )
         }
         catch (let error) {
@@ -142,7 +142,7 @@ struct DefaultAuthRepository: AuthInterface {
     }
     
     func withdraw() async throws -> Bool {
-        let header: HeaderType = .withAuth(acessToken: keychainService.load(key: .accessToken))
+        let header: HeaderType = .withAuth
         
         do {
             try await network.request(

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
@@ -25,7 +25,6 @@ struct DefaultCommonQuestRepository: CommonQuestInterface {
         
         let _ = try await network.request(
             CommonQuestAPI.postCommonQuest(
-                accessToken: loadAccessToken(),
                 questID: questID,
                 dto: saveCommonQuestRequestDTO
             )
@@ -38,16 +37,11 @@ struct DefaultCommonQuestRepository: CommonQuestInterface {
     ) async throws -> CommonQuestAnswersEntity {
         let commonQuest = try await network.request(
             CommonQuestAPI.fetchCommonQuest(
-                accessToken: loadAccessToken(),
                 date: date,
                 cursor: cursor
             ),
             decodingType: CommonQuestAnswersResponseDTO.self
         )
         return commonQuest.toEntity()
-    }
-    
-    private func loadAccessToken() -> String {
-        keychainService.load(key: .accessToken)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
@@ -38,7 +38,7 @@ struct DefaultNotificationRepository: NotificationInterface {
         
         let fcmTokenDTO = createDTO(token: token)
         try await network.request(
-            NotificationAPI.saveToken(accessToken: accessToken, dto: fcmTokenDTO)
+            NotificationAPI.saveToken(dto: fcmTokenDTO)
         )
         saveToken(token: token)
     }
@@ -53,7 +53,7 @@ struct DefaultNotificationRepository: NotificationInterface {
         
         let fcmTokenDTO = createDTO(token: token)
         try await network.request(
-            NotificationAPI.updateToken(accessToken: accessToken, dto: fcmTokenDTO)
+            NotificationAPI.updateToken(dto: fcmTokenDTO)
         )
         saveToken(token: token)
     }
@@ -66,7 +66,7 @@ struct DefaultNotificationRepository: NotificationInterface {
         let fcmTokenDTO = createDTO(token: token)
         let accessToken = keychainService.load(key: .accessToken)
         try await network.request(
-            NotificationAPI.deleteToken(accessToken: accessToken, dto: fcmTokenDTO)
+            NotificationAPI.deleteToken(dto: fcmTokenDTO)
         )
         let _ = userDefaultsService.delete(key: .fcmToken)
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
@@ -28,7 +28,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchJourney() async throws -> JourneyEntity {
         let accessToken = loadAccessToken()
         let result = try await network.request(
-            UsersAPI.journey(accessToken: accessToken),
+            UsersAPI.journey,
             decodingType: UserJourneyResponseDTO.self
         )
         
@@ -47,7 +47,6 @@ struct DefaultUsersRepository: UsersInterface {
         )
         let result = try await network.request(
             UsersAPI.sendUser(
-                accessToken: accessToken,
                 requestDTO: userRequestDTO
             ),
             decodingType: UserResponseDTO.self
@@ -65,7 +64,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchCharacterDialogue() async throws -> DialogueEntity {
         let accessToken = loadAccessToken()
         let result = try await network.request(
-            UsersAPI.character(accessToken: accessToken),
+            UsersAPI.character,
             decodingType: DialogueResponseDTO.self
         )
         
@@ -75,7 +74,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchQuestStatus() async throws -> UserQuestStatusEntity {
         let accessToken = loadAccessToken()
         let result = try await network.request(
-            UsersAPI.count(accessToken: accessToken),
+            UsersAPI.count,
             decodingType: UserQuestStatusResponseDTO.self
         )
         
@@ -84,7 +83,7 @@ struct DefaultUsersRepository: UsersInterface {
     
     func startJourney() async throws {
         let accessToken = loadAccessToken()
-        try await network.request(UsersAPI.start(accessToken: accessToken))
+        try await network.request(UsersAPI.start)
     }
     
     // MARK: Persistence
@@ -113,7 +112,6 @@ struct DefaultUsersRepository: UsersInterface {
         let accessToken = loadAccessToken()
         let result = try await network.request(
             UsersAPI.modifyName(
-                accessToken: accessToken,
                 requestDTO: UserNameRequestDTO(
                     name: name
                 )
@@ -132,7 +130,7 @@ struct DefaultUsersRepository: UsersInterface {
     func updateNotificationPermission() async throws -> Bool {
         let accessToken = loadAccessToken()
         let result = try await network.request(
-            UsersAPI.updateNotificationPermission(accessToken: accessToken),
+            UsersAPI.updateNotificationPermission,
             decodingType: AlarmEnabledResponseDTO.self
         )
         let alarmEnabled = result.alarmEnabled
@@ -155,10 +153,7 @@ struct DefaultUsersRepository: UsersInterface {
     func fetchMyCommonQuestAnswers(cursor: Int?) async throws -> CommonQuestMyAnswersEntity {
         let accessToken = loadAccessToken()
         let result = try await network.request(
-            UsersAPI.fetchCommonQuestAnswers(
-                accessToken: accessToken,
-                cursor: cursor
-            ),
+            UsersAPI.fetchCommonQuestAnswers(cursor: cursor),
             decodingType: CommonQuestMyAnswersResponseDTO.self
         )
         return result.toEntity()


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #398 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존 ~API 코드 헤더에서 키체인 재생성되는 로직을 리팩토링했습니다. 
- withAuth 헤더만 따로 분리하여 TokenInterceptor adapt 함수에서 액세스토큰을 넣을 수 있도록 수정했습니다.
- 이에 따라 카카오로그인, 애플로그인, 리프레시 관련 헤더는 따로 HeaderType을 분리하였습니다. 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`EndPoint`
```swift
var value: HTTPHeaders {
        switch self {
        case .basic:
            return ["Content-Type": "application/json"]
        case .withAuth:
            return [
                "Content-Type": "application/json",
                "X-Requires-Auth": "true" // 액세스 토큰 주입이 필요한지 판단 
            ]
        case .refresh(let token), .kakaoLoginHeader(let token):
            return [
                "Content-Type": "application/json",
                "Authorization": "Bearer \(token)"
            ]
        case .appleLoginHeader(let acessToken, let authorizationCode):
            return [
                "Content-Type": "application/json",
                "Authorization": "Bearer \(acessToken)",
                "X-Apple-Code": "\(authorizationCode)"
            ]
        }
    }
```

`TokenInterceptor`
```swift
func adapt(
        _ urlRequest: URLRequest,
        for session: Alamofire.Session,
        completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
            var request = urlRequest
            guard request.value(forHTTPHeaderField: "X-Requires-Auth") == "true" else { // 액세스 토큰 주입이 필요한 경우에만 해당 로직 실행 
                completion(.success(request))
                return
            }
            request.headers.remove(name: "X-Requires-Auth") // 헤더 제거 
            
            let accessToken = keychainService.load(key: .accessToken)
            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
            completion(.success(request))
        }
```

