### PR TITLE
Refactor/#413 코드리뷰 반영

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestsRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/QuestsRepository.swift
@@ -122,21 +122,20 @@ struct DefaultQuestRepository: QuestsInterface {
         .emptyAnswerStub()
     }
     
-    func fetchAIAnswer(questID: Int, isAnswerExists: Bool) async throws -> AIAnswerEntity {
-        let result: AIAnswerResponseDTO
+    func fetchAIAnswer(questID: Int) async throws -> AIAnswerEntity {
+        let result: AIAnswerResponseDTO = try await network.request(
+            QuestAPI.createAIAnswer(questID: questID),
+            decodingType: AIAnswerResponseDTO.self
+        )
         
-        if isAnswerExists {
-            result = try await network.request(
-                QuestAPI.fetchAIAnswer(questID: questID),
-                decodingType: AIAnswerResponseDTO.self
-            )
-        } else {
-            result = try await network.request(
-                QuestAPI.createAIAnswer(questID: questID),
-                decodingType: AIAnswerResponseDTO.self
-            )
-        }
-        
+        return result.toEntity()
+    }
+    
+    func createAIAnswer(questID: Int) async throws -> AIAnswerEntity {
+        let result = try await network.request(
+            QuestAPI.createAIAnswer(questID: questID),
+            decodingType: AIAnswerResponseDTO.self
+        )
         return result.toEntity()
     }
     
@@ -187,14 +186,6 @@ struct DefaultQuestRepository: QuestsInterface {
         let _ = try await network.request(
             QuestAPI.editActive(questID: questID, request: editQuestActiveDTO)
         )
-    }
-    
-    private func createAIAnswer(questID: Int) async throws -> AIAnswerEntity {
-        let result = try await network.request(
-            QuestAPI.createAIAnswer(questID: questID),
-            decodingType: AIAnswerResponseDTO.self
-        )
-        return result.toEntity()
     }
 }
 
@@ -258,9 +249,13 @@ final class MockQuestsRepository: QuestsInterface {
         .emptyAnswerStub()
     }
     
-    func fetchAIAnswer(questID: Int, isAnswerExists: Bool) async throws -> AIAnswerEntity {
+    func fetchAIAnswer(questID: Int) async throws -> AIAnswerEntity {
+//        throw ByeBooError.unknownError
+        .stub()
+    }
+    
+    func createAIAnswer(questID: Int) async throws -> AIAnswerEntity {
         try await Task.sleep(for: .seconds(2))
-        throw ByeBooError.unknownError
-//        .stub()
+        return .stub()
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/QuestsInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/QuestsInterface.swift
@@ -31,5 +31,6 @@ protocol QuestsInterface {
         imageKey: String,
         isImageChanged: Bool) async throws
     func fetchCommoncQuest(date: String) async throws -> CommonQuestAnswersEntity
-    func fetchAIAnswer(questID: Int, isAnswerExists: Bool) async throws -> AIAnswerEntity
+    func fetchAIAnswer(questID: Int) async throws -> AIAnswerEntity
+    func createAIAnswer(questID: Int) async throws -> AIAnswerEntity
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchAIAnswerUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchAIAnswerUseCase.swift
@@ -17,6 +17,10 @@ struct DefaultFetchAIAnswerUseCase: FetchAIAnswerUseCase {
     }
     
     func execute(questID: Int, isAnswerExists: Bool) async throws -> AIAnswerEntity {
-        try await repository.fetchAIAnswer(questID: questID, isAnswerExists: isAnswerExists)
+        if isAnswerExists {
+            return try await repository.fetchAIAnswer(questID: questID)
+        } else {
+            return try await repository.createAIAnswer(questID: questID)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/AIAnswerViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/AIAnswerViewController.swift
@@ -50,6 +50,12 @@ final class AIAnswerViewController: BaseViewController {
             )
         )
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        viewModel.action(.viewDidDisappear)
+    }
 }
 
 extension AIAnswerViewController {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/AIAnswerViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/AIAnswerViewModel.swift
@@ -20,6 +20,8 @@ final class AIAnswerViewModel {
     private var questID: Int = 1
     private var isAnswerExists: Bool = false
     
+    private var fetchAIAnswerTask: Task<Void, Never>?
+    
     init(fetchAIAnswerUseCase: FetchAIAnswerUseCase) {
         self.fetchAIAnswerUseCase = fetchAIAnswerUseCase
         
@@ -34,6 +36,7 @@ final class AIAnswerViewModel {
 extension AIAnswerViewModel: ViewModelType {
     enum Input {
         case viewDidLoad(questID: Int, isAIAnswerExists: Bool)
+        case viewDidDisappear
     }
     
     struct Output {
@@ -48,13 +51,17 @@ extension AIAnswerViewModel: ViewModelType {
             self.isAnswerExists = isExists
             
             fetchAIAnswer()
+        case .viewDidDisappear:
+            cancelTask()
         }
     }
 }
 
 extension AIAnswerViewModel {
     private func fetchAIAnswer() {
-        Task {
+        fetchAIAnswerTask?.cancel()
+        
+        fetchAIAnswerTask = Task {
             do {
                 AILoadingSubject.send(true)
                 
@@ -73,5 +80,10 @@ extension AIAnswerViewModel {
                 AILoadingSubject.send(false)
             }
         }
+    }
+    
+    private func cancelTask() {
+        fetchAIAnswerTask?.cancel()
+        fetchAIAnswerTask = nil
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -91,9 +91,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: ArchiveQuestViewModel.self) { container in
-            guard let questAnswerUseCase = container.resolve(type: QuestAnswerUseCase.self),
-                  let fetchAIAnswerUseCase = container.resolve(type: FetchAIAnswerUseCase.self)
-            else {
+            guard let questAnswerUseCase = container.resolve(type: QuestAnswerUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
@@ -102,7 +100,6 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 questAnswerUseCase: questAnswerUseCase
             )
         }
-        
         
         DIContainer.shared.register(type: HomeViewModel.self) { container in
             guard let characterUseCase = container.resolve(type: FetchCharacterDialogueUseCase.self),


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #413 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- #394 해당 PR의 코드리뷰를 반영했습니다.
- task의 취소를 관리할 수 있도록 변수로 선언하고 view가 사라질 때 cancel 및 메모리 해제 시켜주었습니다.
- AI 답장 존재 여부에 따라 분기하던 로직을 `usecase`로 변경했습니다. 


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`AIAnswerViewModel`
- viewDidDisappear에서 cancelTask를 호출해줬습니디ㅓㅏ! 
```swift
private var fetchAIAnswerTask: Task<Void, Never>?

private func fetchAIAnswer() {
        fetchAIAnswerTask?.cancel()
        
        fetchAIAnswerTask = Task {
            do {
                AILoadingSubject.send(true)
                
                let answer = try await fetchAIAnswerUseCase.execute(
                    questID: questID,
                    isAnswerExists: isAnswerExists
                ).AIAnswer
                AIResultSubject.send(.success(answer))
                
                AILoadingSubject.send(false)
            } catch {
                guard let error = error as? ByeBooError else {
                    return
                }
                AIResultSubject.send(.failure(error))
                AILoadingSubject.send(false)
            }
        }
    }
    
    private func cancelTask() {
        fetchAIAnswerTask?.cancel()
        fetchAIAnswerTask = nil
    }
```

