### PR TITLE
Feat/#437 알림 전체 조회 API 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -329,7 +329,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS 1780581426";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -349,7 +349,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-Prod.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = "";
@@ -372,7 +372,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.heartz.ByeBoo-iOS";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS 1780581426";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/ByeBoo-iOS/ByeBoo-iOS/App/AppDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        guard let notificationRepository = DIContainer.shared.resolve(type: DefaultNotificationRepository.self) else {
+        guard let notificationRepository = DIContainer.shared.resolve(type: DefaultNotificationTokenRepository.self) else {
             return
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/DataDependencyAssembler.swift
@@ -67,6 +67,10 @@ struct DataDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: ReportsInterface.self) { _ in
             return DefaultReportsRepository(networkService: networkService)
         }
+        
+        DIContainer.shared.register(type: NotificationInterface.self) { _ in
+            return DefaultNotificationRepository(networkService: networkService)
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Enum/NotificationType+Data.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Enum/NotificationType+Data.swift
@@ -1,0 +1,24 @@
+//
+//  NotificationType+Data.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/7/26.
+//
+
+extension NotificationType {
+    
+    var responseKey: String {
+        switch self {
+        case .questOpen:
+            "QUEST_OPEN"
+        case .comment:
+            "COMMENT"
+        case .like:
+            "LIKE"
+        }
+    }
+    
+    static func keyToEnum(_ key: String) -> Self? {
+        allCases.first { $0.responseKey == key }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/HasUnreadNotificationResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/HasUnreadNotificationResponseDTO.swift
@@ -1,0 +1,16 @@
+//
+//  HasUnreadNotificationResponseDTO.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/19/26.
+//
+
+struct HasUnreadNotificationResponseDTO: Decodable {
+    let hasUnread: Bool
+}
+
+extension HasUnreadNotificationResponseDTO {
+    func toEntity() -> HasUnreadNotificationEntity {
+        .init(hasUnread: hasUnread)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListReponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListReponseDTO.swift
@@ -1,0 +1,41 @@
+//
+//  NotificationListReponseDTO.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/5/26.
+//
+
+struct NotificationListReponseDTO: Decodable {
+    let notifications: [NotificationResponseDTO]
+}
+
+struct NotificationResponseDTO: Decodable {
+    let notificationID: Int
+    let notificationType: String
+    let title: String
+    let content: String
+    let isRead: Bool
+    let createdAt: String
+    let landingURL: String
+}
+
+extension NotificationListReponseDTO {
+    func toEntity() -> NotificationListEntity {
+        let notifications = notifications.map { $0.toEntity() }
+        return .init(notifications: notifications)
+    }
+}
+
+extension NotificationResponseDTO {
+    func toEntity() -> NotificationEntity {
+        .init(
+            notificationID: notificationID,
+            notificationType: notificationType,
+            title: title,
+            content: content,
+            isRead: isRead,
+            createdAt: createdAt,
+            landingURL: landingURL
+        )
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListReponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListReponseDTO.swift
@@ -30,7 +30,7 @@ extension NotificationResponseDTO {
     func toEntity() -> NotificationEntity {
         .init(
             notificationID: notificationID,
-            notificationType: notificationType,
+            notificationType: NotificationType.keyToEnum(notificationType),
             title: title,
             content: content,
             isRead: isRead,

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListResponseDTO.swift
@@ -10,13 +10,13 @@ struct NotificationListResponseDTO: Decodable {
 }
 
 struct NotificationResponseDTO: Decodable {
-    let notificationID: Int
-    let notificationType: String
-    let title: String
+    let notificationId: Int
     let content: String
+    let title: String
     let isRead: Bool
     let createdAt: String
-    let landingURL: String
+    let landingUrl: String
+    let notificationType: String
 }
 
 extension NotificationListResponseDTO {
@@ -29,13 +29,13 @@ extension NotificationListResponseDTO {
 extension NotificationResponseDTO {
     func toEntity() -> NotificationEntity {
         .init(
-            notificationID: notificationID,
+            notificationID: notificationId,
             notificationType: NotificationType.keyToEnum(notificationType),
             title: title,
             content: content,
             isRead: isRead,
             createdAt: createdAt,
-            landingURL: landingURL
+            landingURL: landingUrl
         )
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/NotificationListResponseDTO.swift
@@ -1,11 +1,11 @@
 //
-//  NotificationListReponseDTO.swift
+//  NotificationListResponseDTO.swift
 //  ByeBoo-iOS
 //
 //  Created by 더스틴 on 6/5/26.
 //
 
-struct NotificationListReponseDTO: Decodable {
+struct NotificationListResponseDTO: Decodable {
     let notifications: [NotificationResponseDTO]
 }
 
@@ -19,7 +19,7 @@ struct NotificationResponseDTO: Decodable {
     let landingURL: String
 }
 
-extension NotificationListReponseDTO {
+extension NotificationListResponseDTO {
     func toEntity() -> NotificationListEntity {
         let notifications = notifications.map { $0.toEntity() }
         return .init(notifications: notifications)

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
@@ -11,6 +11,7 @@ import Alamofire
 
 enum NotificationAPI {
     case fetchNotificationList
+    case fetchUnreadNotification
 }
 
 extension NotificationAPI: EndPoint {
@@ -23,40 +24,42 @@ extension NotificationAPI: EndPoint {
         switch self {
         case .fetchNotificationList:
             ""
+        case .fetchUnreadNotification:
+            "/unread/status"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .fetchNotificationList:
+        case .fetchNotificationList, .fetchUnreadNotification:
                 .get
         }
     }
     
     var headers: HeaderType {
         switch self {
-        case .fetchNotificationList:
+        case .fetchNotificationList, .fetchUnreadNotification:
                 .withAuth
         }
     }
     
     var parameterEncoding: ParameterEncoding {
         switch self {
-        case .fetchNotificationList:
+        case .fetchNotificationList, .fetchUnreadNotification:
             JSONEncoding.default
         }
     }
     
     var queryParameters: [String : String]? {
         switch self {
-        case .fetchNotificationList:
+        case .fetchNotificationList, .fetchUnreadNotification:
             nil
         }
     }
     
     var bodyParameters: Parameters? {
         switch self {
-        case .fetchNotificationList:
+        case .fetchNotificationList ,.fetchUnreadNotification:
             nil
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
@@ -1,0 +1,63 @@
+//
+//  NotificationAPI.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/5/26.
+//
+
+import Foundation
+
+import Alamofire
+
+enum NotificationAPI {
+    case fetchNotificationList
+}
+
+extension NotificationAPI: EndPoint {
+    
+    var basePath: String {
+        return "/api/v1/notifications"
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchNotificationList:
+            ""
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .fetchNotificationList:
+                .get
+        }
+    }
+    
+    var headers: HeaderType {
+        switch self {
+        case .fetchNotificationList:
+                .withAuth
+        }
+    }
+    
+    var parameterEncoding: ParameterEncoding {
+        switch self {
+        case .fetchNotificationList:
+            JSONEncoding.default
+        }
+    }
+    
+    var queryParameters: [String : String]? {
+        switch self {
+        case .fetchNotificationList:
+            nil
+        }
+    }
+    
+    var bodyParameters: Parameters? {
+        switch self {
+        case .fetchNotificationList:
+            nil
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationTokenAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationTokenAPI.swift
@@ -1,5 +1,5 @@
 //
-//  NotificationAPI.swift
+//  NotificationTokenAPI.swift
 //  ByeBoo-iOS
 //
 //  Created by APPLE on 11/22/25.

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationTokenAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationTokenAPI.swift
@@ -9,13 +9,13 @@ import Foundation
 
 import Alamofire
 
-enum NotificationAPI {
+enum NotificationTokenAPI {
     case saveToken(dto: FCMTokenDTO)
     case updateToken(dto: FCMTokenDTO)
     case deleteToken(dto: FCMTokenDTO)
 }
 
-extension NotificationAPI: EndPoint {
+extension NotificationTokenAPI: EndPoint {
         
     var basePath: String {
         return "/api/v1/notification-tokens"

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/AuthRepository.swift
@@ -89,7 +89,7 @@ struct DefaultAuthRepository: AuthInterface {
             let fcmToken = try await Messaging.messaging().token()
             let fcmTokenDTO = FCMTokenDTO(token: fcmToken)
             try await network.request(
-                NotificationAPI.saveToken(dto: fcmTokenDTO)
+                NotificationTokenAPI.saveToken(dto: fcmTokenDTO)
             )
         } catch (let error) {
             ByeBooLogger.error(error)
@@ -127,7 +127,7 @@ struct DefaultAuthRepository: AuthInterface {
                 return false
             }
             try await network.request(
-                NotificationAPI.deleteToken(dto: .init(token: fcmToken))
+                NotificationTokenAPI.deleteToken(dto: .init(token: fcmToken))
             )
         }
         catch (let error) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
@@ -20,4 +20,12 @@ struct DefaultNotificationRepository: NotificationInterface {
         )
         return result.toEntity()
     }
+    
+    func fetchHasUnreadNotification() async throws -> HasUnreadNotificationEntity {
+        let result = try await networkService.request(
+            NotificationAPI.fetchUnreadNotification,
+            decodingType: HasUnreadNotificationResponseDTO.self
+        )
+        return result.toEntity()
+    }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
@@ -16,7 +16,7 @@ struct DefaultNotificationRepository: NotificationInterface {
     func fetchNotifications() async throws -> NotificationListEntity {
         let result = try await networkService.request(
             NotificationAPI.fetchNotificationList,
-            decodingType: NotificationListReponseDTO.self
+            decodingType: NotificationListResponseDTO.self
         )
         return result.toEntity()
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
@@ -1,0 +1,23 @@
+//
+//  NotificationRepository.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/5/26.
+//
+
+struct DefaultNotificationRepository: NotificationInterface {
+    
+    private let networkService: NetworkService
+    
+    init(networkService: NetworkService) {
+        self.networkService = networkService
+    }
+    
+    func fetchNotifications() async throws -> NotificationListEntity {
+        let result = try await networkService.request(
+            NotificationAPI.fetchNotificationList,
+            decodingType: NotificationListReponseDTO.self
+        )
+        return result.toEntity()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationTokenRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationTokenRepository.swift
@@ -5,7 +5,7 @@
 //  Created by APPLE on 11/22/25.
 //
 
-struct DefaultNotificationRepository: NotificationInterface {
+struct DefaultNotificationTokenRepository: NotificationTokenInterface {
     
     private let network: NetworkService
     private let userDefaultsService: UserDefaultService
@@ -38,7 +38,7 @@ struct DefaultNotificationRepository: NotificationInterface {
         
         let fcmTokenDTO = createDTO(token: token)
         try await network.request(
-            NotificationAPI.saveToken(dto: fcmTokenDTO)
+            NotificationTokenAPI.saveToken(dto: fcmTokenDTO)
         )
         saveToken(token: token)
     }
@@ -53,7 +53,7 @@ struct DefaultNotificationRepository: NotificationInterface {
         
         let fcmTokenDTO = createDTO(token: token)
         try await network.request(
-            NotificationAPI.updateToken(dto: fcmTokenDTO)
+            NotificationTokenAPI.updateToken(dto: fcmTokenDTO)
         )
         saveToken(token: token)
     }
@@ -66,7 +66,7 @@ struct DefaultNotificationRepository: NotificationInterface {
         let fcmTokenDTO = createDTO(token: token)
         let accessToken = keychainService.load(key: .accessToken)
         try await network.request(
-            NotificationAPI.deleteToken(dto: fcmTokenDTO)
+            NotificationTokenAPI.deleteToken(dto: fcmTokenDTO)
         )
         let _ = userDefaultsService.delete(key: .fcmToken)
     }
@@ -76,7 +76,7 @@ struct DefaultNotificationRepository: NotificationInterface {
     }
 }
 
-final class MockNotificationRepository: NotificationInterface {
+final class MockNotificationTokenRepository: NotificationTokenInterface {
     
     private let userDefaultsService: UserDefaultService
     var sendTokenCalled = false

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationTokenRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationTokenRepository.swift
@@ -1,5 +1,5 @@
 //
-//  NotificationRepositoru.swift
+//  NotificationTokenRepository.swift
 //  ByeBoo-iOS
 //
 //  Created by APPLE on 11/22/25.

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -216,5 +216,9 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: FormatElapsedTimeUseCase.self) { _ in
             return DefaultFormatElapsedTimeUseCase()
         }
+        
+        DIContainer.shared.register(type: FetchHasUnreadNotificationUseCase.self) { _ in
+            return DefaultFetchHasUnreadNotificationUseCase(repository: notificationRepository)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -23,10 +23,11 @@ struct DomainDependencyAssembler: DependencyAssembler {
               let forbiddenWordRepository = DIContainer.shared.resolve(type: ForbiddenWordInterface.self),
               let commonQuestRepository = DIContainer.shared.resolve(type: CommonQuestInterface.self),
               let blocksRepository = DIContainer.shared.resolve(type: BlocksInterface.self),
-              let reportsRepository = DIContainer.shared.resolve(type: ReportsInterface.self) else {
-                ByeBooLogger.error(ByeBooError.DIFailedError)
-                return
-            }
+              let reportsRepository = DIContainer.shared.resolve(type: ReportsInterface.self),
+              let notificationRepository = DIContainer.shared.resolve(type: NotificationInterface.self) else {
+            ByeBooLogger.error(ByeBooError.DIFailedError)
+            return
+        }
         
         DIContainer.shared.register(type: FetchUserJourneyUseCase.self) { _ in
             return DefaultFetchUserJourneyUseCase(repository: userRepository)
@@ -171,7 +172,7 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: FetchCommonQuestMyAnswersUseCase.self) { _ in
             return DefaultFetchCommonQuestMyAnswersUseCase(repository: userRepository)
         }
-      
+        
         DIContainer.shared.register(type: FetchAIAnswerUseCase.self) { _ in
             return DefaultFetchAIAnswerUseCase(repository: questRepository)
         }
@@ -187,7 +188,7 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: UpdateCommonQuestUseCase.self) { _ in
             return DefaultUpdateCommonQuestUseCase(repository: commonQuestRepository)
         }
-      
+        
         DIContainer.shared.register(type: BlockUserUseCase.self) { _ in
             return DefaultBlockUserCase(repository: blocksRepository)
         }
@@ -206,6 +207,10 @@ struct DomainDependencyAssembler: DependencyAssembler {
         
         DIContainer.shared.register(type: DeleteCommonQuestUseCase.self) { _ in
             return DefaultDeleteCommonQuestUseCase(repository: commonQuestRepository)
+        }
+        
+        DIContainer.shared.register(type: FetchNotificationListUseCase.self) { _ in
+            return DefaultFetchNotificationListUseCase(repository: notificationRepository)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -212,5 +212,9 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: FetchNotificationListUseCase.self) { _ in
             return DefaultFetchNotificationListUseCase(repository: notificationRepository)
         }
+        
+        DIContainer.shared.register(type: FormatElapsedTimeUseCase.self) { _ in
+            return DefaultFormatElapsedTimeUseCase()
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/Enum/NotificationType.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/Enum/NotificationType.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationType.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/7/26.
+//
+
+enum NotificationType: CaseIterable {
+    case questOpen
+    case comment
+    case like
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/HasUnreadNotificationEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/HasUnreadNotificationEntity.swift
@@ -1,0 +1,10 @@
+//
+//  HasUnreadNotificationEntity.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/19/26.
+//
+
+struct HasUnreadNotificationEntity {
+    let hasUnread: Bool
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
@@ -11,10 +11,100 @@ struct NotificationListEntity {
 
 struct NotificationEntity {
     let notificationID: Int
-    let notificationType: String
+    let notificationType: NotificationType?
     let title: String
     let content: String
     let isRead: Bool
     let createdAt: String
     let landingURL: String
+}
+
+extension NotificationListEntity {
+    static func stub() -> Self {
+        .init(
+            notifications: [
+                NotificationEntity(
+                    notificationID: 9,
+                    notificationType: .questOpen,
+                    title: "오늘의 퀘스트 오픈 🌱",
+                    content: "24번째 퀘스트가 오픈됐어요, 시작해볼까요?",
+                    isRead: false,
+                    createdAt: "2026-06-07T11:29:00.735730",
+                    landingURL: "myapp://quest/24"
+                ),
+                NotificationEntity(
+                    notificationID: 8,
+                    notificationType: .comment,
+                    title: "공통여정에 답변이 달렸어요 💬",
+                    content: "내가 작성한 글에 보리보리쌀님이 답변을 남겼어요",
+                    isRead: true,
+                    createdAt: "2026-06-07T08:35:43.735730",
+                    landingURL: "myapp://common-quests/24"
+                ),
+                NotificationEntity(
+                    notificationID: 7,
+                    notificationType: .like,
+                    title: "공통여정에 답변에 공감이 달렸어요 ❤️",
+                    content: "내가 작성한 글에 보리보리쌀님이 공감을 남겼어요",
+                    isRead: true,
+                    createdAt: "2026-06-06T15:35:43.735730",
+                    landingURL: "myapp://common-quests/23"
+                ),
+                NotificationEntity(
+                    notificationID: 6,
+                    notificationType: .questOpen,
+                    title: "오늘의 퀘스트 오픈 🌱",
+                    content: "24번째 퀘스트가 오픈됐어요, 시작해볼까요?",
+                    isRead: false,
+                    createdAt: "2026-02-19T02:09:43.735730",
+                    landingURL: "myapp://quest/24"
+                ),
+                NotificationEntity(
+                    notificationID: 5,
+                    notificationType: .comment,
+                    title: "공통여정에 답변이 달렸어요 💬",
+                    content: "내가 작성한 글에 보리보리쌀님이 답변을 남겼어요",
+                    isRead: true,
+                    createdAt: "2026-02-19T02:09:43.735730",
+                    landingURL: "myapp://common-quests/24"
+                ),
+                NotificationEntity(
+                    notificationID: 4,
+                    notificationType: .like,
+                    title: "공통여정에 답변에 공감이 달렸어요 ❤️",
+                    content: "내가 작성한 글에 보리보리쌀님이 공감을 남겼어요",
+                    isRead: true,
+                    createdAt: "2026-02-19T02:09:43.735730",
+                    landingURL: "myapp://common-quests/23"
+                ),
+                NotificationEntity(
+                    notificationID: 3,
+                    notificationType: .questOpen,
+                    title: "오늘의 퀘스트 오픈 🌱",
+                    content: "24번째 퀘스트가 오픈됐어요, 시작해볼까요?",
+                    isRead: false,
+                    createdAt: "2026-02-19T02:09:43.735730",
+                    landingURL: "myapp://quest/24"
+                ),
+                NotificationEntity(
+                    notificationID: 2,
+                    notificationType: .comment,
+                    title: "공통여정에 답변이 달렸어요 💬",
+                    content: "내가 작성한 글에 보리보리쌀님이 답변을 남겼어요",
+                    isRead: true,
+                    createdAt: "2026-02-19T02:09:43.735730",
+                    landingURL: "myapp://common-quests/24"
+                ),
+                NotificationEntity(
+                    notificationID: 1,
+                    notificationType: .like,
+                    title: "공통여정에 답변에 공감이 달렸어요 ❤️",
+                    content: "내가 작성한 글에 보리보리쌀님이 공감을 남겼어요",
+                    isRead: true,
+                    createdAt: "2026-02-19T02:09:43.735730",
+                    landingURL: "myapp://common-quests/23"
+                )
+            ]
+        )
+    }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
@@ -1,0 +1,20 @@
+//
+//  NotificationListEntity.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/5/26.
+//
+
+struct NotificationListEntity {
+    let notifications: [NotificationEntity]
+}
+
+struct NotificationEntity {
+    let notificationID: Int
+    let notificationType: String
+    let title: String
+    let content: String
+    let isRead: Bool
+    let createdAt: String
+    let landingURL: String
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationInterface.swift
@@ -1,0 +1,10 @@
+//
+//  NotificationInterface.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/5/26.
+//
+
+protocol NotificationInterface {
+    func fetchNotifications() async throws -> NotificationListEntity
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationInterface.swift
@@ -7,4 +7,5 @@
 
 protocol NotificationInterface {
     func fetchNotifications() async throws -> NotificationListEntity
+    func fetchHasUnreadNotification() async throws -> HasUnreadNotificationEntity
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationTokenInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationTokenInterface.swift
@@ -5,7 +5,7 @@
 //  Created by APPLE on 11/26/25.
 //
 
-protocol NotificationInterface {
+protocol NotificationTokenInterface {
     func loadToken() -> String?
     func sendToken(token: String) async throws
     func saveToken(token: String)

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchHasUnreadNotificationUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchHasUnreadNotificationUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  FetchHasUnreadNotificationUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/19/26.
+//
+
+protocol FetchHasUnreadNotificationUseCase {
+    func execute() async throws -> HasUnreadNotificationEntity
+}
+
+struct DefaultFetchHasUnreadNotificationUseCase: FetchHasUnreadNotificationUseCase {
+    
+    private let repository: NotificationInterface
+    
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+    
+    func execute() async throws -> HasUnreadNotificationEntity {
+        let result = try await repository.fetchHasUnreadNotification()
+        return result
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchNotificationListUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FetchNotificationListUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  FetchNotificationListUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/5/26.
+//
+
+protocol FetchNotificationListUseCase {
+    func execute() async throws -> NotificationListEntity
+}
+
+struct DefaultFetchNotificationListUseCase: FetchNotificationListUseCase {
+    
+    private let repository: NotificationInterface
+    
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+    
+    func execute() async throws -> NotificationListEntity {
+        try await repository.fetchNotifications()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FormatElapsedTimeUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/FormatElapsedTimeUseCase.swift
@@ -1,0 +1,40 @@
+//
+//  FormatElapsedTimeUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/7/26.
+//
+
+import Foundation
+
+protocol FormatElapsedTimeUseCase {
+    func execute(from timeString: String) -> String?
+}
+
+struct DefaultFormatElapsedTimeUseCase: FormatElapsedTimeUseCase {
+    
+    private let minute: Double = 60
+    private let hour: Double = 3600
+    private let day: Double = 86400
+    
+    func execute(from timeString: String) -> String? {
+        guard let time = DateFormatter.toDetailDate(from: timeString) else {
+            return nil
+        }
+        
+        let diffTime = Date().timeIntervalSince(time)
+        
+        switch diffTime {
+        case ..<minute:
+            return "방금 전"
+        case minute..<hour:
+            let minutes = Int(diffTime / minute)
+            return "\(minutes)분 전"
+        case hour..<day:
+            let hours = Int(diffTime / hour)
+            return "\(hours)시간 전"
+        default:
+            return DateFormatter.toDisplayDateString(from: time)
+        }
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardCell.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardCell.swift
@@ -29,6 +29,7 @@ final class NoticeCardCell: UITableViewCell {
     private func setStyle() {
         self.do {
             $0.layer.cornerRadius = 12
+            $0.selectionStyle = .none
         }
         titleLabel.applyByeBooFont(
             style: .body1Sb16,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardCell.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardCell.swift
@@ -86,12 +86,12 @@ extension NoticeCardCell {
         iconImage: UIImage,
         title: String,
         subtitle: String,
-        writtenTiem: String
+        writtenTime: String
     ) {
         self.backgroundColor = backgroundColor
         noticeImageView.image = iconImage
         titleLabel.text = title
         subtitleLabel.text = subtitle
-        writtenTimeLabel.text = writtenTiem
+        writtenTimeLabel.text = writtenTime
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardCell.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardCell.swift
@@ -82,16 +82,25 @@ final class NoticeCardCell: UITableViewCell {
 extension NoticeCardCell {
     
     func bind(
-        backgroundColor: UIColor,
-        iconImage: UIImage,
+        isRead: Bool,
+        notificationType: NotificationType,
         title: String,
         subtitle: String,
         writtenTime: String
     ) {
-        self.backgroundColor = backgroundColor
-        noticeImageView.image = iconImage
+        self.backgroundColor = isRead ? .primary30020 : .white5
+        noticeImageView.image = mapToImage(for: notificationType)
         titleLabel.text = title
         subtitleLabel.text = subtitle
         writtenTimeLabel.text = writtenTime
+    }
+    
+    private func mapToImage(for notificationType: NotificationType) -> UIImage {
+        switch notificationType {
+        case .questOpen:
+            return .myOn
+        case .comment, .like:
+            return .commonJourney
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -22,7 +22,6 @@ final class HomeViewController: BaseViewController {
     private var isFirstVisit: Bool = true
     private var journeyType: JourneyType = .recording
     private var isAnimating: Bool = false
-    private var isExistNotice: Bool?
     
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -61,9 +60,6 @@ final class HomeViewController: BaseViewController {
         if isFirstVisit { isFirstVisit.toggle() }
         
         self.navigationController?.setNavigationBarHidden(true, animated: false)
-        // 추후 API 연동 시 뷰모델 액션을 호출하여 알림 유무를 판단할 예정
-        rootView.headerView.updateNotice(isExist: true)
-        isExistNotice = true
     }
     
     override func setAddTarget() {
@@ -121,11 +117,10 @@ extension HomeViewController {
     }
     
     @objc
-    private func noticeButtonDidTap() {
-        guard let isExistNotice else { return }
-        
-        let viewController = ViewControllerFactory.shared.makeNoticesViewController(isExistNotice: isExistNotice)
+    private func noticeButtonDidTap() {        
+        let viewController = ViewControllerFactory.shared.makeNoticesViewController()
         viewController.hidesBottomBarWhenPushed = true
+        viewController.configure(notificationList: viewModel.notifications)
         
         self.navigationController?.setNavigationBarHidden(false, animated: false)
         self.navigationController?.pushViewController(viewController, animated: false)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -47,6 +47,9 @@ final class HomeViewController: BaseViewController {
         super.viewWillAppear(animated)
         
         viewModel.action(.viewWillAppear)
+        if isFirstVisit { isFirstVisit.toggle() }
+        
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
         
         let property = HomeEvents.HomePageProperty(
             isFirstPageView: isFirstVisit,
@@ -56,10 +59,6 @@ final class HomeViewController: BaseViewController {
             event: HomeEvents.Name.homePageView,
             properties: property.dictionary
         )
-        
-        if isFirstVisit { isFirstVisit.toggle() }
-        
-        self.navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     override func setAddTarget() {
@@ -147,6 +146,13 @@ extension HomeViewController {
 
 extension HomeViewController: ToastPresentable, ToastErrorHandler {
     private func bind() {
+        bindCharacter()
+        bindHomeState()
+        bindHelper()
+        bindNotifications()
+    }
+    
+    private func bindCharacter() {
         viewModel.output.characterResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
@@ -158,7 +164,9 @@ extension HomeViewController: ToastPresentable, ToastErrorHandler {
                 }
             }
             .store(in: &cancellables)
-        
+    }
+    
+    private func bindHomeState() {
         Publishers.CombineLatest3(
             viewModel.output.userResult,
             viewModel.output.journeyResult,
@@ -188,12 +196,29 @@ extension HomeViewController: ToastPresentable, ToastErrorHandler {
                 }
             }
             .store(in: &cancellables)
-        
+    }
+    
+    private func bindHelper() {
         viewModel.output.helperResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 if !result {
                     self?.rootView.headerView.startHelperAnimation()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func bindNotifications() {
+        viewModel.output.notificationResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let notificationList):
+                    let isAllRead = notificationList.notifications.allSatisfy { $0.isRead }
+                    self?.rootView.headerView.updateNotice(isExist: !isAllRead)
+                case .failure(let error):
+                    self?.handleError(error)
                 }
             }
             .store(in: &cancellables)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -118,7 +118,7 @@ extension HomeViewController {
     
     @objc
     private func noticeButtonDidTap() {        
-        let viewController = ViewControllerFactory.shared.makeNoticesViewController()
+        let viewController = ViewControllerFactory.shared.makeNotificationsViewController()
         viewController.hidesBottomBarWhenPushed = true
         viewController.configure(notificationList: viewModel.notifications)
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -116,10 +116,9 @@ extension HomeViewController {
     }
     
     @objc
-    private func noticeButtonDidTap() {        
+    private func noticeButtonDidTap() {
         let viewController = ViewControllerFactory.shared.makeNotificationsViewController()
         viewController.hidesBottomBarWhenPushed = true
-        viewController.configure(notificationList: viewModel.notifications)
         
         self.navigationController?.setNavigationBarHidden(false, animated: false)
         self.navigationController?.pushViewController(viewController, animated: false)
@@ -149,7 +148,7 @@ extension HomeViewController: ToastPresentable, ToastErrorHandler {
         bindCharacter()
         bindHomeState()
         bindHelper()
-        bindNotifications()
+        bindHasNotification()
     }
     
     private func bindCharacter() {
@@ -209,14 +208,13 @@ extension HomeViewController: ToastPresentable, ToastErrorHandler {
             .store(in: &cancellables)
     }
     
-    private func bindNotifications() {
-        viewModel.output.notificationResult
+    private func bindHasNotification() {
+        viewModel.output.hasNotifcationResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
                 switch result {
-                case .success(let notificationList):
-                    let isAllRead = notificationList.notifications.allSatisfy { $0.isRead }
-                    self?.rootView.headerView.updateNotice(isExist: !isAllRead)
+                case .success(let entity):
+                    self?.rootView.headerView.updateNotice(isExist: entity.hasUnread)
                 case .failure(let error):
                     self?.handleError(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NoticesViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NoticesViewController.swift
@@ -9,11 +9,10 @@ import UIKit
 
 final class NoticesViewController: BaseViewController {
     
-    private let isExistNotice: Bool
     private let rootView = NoticesView()
+    private var notificationList: NotificationListEntity?
     
-    init(isExistNotice: Bool) {
-        self.isExistNotice = isExistNotice
+    init() {
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -35,7 +34,11 @@ final class NoticesViewController: BaseViewController {
             action: #selector(back)
         )
                 
-        rootView.contentView.decideNoticeContent(isExistNotice: isExistNotice)
+        guard let notifications = notificationList?.notifications else {
+            return
+        }
+        
+        rootView.contentView.decideNoticeContent(isExistNotice: !notifications.isEmpty)
     }
     
     override func setAddTarget() {
@@ -66,6 +69,13 @@ extension NoticesViewController {
     
     @objc
     private func readAllButtonDidTap() {}
+}
+
+extension NoticesViewController {
+    
+    func configure(notificationList: NotificationListEntity?) {
+        self.notificationList = notificationList
+    }
 }
 
 extension NoticesViewController: UITableViewDataSource {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
@@ -1,5 +1,5 @@
 //
-//  NoticesViewController.swift
+//  NotificationsViewController.swift
 //  ByeBoo-iOS
 //
 //  Created by APPLE on 4/30/26.
@@ -7,12 +7,14 @@
 
 import UIKit
 
-final class NoticesViewController: BaseViewController {
+final class NotificationsViewController: BaseViewController {
     
     private let rootView = NoticesView()
+    private let viewModel: NotificationsViewModel
     private var notificationList: NotificationListEntity?
     
-    init() {
+    init(viewModel: NotificationsViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -33,7 +35,7 @@ final class NoticesViewController: BaseViewController {
             type: .titleAndBack("알림"),
             action: #selector(back)
         )
-                
+        
         guard let notifications = notificationList?.notifications else {
             return
         }
@@ -58,31 +60,30 @@ final class NoticesViewController: BaseViewController {
     }
 }
 
-extension NoticesViewController: BackNavigable {
+extension NotificationsViewController: BackNavigable {
     
     func back() {
         self.navigationController?.popViewController(animated: false)
     }
 }
 
-extension NoticesViewController {
+extension NotificationsViewController {
     
     @objc
     private func readAllButtonDidTap() {}
 }
 
-extension NoticesViewController {
+extension NotificationsViewController {
     
     func configure(notificationList: NotificationListEntity?) {
         self.notificationList = notificationList
     }
 }
 
-extension NoticesViewController: UITableViewDataSource {
+extension NotificationsViewController: UITableViewDataSource {
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        // 실제로는 알림 개수만큼 설정
-        2
+        notificationList?.notifications.count ?? 0
     }
     
     func tableView(
@@ -97,16 +98,31 @@ extension NoticesViewController: UITableViewDataSource {
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
         
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: NoticeCardCell.identifier, for: indexPath) as? NoticeCardCell
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: NoticeCardCell.identifier,
+                for: indexPath
+            ) as? NoticeCardCell,
+            let notification = notificationList?.notifications[indexPath.section],
+            let notificationType = notification.notificationType,
+            let writtenTime = viewModel.formatElapsedTime(from: notification.createdAt)
         else {
             return UITableViewCell()
         }
-
+        
+        cell.bind(
+            isRead: notification.isRead,
+            notificationType: notificationType,
+            title: notification.title,
+            subtitle: notification.content,
+            writtenTime: writtenTime
+        )
+        
         return cell
     }
 }
 
-extension NoticesViewController: UITableViewDelegate {
+extension NotificationsViewController: UITableViewDelegate {
     
     func tableView(
         _ tableView: UITableView,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
@@ -5,13 +5,14 @@
 //  Created by APPLE on 4/30/26.
 //
 
+import Combine
 import UIKit
 
 final class NotificationsViewController: BaseViewController {
     
     private let rootView = NoticesView()
     private let viewModel: NotificationsViewModel
-    private var notificationList: NotificationListEntity?
+    private var cancellables = Set<AnyCancellable>()
     
     init(viewModel: NotificationsViewModel) {
         self.viewModel = viewModel
@@ -26,6 +27,11 @@ final class NotificationsViewController: BaseViewController {
         view = rootView
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.action(.viewWillAppear)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -36,11 +42,7 @@ final class NotificationsViewController: BaseViewController {
             action: #selector(back)
         )
         
-        guard let notifications = notificationList?.notifications else {
-            return
-        }
-        
-        rootView.contentView.decideNoticeContent(isExistNotice: !notifications.isEmpty)
+        bind()
     }
     
     override func setAddTarget() {
@@ -67,23 +69,34 @@ extension NotificationsViewController: BackNavigable {
     }
 }
 
+extension NotificationsViewController: ToastPresentable, ToastErrorHandler {
+    
+    func bind() {
+        viewModel.output.notificationList
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let notificationList):
+                    self?.rootView.contentView.decideNoticeContent(isExistNotice: !notificationList.notifications.isEmpty)
+                    self?.rootView.contentView.noticeCardsView.cardTableView.reloadData()
+                case .failure(let error):
+                    self?.handleError(error)
+                }
+            }
+            .store(in: &cancellables)
+    }
+}
+
 extension NotificationsViewController {
     
     @objc
     private func readAllButtonDidTap() {}
 }
 
-extension NotificationsViewController {
-    
-    func configure(notificationList: NotificationListEntity?) {
-        self.notificationList = notificationList
-    }
-}
-
 extension NotificationsViewController: UITableViewDataSource {
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        notificationList?.notifications.count ?? 0
+        viewModel.notificatinosCount
     }
     
     func tableView(
@@ -103,7 +116,7 @@ extension NotificationsViewController: UITableViewDataSource {
                 withIdentifier: NoticeCardCell.identifier,
                 for: indexPath
             ) as? NoticeCardCell,
-            let notification = notificationList?.notifications[indexPath.section],
+            let notification = viewModel.getNotification(at: indexPath.section),
             let notificationType = notification.notificationType,
             let writtenTime = viewModel.formatElapsedTime(from: notification.createdAt)
         else {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -72,17 +72,24 @@ extension HomeViewModel: ViewModelType {
         let helperResult: AnyPublisher<Bool, Never>
         let homeStateResult: AnyPublisher<Result<UserQuestStatusEntity, ByeBooError>, Never>
         let journeyResult: AnyPublisher<Result<JourneyEntity, ByeBooError>, Never>
+        let notificationResult: AnyPublisher<Result<NotificationListEntity, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
         switch trigger {
         case .viewWillAppear:
-            // TODO: 구조적 동시성 반영
-            fetchDialogue()
-            fetchStatus()
-            fetchJourney()
-            
             getUserResult()
+            
+            Task {
+                await withTaskGroup(of: Void.self) { group in
+                    group.addTask { await self.fetchDialogue() }
+                    group.addTask { await self.fetchStatus() }
+                    group.addTask { await self.fetchJourney() }
+                    group.addTask { await self.fetchNotificationList() }
+                    
+                    await group.waitForAll()
+                }
+            }
         case .helperDidTap:
             setHelperShown()
         }
@@ -90,49 +97,43 @@ extension HomeViewModel: ViewModelType {
 }
 
 extension HomeViewModel {
-    private func fetchDialogue() {
-        Task {
-            do {
-                let dialogues = try await fetchCharacterDialogueUseCase.execute()
-                characterResultSubject.send(.success(dialogues))
-            } catch {
-                characterResultSubject.send(
-                    .failure(
-                        error as? ByeBooError ?? ByeBooError.unknownError
-                    )
+    private func fetchDialogue() async {
+        do {
+            let dialogues = try await fetchCharacterDialogueUseCase.execute()
+            characterResultSubject.send(.success(dialogues))
+        } catch {
+            characterResultSubject.send(
+                .failure(
+                    error as? ByeBooError ?? ByeBooError.unknownError
                 )
-            }
+            )
         }
     }
     
-    private func fetchStatus() {
-        Task {
-            do {
-                let status = try await fetchQuestStatusUseCase.execute()
-                homeStateResultSubject.send(.success(status))
-                isHelperShown(state: status.currentStatus)
-                ByeBooLogger.debug("home status: \(status)")
-            } catch {
-                if let error = error as? ByeBooError {
-                    homeStateResultSubject.send(.failure(error))
-                }
-                isHelperShown(state: .beforeJourneyStart)
+    private func fetchStatus() async {
+        do {
+            let status = try await fetchQuestStatusUseCase.execute()
+            homeStateResultSubject.send(.success(status))
+            isHelperShown(state: status.currentStatus)
+            ByeBooLogger.debug("home status: \(status)")
+        } catch {
+            if let error = error as? ByeBooError {
+                homeStateResultSubject.send(.failure(error))
             }
+            isHelperShown(state: .beforeJourneyStart)
         }
     }
     
-    private func fetchJourney() {
-        Task {
-            do {
-                let journey = try await fetchUserJourneyUseCase.execute()
-                journeyResultSubject.send(.success(journey))
-            } catch {
-                journeyResultSubject.send(
-                    .failure(
-                        error as? ByeBooError ?? ByeBooError.unknownError
-                    )
+    private func fetchJourney() async {
+        do {
+            let journey = try await fetchUserJourneyUseCase.execute()
+            journeyResultSubject.send(.success(journey))
+        } catch {
+            journeyResultSubject.send(
+                .failure(
+                    error as? ByeBooError ?? ByeBooError.unknownError
                 )
-            }
+            )
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -23,7 +23,6 @@ final class HomeViewModel {
     private var isHelperShownResultSubject = CurrentValueSubject<Bool, Never>(true)
     private var homeStateResultSubject = PassthroughSubject<Result<UserQuestStatusEntity, ByeBooError>, Never>()
     private var journeyResultSubject = PassthroughSubject<Result<JourneyEntity, ByeBooError>, Never>()
-    private var notificationResultSubject = PassthroughSubject<Result<NotificationListEntity, ByeBooError>, Never>()
     
     private let fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase
     private let fetchQuestStatusUseCase: FetchQuestStatusUseCase
@@ -31,7 +30,6 @@ final class HomeViewModel {
     private let getUserNameUseCase: GetUserNameUseCase
     private let setHelperUseCase: SetHelperUseCase
     private let getHelperUseCase: GetHelperUseCase
-    private let fetchNotificationListUseCase: FetchNotificationListUseCase
     
     init(
         fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase,
@@ -39,8 +37,7 @@ final class HomeViewModel {
         fetchUserJourneyUseCase: FetchUserJourneyUseCase,
         getUserNameUseCase: GetUserNameUseCase,
         setHelperUseCase: SetHelperUseCase,
-        getHelperUseCase: GetHelperUseCase,
-        fetchNotificationListUseCase: FetchNotificationListUseCase
+        getHelperUseCase: GetHelperUseCase
     ) {
         self.fetchCharacterDialogueUseCase = fetchCharacterDialogueUseCase
         self.fetchQuestStatusUseCase = fetchQuestStatusUseCase
@@ -48,15 +45,13 @@ final class HomeViewModel {
         self.getUserNameUseCase = getUserNameUseCase
         self.setHelperUseCase = setHelperUseCase
         self.getHelperUseCase = getHelperUseCase
-        self.fetchNotificationListUseCase = fetchNotificationListUseCase
         
         output = Output(
             characterResult: characterResultSubject.eraseToAnyPublisher(),
             userResult: userResultSubject.eraseToAnyPublisher(),
             helperResult: isHelperShownResultSubject.eraseToAnyPublisher(),
             homeStateResult: homeStateResultSubject.eraseToAnyPublisher(),
-            journeyResult: journeyResultSubject.eraseToAnyPublisher(),
-            notificationResult: notificationResultSubject.eraseToAnyPublisher()
+            journeyResult: journeyResultSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -73,7 +68,6 @@ extension HomeViewModel: ViewModelType {
         let helperResult: AnyPublisher<Bool, Never>
         let homeStateResult: AnyPublisher<Result<UserQuestStatusEntity, ByeBooError>, Never>
         let journeyResult: AnyPublisher<Result<JourneyEntity, ByeBooError>, Never>
-        let notificationResult: AnyPublisher<Result<NotificationListEntity, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -85,9 +79,8 @@ extension HomeViewModel: ViewModelType {
                 async let dialogue: Void = fetchDialogue()
                 async let status: Void = fetchStatus()
                 async let journey: Void = fetchJourney()
-                async let notificationList: Void = fetchNotificationList()
                 
-                let _ = await (dialogue, status, journey, notificationList)
+                let _ = await (dialogue, status, journey)
             }
             
         case .helperDidTap:
@@ -152,15 +145,5 @@ extension HomeViewModel {
     
     private func setHelperShown() {
         setHelperUseCase.execute()
-    }
-    
-    private func fetchNotificationList() async {
-        do {
-            let notifications = try await fetchNotificationListUseCase.execute()
-            self.notifications = notifications
-            notificationResultSubject.send(.success(notifications))
-        } catch {
-            notificationResultSubject.send(.failure(error as? ByeBooError ?? ByeBooError.unknownError))
-        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -82,15 +82,14 @@ extension HomeViewModel: ViewModelType {
             getUserResult()
             
             Task {
-                await withTaskGroup(of: Void.self) { group in
-                    group.addTask { await self.fetchDialogue() }
-                    group.addTask { await self.fetchStatus() }
-                    group.addTask { await self.fetchJourney() }
-                    group.addTask { await self.fetchNotificationList() }
-                    
-                    await group.waitForAll()
-                }
+                async let dialogue: Void = fetchDialogue()
+                async let status: Void = fetchStatus()
+                async let journey: Void = fetchJourney()
+                async let notificationList: Void = fetchNotificationList()
+                
+                let _ = await (dialogue, status, journey, notificationList)
             }
+            
         case .helperDidTap:
             setHelperShown()
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -15,6 +15,7 @@ final class HomeViewModel {
     var dialoguesResult: Result<DialogueEntity, ByeBooError> {
         characterResultSubject.value
     }
+    private(set) var notifications: NotificationListEntity?
     
     private(set) var output: Output
     private var characterResultSubject = CurrentValueSubject<Result<DialogueEntity, ByeBooError>, Never>(.failure(ByeBooError.noData))
@@ -157,6 +158,7 @@ extension HomeViewModel {
     private func fetchNotificationList() async {
         do {
             let notifications = try await fetchNotificationListUseCase.execute()
+            self.notifications = notifications
             notificationResultSubject.send(.success(notifications))
         } catch {
             notificationResultSubject.send(.failure(error as? ByeBooError ?? ByeBooError.unknownError))

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -22,13 +22,15 @@ final class HomeViewModel {
     private var isHelperShownResultSubject = CurrentValueSubject<Bool, Never>(true)
     private var homeStateResultSubject = PassthroughSubject<Result<UserQuestStatusEntity, ByeBooError>, Never>()
     private var journeyResultSubject = PassthroughSubject<Result<JourneyEntity, ByeBooError>, Never>()
-
+    private var notificationResultSubject = PassthroughSubject<Result<NotificationListEntity, ByeBooError>, Never>()
+    
     private let fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase
     private let fetchQuestStatusUseCase: FetchQuestStatusUseCase
     private let fetchUserJourneyUseCase: FetchUserJourneyUseCase
     private let getUserNameUseCase: GetUserNameUseCase
     private let setHelperUseCase: SetHelperUseCase
     private let getHelperUseCase: GetHelperUseCase
+    private let fetchNotificationListUseCase: FetchNotificationListUseCase
     
     init(
         fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase,
@@ -36,7 +38,8 @@ final class HomeViewModel {
         fetchUserJourneyUseCase: FetchUserJourneyUseCase,
         getUserNameUseCase: GetUserNameUseCase,
         setHelperUseCase: SetHelperUseCase,
-        getHelperUseCase: GetHelperUseCase
+        getHelperUseCase: GetHelperUseCase,
+        fetchNotificationListUseCase: FetchNotificationListUseCase
     ) {
         self.fetchCharacterDialogueUseCase = fetchCharacterDialogueUseCase
         self.fetchQuestStatusUseCase = fetchQuestStatusUseCase
@@ -44,13 +47,15 @@ final class HomeViewModel {
         self.getUserNameUseCase = getUserNameUseCase
         self.setHelperUseCase = setHelperUseCase
         self.getHelperUseCase = getHelperUseCase
+        self.fetchNotificationListUseCase = fetchNotificationListUseCase
         
         output = Output(
             characterResult: characterResultSubject.eraseToAnyPublisher(),
             userResult: userResultSubject.eraseToAnyPublisher(),
             helperResult: isHelperShownResultSubject.eraseToAnyPublisher(),
             homeStateResult: homeStateResultSubject.eraseToAnyPublisher(),
-            journeyResult: journeyResultSubject.eraseToAnyPublisher()
+            journeyResult: journeyResultSubject.eraseToAnyPublisher(),
+            notificationResult: notificationResultSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -137,7 +142,6 @@ extension HomeViewModel {
     }
     
     private func isHelperShown(state: HomeState) {
-        
         if !getHelperUseCase.execute() && state == .beforeJourneyStart {
             isHelperShownResultSubject.send(false)
         } else {
@@ -147,5 +151,14 @@ extension HomeViewModel {
     
     private func setHelperShown() {
         setHelperUseCase.execute()
+    }
+    
+    private func fetchNotificationList() async {
+        do {
+            let notifications = try await fetchNotificationListUseCase.execute()
+            notificationResultSubject.send(.success(notifications))
+        } catch {
+            notificationResultSubject.send(.failure(error as? ByeBooError ?? ByeBooError.unknownError))
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/HomeViewModel.swift
@@ -15,7 +15,6 @@ final class HomeViewModel {
     var dialoguesResult: Result<DialogueEntity, ByeBooError> {
         characterResultSubject.value
     }
-    private(set) var notifications: NotificationListEntity?
     
     private(set) var output: Output
     private var characterResultSubject = CurrentValueSubject<Result<DialogueEntity, ByeBooError>, Never>(.failure(ByeBooError.noData))
@@ -23,6 +22,7 @@ final class HomeViewModel {
     private var isHelperShownResultSubject = CurrentValueSubject<Bool, Never>(true)
     private var homeStateResultSubject = PassthroughSubject<Result<UserQuestStatusEntity, ByeBooError>, Never>()
     private var journeyResultSubject = PassthroughSubject<Result<JourneyEntity, ByeBooError>, Never>()
+    private var hasNotificationResultSubject = PassthroughSubject<Result<HasUnreadNotificationEntity, ByeBooError>,Never>()
     
     private let fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase
     private let fetchQuestStatusUseCase: FetchQuestStatusUseCase
@@ -30,6 +30,7 @@ final class HomeViewModel {
     private let getUserNameUseCase: GetUserNameUseCase
     private let setHelperUseCase: SetHelperUseCase
     private let getHelperUseCase: GetHelperUseCase
+    private let fetchHasUnreadNotificationUseCase: FetchHasUnreadNotificationUseCase
     
     init(
         fetchCharacterDialogueUseCase: FetchCharacterDialogueUseCase,
@@ -37,7 +38,8 @@ final class HomeViewModel {
         fetchUserJourneyUseCase: FetchUserJourneyUseCase,
         getUserNameUseCase: GetUserNameUseCase,
         setHelperUseCase: SetHelperUseCase,
-        getHelperUseCase: GetHelperUseCase
+        getHelperUseCase: GetHelperUseCase,
+        fetchHasUnreadNotificationUseCase: FetchHasUnreadNotificationUseCase
     ) {
         self.fetchCharacterDialogueUseCase = fetchCharacterDialogueUseCase
         self.fetchQuestStatusUseCase = fetchQuestStatusUseCase
@@ -45,13 +47,15 @@ final class HomeViewModel {
         self.getUserNameUseCase = getUserNameUseCase
         self.setHelperUseCase = setHelperUseCase
         self.getHelperUseCase = getHelperUseCase
+        self.fetchHasUnreadNotificationUseCase = fetchHasUnreadNotificationUseCase
         
         output = Output(
             characterResult: characterResultSubject.eraseToAnyPublisher(),
             userResult: userResultSubject.eraseToAnyPublisher(),
             helperResult: isHelperShownResultSubject.eraseToAnyPublisher(),
             homeStateResult: homeStateResultSubject.eraseToAnyPublisher(),
-            journeyResult: journeyResultSubject.eraseToAnyPublisher()
+            journeyResult: journeyResultSubject.eraseToAnyPublisher(),
+            hasNotifcationResult: hasNotificationResultSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -68,6 +72,7 @@ extension HomeViewModel: ViewModelType {
         let helperResult: AnyPublisher<Bool, Never>
         let homeStateResult: AnyPublisher<Result<UserQuestStatusEntity, ByeBooError>, Never>
         let journeyResult: AnyPublisher<Result<JourneyEntity, ByeBooError>, Never>
+        let hasNotifcationResult: AnyPublisher<Result<HasUnreadNotificationEntity, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -79,6 +84,7 @@ extension HomeViewModel: ViewModelType {
                 async let dialogue: Void = fetchDialogue()
                 async let status: Void = fetchStatus()
                 async let journey: Void = fetchJourney()
+                async let hasNotification: Void = fetchHasUnreadNotification()
                 
                 let _ = await (dialogue, status, journey)
             }
@@ -145,5 +151,18 @@ extension HomeViewModel {
     
     private func setHelperShown() {
         setHelperUseCase.execute()
+    }
+    
+    private func fetchHasUnreadNotification() async {
+        do {
+            let result = try await fetchHasUnreadNotificationUseCase.execute()
+            hasNotificationResultSubject.send(.success(result))
+        } catch {
+            hasNotificationResultSubject.send(
+                .failure(
+                    error as? ByeBooError ?? ByeBooError.unknownError
+                )
+            )
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  NotificationsViewModel.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/7/26.
+//
+
+final class NotificationsViewModel {
+    
+    private let formatElapsedTimeUseCase: FormatElapsedTimeUseCase
+    
+    init(formatElapsedTimeUseCase: FormatElapsedTimeUseCase) {
+        self.formatElapsedTimeUseCase = formatElapsedTimeUseCase
+    }
+    
+    func formatElapsedTime(from timeString: String) -> String? {
+        guard let formattedTime = formatElapsedTimeUseCase.execute(from: timeString) else {
+            return nil
+        }
+        
+        return formattedTime
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
@@ -5,19 +5,75 @@
 //  Created by 더스틴 on 6/7/26.
 //
 
+import Combine
+
 final class NotificationsViewModel {
     
+    private var cancellables = Set<AnyCancellable>()
+    private var notifications: [NotificationEntity]?
+    
+    private let fetchNotificationListUseCase: FetchNotificationListUseCase
     private let formatElapsedTimeUseCase: FormatElapsedTimeUseCase
     
-    init(formatElapsedTimeUseCase: FormatElapsedTimeUseCase) {
+    private(set) var output: Output
+    private var notificationListSubject = PassthroughSubject<Result<NotificationListEntity, ByeBooError>, Never>()
+    
+    init(
+        fetchNotificationListUseCase: FetchNotificationListUseCase,
+        formatElapsedTimeUseCase: FormatElapsedTimeUseCase
+    ) {
+        self.fetchNotificationListUseCase = fetchNotificationListUseCase
         self.formatElapsedTimeUseCase = formatElapsedTimeUseCase
+        self.output = .init(notificationList: notificationListSubject.eraseToAnyPublisher())
+    }
+}
+
+extension NotificationsViewModel: ViewModelType {
+    enum Input {
+        case viewWillAppear
+    }
+    
+    struct Output {
+        let notificationList: AnyPublisher<Result<NotificationListEntity, ByeBooError>, Never>
+    }
+    
+    func action(_ trigger: Input) {
+        switch trigger {
+        case .viewWillAppear:
+            fetchNotificationList()
+        }
+    }
+}
+
+extension NotificationsViewModel {
+    
+    func fetchNotificationList() {
+        Task {
+            do {
+                let notificationList = try await fetchNotificationListUseCase.execute()
+                self.notifications = notificationList.notifications
+                notificationListSubject.send(.success(notificationList))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                notificationListSubject.send(.failure(error))
+            }
+        }
     }
     
     func formatElapsedTime(from timeString: String) -> String? {
-        guard let formattedTime = formatElapsedTimeUseCase.execute(from: timeString) else {
-            return nil
-        }
-        
-        return formattedTime
+        formatElapsedTimeUseCase.execute(from: timeString)
+    }
+}
+
+extension NotificationsViewModel {
+    
+    var notificatinosCount: Int {
+        notifications?.count ?? 0
+    }
+    
+    func getNotification(at index: Int) -> NotificationEntity? {
+        notifications?[index]
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
@@ -13,6 +13,7 @@ final class CommonQuestMyAnswerViewModel {
     private let cancellables = Set<AnyCancellable>()
     private let nameSubject = PassthroughSubject<Result<String, ByeBooError>, Never>.init()
     private let answersSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
+    
     private let getUserNameUseCase: GetUserNameUseCase
     private let fetchCommonQuestMyAnswersUseCase: FetchCommonQuestMyAnswersUseCase
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -13,9 +13,7 @@ final class CommonQuestViewModel {
     private let cancellables = Set<AnyCancellable>()
     private let commonQuestSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
     private let fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase
-    private let minute: Double = 60
-    private let hour: Double = 3600
-    private let day: Double = 86400
+    private let formatElapsedTimeUseCase: FormatElapsedTimeUseCase
     
     private(set) var output: Output
     private var commonQuest: CommonQuestAnswersEntity?
@@ -24,8 +22,12 @@ final class CommonQuestViewModel {
     private var nextCursor: Int? = nil
     private var currentDate: String = DateFormatter.toAPIDateString(from: .now)
     
-    init(fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase) {
+    init(
+        fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase,
+        formatElapsedTimeUseCase: FormatElapsedTimeUseCase
+    ) {
         self.fetchCommonQuestByDateUseCase = fetchCommonQuestByDateUseCase
+        self.formatElapsedTimeUseCase = formatElapsedTimeUseCase
         self.output = Output(
             commonQuestPublisher: commonQuestSubject.eraseToAnyPublisher()
         )
@@ -127,25 +129,6 @@ extension CommonQuestViewModel {
     }
     
     func getWrittenAt(at index: Int) -> String? {
-        guard index >= 0 && index < answers.count,
-              let writtenAt = DateFormatter.toDetailDate(from: answers[index].writtenAt)
-        else {
-            return nil
-        }
-        
-        let diffTime = Date().timeIntervalSince(writtenAt)
-        
-        switch diffTime {
-        case ..<minute:
-            return "방금 전"
-        case minute..<hour:
-            let minutes = Int(diffTime / minute)
-            return "\(minutes)분 전"
-        case hour..<day:
-            let hours = Int(diffTime / hour)
-            return "\(hours)시간 전"
-        default:
-            return DateFormatter.toDisplayDateString(from: writtenAt)
-        }
+        formatElapsedTimeUseCase.execute(from: answers[index].writtenAt)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -356,12 +356,16 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: NotificationsViewModel.self) { container in
-            guard let fetchNotificationListUseCase = container.resolve(type: FetchNotificationListUseCase.self) else  {
+            guard let fetchNotificationListUseCase = container.resolve(type: FetchNotificationListUseCase.self),
+                  let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self) else  {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             
-            return NotificationsViewModel(fetchNotificationListUseCase: fetchNotificationListUseCase)
+            return NotificationsViewModel(
+                fetchNotificationListUseCase: fetchNotificationListUseCase,
+                formatElapsedTimeUseCase: formatElapsedTimeUseCase
+            )
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -107,7 +107,9 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                   let setHelperUseCase = container.resolve(type: SetHelperUseCase.self),
                   let fetchUserJourneyUseCase = container.resolve(type: FetchUserJourneyUseCase.self),
                   let getUserNameUseCase = container.resolve(type: GetUserNameUseCase.self),
-                  let getHelperUseCase = container.resolve(type: GetHelperUseCase.self) else {
+                  let getHelperUseCase = container.resolve(type: GetHelperUseCase.self),
+                  let fetchNotificationListUseCase = container.resolve(type: FetchNotificationListUseCase.self)
+            else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
@@ -118,7 +120,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 fetchUserJourneyUseCase: fetchUserJourneyUseCase,
                 getUserNameUseCase: getUserNameUseCase,
                 setHelperUseCase: setHelperUseCase,
-                getHelperUseCase: getHelperUseCase
+                getHelperUseCase: getHelperUseCase,
+                fetchNotificationListUseCase: fetchNotificationListUseCase
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -108,7 +108,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                   let fetchUserJourneyUseCase = container.resolve(type: FetchUserJourneyUseCase.self),
                   let getUserNameUseCase = container.resolve(type: GetUserNameUseCase.self),
                   let getHelperUseCase = container.resolve(type: GetHelperUseCase.self),
-                  let fetchNotificationListUseCase = container.resolve(type: FetchNotificationListUseCase.self)
+                  let fetchHasUnreadNotificationUseCase = container.resolve(type: FetchHasUnreadNotificationUseCase.self)
             else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -121,7 +121,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 getUserNameUseCase: getUserNameUseCase,
                 setHelperUseCase: setHelperUseCase,
                 getHelperUseCase: getHelperUseCase,
-                fetchNotificationListUseCase: fetchNotificationListUseCase
+                fetchHasUnreadNotificationUseCase: fetchHasUnreadNotificationUseCase
             )
         }
         
@@ -356,12 +356,12 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: NotificationsViewModel.self) { container in
-            guard let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self) else  {
+            guard let fetchNotificationListUseCase = container.resolve(type: FetchNotificationListUseCase.self) else  {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             
-            return NotificationsViewModel(formatElapsedTimeUseCase: formatElapsedTimeUseCase)
+            return NotificationsViewModel(fetchNotificationListUseCase: fetchNotificationListUseCase)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -289,13 +289,15 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: CommonQuestViewModel.self) { container in
-            guard let fetchCommonQuestByDateUseCase = container.resolve(type: FetchCommonQuestByDateUseCase.self) else {
+            guard let fetchCommonQuestByDateUseCase = container.resolve(type: FetchCommonQuestByDateUseCase.self),
+                  let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             
             return CommonQuestViewModel(
-                fetchCommonQuestByDateUseCase: fetchCommonQuestByDateUseCase
+                fetchCommonQuestByDateUseCase: fetchCommonQuestByDateUseCase,
+                formatElapsedTimeUseCase: formatElapsedTimeUseCase
             )
         }
         
@@ -351,6 +353,15 @@ struct PresentationDependencyAssembler: DependencyAssembler {
                 getBlockedUsersListUseCase: getBlockedUsersListUseCase,
                 deleteBlockedUserUseCase: deleteBlockedUserUseCase
             )
+        }
+        
+        DIContainer.shared.register(type: NotificationsViewModel.self) { container in
+            guard let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self) else  {
+                ByeBooLogger.error(ByeBooError.DIFailedError)
+                return
+            }
+            
+            return NotificationsViewModel(formatElapsedTimeUseCase: formatElapsedTimeUseCase)
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
@@ -26,6 +26,14 @@ protocol ViewControllerFactoryProtocol {
     func makeWriteActiveTypeQuestViewController() -> WriteActiveTypeQuestViewController
     func makeFinishJourneyViewController() -> FinishJourneyViewController
     func makeCommonQuestBottomSheetViewController() -> CommonQuestBottomSheetViewController
+    func makeCompletedQuestsViewController() -> CompletedQuestsViewController
+    func makeParentQuestViewController() -> ParentQuestViewController<QuestTabItem>
+    func makeCommonQuestViewController() -> CommonQuestViewController
+    func makeCommonQuestHistoryViewController() -> CommonQuestHistoryViewController
+    func makeCommonQuestMyAnswersViewController() -> CommonQuestMyAnswersViewController
+    func makeBlockedUserListViewController() -> BlockedkUserListViewController
+    func makeAIAnswerViewController() -> AIAnswerViewController
+    func makeNotificationsViewController() -> NotificationsViewController
 }
 
 final class ViewControllerFactory: ViewControllerFactoryProtocol {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
@@ -225,8 +225,8 @@ final class ViewControllerFactory: ViewControllerFactoryProtocol {
         return .init(viewModel: viewModel)
     }
     
-    func makeNoticesViewController(isExistNotice: Bool) -> NoticesViewController {
-        .init(isExistNotice: isExistNotice)
+    func makeNoticesViewController() -> NoticesViewController {
+        .init()
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/ViewControllerFactory.swift
@@ -233,8 +233,13 @@ final class ViewControllerFactory: ViewControllerFactoryProtocol {
         return .init(viewModel: viewModel)
     }
     
-    func makeNoticesViewController() -> NoticesViewController {
-        .init()
+    func makeNotificationsViewController() -> NotificationsViewController {
+        guard let viewModel = DIContainer.shared.resolve(type: NotificationsViewModel.self) else {
+            DIErrorHandle()
+            fatalError()
+        }
+        
+        return .init(viewModel: viewModel)
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #437 

## 📄 작업 내용
- 오랜만입니다☺️
- 알림 전체 조회 API를 연동했습니다. 알림이 없는 경우 NotificationListEntity에 만들어둔 stub 메서드를 활용하여 테스트했습니다.
- 시간 차이를 계산하여 '방금 전', 'n분 전', 'n시간 전', 일반 날짜로 매핑해주는 유스케이스를 만들었습니다.
- HomeViewModel에서 구조적 동시성을 반영해보았습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| 알림이 있는 경우 | <img src = "https://github.com/user-attachments/assets/b4defd3f-fb9b-4eee-997a-909e57c06199" width ="250"> | <img src = "https://github.com/user-attachments/assets/8caa7ff1-58be-4291-843c-642a03f8490c" width ="250"> |
| 알림이 없는 경우 | <img src = "https://github.com/user-attachments/assets/295d8c6c-c2d1-402a-825d-69296a8dd1d8" width ="250"> | <img src = "https://github.com/user-attachments/assets/f82ef465-414c-4271-85eb-96d2a34eaff4" width ="250"> |



## 💻 주요 코드 설명
`HomeViewModel`
- 기존 : viewWillAppear 트리거에서 알림 전체 조회 포함 4가지의 API를 순차적으로 호출하고 있었습니다.
- 현재 : 구조적 동시성을 적용해서 4가지의 API 호출이 병렬적으로 실행되도록 만들었습니다.
```swift
extension HomeViewModel: ViewModelType {
    // 생략
    
    func action(_ trigger: Input) {
        switch trigger {
        case .viewWillAppear:
            getUserResult()
            
            // withTaskGroup 적용을 통한 구조적 동시성 구현
            Task {
                await withTaskGroup(of: Void.self) { group in
                    // 자식 작업들을 추가
                    group.addTask { await self.fetchDialogue() }
                    group.addTask { await self.fetchStatus() }
                    group.addTask { await self.fetchJourney() }
                    group.addTask { await self.fetchNotificationList() }
                    
                    // 자식 작업들이 모두 끝날 때까지 대기한다는 의미
                    // 비동기 반복문을 통해서 결과를 수집하기도 하나, 자식 작업들 모두 Void를 리턴하므로 waitForAll 채택
                    await group.waitForAll()
                }
            }
        case .helperDidTap:
            setHelperShown()
        }
    }
}
```

`FormatElapsedTimeUseCase `
- 알림도 공통퀘스트처럼 시간에 따라 '방금 전', 'n분 전 / n시간 전'과 같은 문자열 정보를 매핑해주어야 합니다.

- 기존 : 공통퀘스트 뷰모델에 해당 로직이 구현되어있었습니다.
- 현재 : FormatElapsedTimeUseCase로 분리하여 공통퀘스트 뷰모델과 알림 뷰모델이 해당 유스케이스를 사용하도록 만들었습니다.
```swift
protocol FormatElapsedTimeUseCase {
    func execute(from timeString: String) -> String?
}

struct DefaultFormatElapsedTimeUseCase: FormatElapsedTimeUseCase {
    
    private let minute: Double = 60
    private let hour: Double = 3600
    private let day: Double = 86400
    
    func execute(from timeString: String) -> String? {
        guard let time = DateFormatter.toDetailDate(from: timeString) else {
            return nil
        }
        
        let diffTime = Date().timeIntervalSince(time)
        
        switch diffTime {
        case ..<minute:
            return "방금 전"
        case minute..<hour:
            let minutes = Int(diffTime / minute)
            return "\(minutes)분 전"
        case hour..<day:
            let hours = Int(diffTime / hour)
            return "\(hours)시간 전"
        default:
            return DateFormatter.toDisplayDateString(from: time)
        }
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 목록 화면을 추가하고 알림을 카드 형태로 표시합니다.
  * 미읽은 알림 여부를 조회해 홈 헤더의 알림 표시를 최신 상태로 갱신합니다.
* **개선사항**
  * 알림 시간 표기를 경과 시간 기준으로 더 자연스럽게 포맷합니다.
  * 알림 유형에 따른 아이콘 표시를 정교하게 개선합니다.
  * 알림 토큰 등록/동기화가 더 안정적으로 동작하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->