### PR TITLE
Refactor/#441 온보딩,로그인 시 isOnboardingCompleted -> isRegistered로 변경

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/UserDefaultsKey.swift
@@ -10,7 +10,6 @@ import Foundation
 enum UserDefaultsKey: String, CaseIterable {
     case userName
     case userID
-    case isOnboardingCompleted
     case isHelperShown
     case isRegistered
     case loginPlatform

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -97,12 +97,12 @@ struct DefaultAuthRepository: AuthInterface {
     }
     
     func autoLogin() async throws -> Bool {
-        let isOnboardingCompleted: Bool = userDefaultsService.load(key: .isOnboardingCompleted) ?? false
-        ByeBooLogger.debug("온보딩 여부 \(isOnboardingCompleted)")
+        let isRegistered: Bool = userDefaultsService.load(key: .isRegistered) ?? false
+        ByeBooLogger.debug("온보딩 여부 \(isRegistered)")
         
         if !keychainService.load(key: .accessToken).isEmpty
             && !keychainService.load(key: .refreshToken).isEmpty
-            && isOnboardingCompleted
+            && isRegistered
         {
             ByeBooLogger.debug("정보 있음")
             try await tokenService.reissue()
@@ -136,7 +136,7 @@ struct DefaultAuthRepository: AuthInterface {
         }
         
         clearKeychain()
-        removeUserInfo(excludedKeys: [.isOnboardingCompleted, .isHelperShown, .hasEnterMyPage])
+        removeUserInfo(excludedKeys: [.isRegistered, .isHelperShown, .hasEnterMyPage])
         
         return true
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/UsersRepository.swift
@@ -50,7 +50,7 @@ struct DefaultUsersRepository: UsersInterface {
         )
         let _ = userDefaultsService.save(result.id, key: .userID)
         let _ = userDefaultsService.save(result.name, key: .userName)
-        let _ = userDefaultsService.save(true, key: .isOnboardingCompleted)
+        let _ = userDefaultsService.save(true, key: .isRegistered)
         let _ = userDefaultsService.save(false, key: .hasEnterMyPage)
         let _ = userDefaultsService.save(false, key: .alarmEnabled)
         

--- a/ByeBoo-iOS/ByeBooTests/Feature/Login/AuthTests.swift
+++ b/ByeBoo-iOS/ByeBooTests/Feature/Login/AuthTests.swift
@@ -15,14 +15,14 @@ struct AuthTests {
     private let networkService = MockNetworkService(userAPI: MockUserAPI(isAvailable: true))
     
     @Test("🏁 isOnboardingCompleted가 true일 때 ✅ 자동로그인 success")
-    func isOnboardingCompleted_true__autoLogin_success() async throws {
+    func isRegistered_true__autoLogin_success() async throws {
         // Given
         let authRepository = MockAuthRepository(
             network: networkService,
             userDefaultsService: userDefaultsService,
             keychainService: keychainService
         )
-        let _ = userDefaultsService.save(true, key: .isOnboardingCompleted)
+        let _ = userDefaultsService.save(true, key: .isRegistered)
         let autoLoginUseCase = DefaultAutoLoginUseCase(repository: authRepository)
         
         // When


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #441 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 제가 기기를 바꾼 이후로 자동로그인이 안되던 문제가 있었습니다. 유저디폴트에 저장되어있던 정보가 삭제된 게 원인일까 싶어요.. 
- 기존 autoLogin에서는 sendUser에서 isOnboardingCompleted를 true로 저장하면서, 이 유저디폴트 key로 자동로그인 여부를 판단했엇습니다. 하지만 이제 원래 기존에 스프1까지 사용하던 온보딩이 간소화되고,, 하면서 클라에서만 사용하는 onboardingCompleted에 의존하는 것보다 서버에서 로그인 시 주는 isRegistered로 변경하는게 좀 나을것 같다 판단이 되었습니다. 
- 그래서 유저디폴트에 있는 isOnboardingCompleted key를 삭제하고, 관련 로직을 전부 isRegistered로 변경하였습니다. 