### PR TITLE
Fix/#399 퀘스트 완료 -> 아카이브 -> 모달 순서 보장되도록 수정

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ArchiveQuestViewController.swift
@@ -141,6 +141,18 @@ extension ArchiveQuestViewController {
         rootView = ArchiveQuestView(type: questType)
     }
     
+    func presentCompleteModal() {
+        let modal = ModalBuilder(
+            modalView: QuestCompleteModal(),
+            action: nil,
+            rootViewController: self
+        )
+        modal.present()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            modal.dismiss()
+        }
+    }
+    
     @objc
     private func editButtonDidTap() {
         ByeBooLogger.debug("버튼 터치, entity: \(String(describing: viewModel.entity))")

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteActiveTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteActiveTypeQuestViewController.swift
@@ -144,23 +144,14 @@ extension WriteActiveTypeQuestViewController: ToastPresentable, ToastErrorHandle
                 switch result {
                 case .success(()):
                     guard let self else { return }
-                    self.bottomSheetViewController.dismiss(animated: true) {
-                        let modal = ModalBuilder(
-                            modalView: QuestCompleteModal(),
-                            action: nil,
-                            rootViewController: self
-                        )
-                        modal.present()
-                        
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            modal.dismiss()
-                            
-                            ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
-                            let viewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
-                            viewController.entryViewController = .writeQuest
-                            viewController.configure(questID: self.questID, questType: .activation)
-                            self.navigationController?.pushViewController(viewController, animated: true)
-                        }
+                    self.bottomSheetViewController.dismiss(animated: true)
+                    ByeBooLogger.debug("퀘스트 아이디 \(self.questID)")
+                    let archiveViewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
+                    archiveViewController.entryViewController = .writeQuest
+                    archiveViewController.configure(questID: self.questID, questType: .activation)
+                    self.navigationController?.pushViewController(archiveViewController, animated: true)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        archiveViewController.presentCompleteModal()
                     }
                 case .failure(let error):
                     self?.handleError(error)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/WriteQuestionTypeQuestViewController.swift
@@ -183,7 +183,7 @@ extension WriteQuestionTypeQuestViewController: ToastPresentable, ToastErrorHand
                 switch result {
                 case .success:
                     ByeBooLogger.debug("공통 퀘스트 비속어 없음")
-                case .failure(let error):
+                case .failure(_):
                     presentToastMessage(type: .questViolation)
                 }
             }
@@ -239,21 +239,10 @@ extension WriteQuestionTypeQuestViewController {
             let archiveViewController = ViewControllerFactory.shared.makeArchiveQuestViewController()
             archiveViewController.entryViewController = .writeQuest
             archiveViewController.configure(questID: self.questID, questType: .question)
-            
-            CATransaction.begin()
-            CATransaction.setCompletionBlock {
-                let modal = ModalBuilder(
-                    modalView: QuestCompleteModal(),
-                    action: nil,
-                    rootViewController: self
-                )
-                modal.present()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    modal.dismiss()
-                }
-            }
             self.navigationController?.pushViewController(archiveViewController, animated: true)
-            CATransaction.commit()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                archiveViewController.presentCompleteModal()
+            }
         }
     }
     


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #399 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존에 WriteQuest 작업하면서 썼던 CATransition이나 completion 클로저들도 순서를 보장하기 위해서 썼던 코드인데요.. 
이후 여러 테스트를 진행하다 보니까 순서 보장이 잘 안 되는 것 같아서 수정하였습니다.

|    구현 내용    |   IPhone 16 pro   |  
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/e6783417-1560-4573-acf7-44de554e6c6b" width ="250"> | 


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
아카이브에서 모달 띄우는 함수를 만들고, Push 이후에 실행해주는 방식으로 변경하였습니다. 
