### PR TITLE
Feat/#453 공통퀘스트 공감 API 연동

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -329,7 +329,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS 1780581426";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -372,7 +372,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS 1780581426";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.heartz.ByeBoo-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/PostCommonQuestLikeResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/PostCommonQuestLikeResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  postCommonQuestLikeResponseDTO.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 6/10/26.
+//
+
+import Foundation
+
+struct PostCommonQuestLikeResponseDTO: Decodable {
+    let likeCount: Int
+    let isLiked: Bool
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Model/PostCommonQuestLikeResponseDTO.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Model/PostCommonQuestLikeResponseDTO.swift
@@ -11,3 +11,9 @@ struct PostCommonQuestLikeResponseDTO: Decodable {
     let likeCount: Int
     let isLiked: Bool
 }
+
+extension PostCommonQuestLikeResponseDTO {
+    func toEntity() -> CommonQuestLikeEntity {
+        .init(isLiked: isLiked, likeCount: likeCount)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/CommonQuestAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/CommonQuestAPI.swift
@@ -15,6 +15,7 @@ enum CommonQuestAPI {
     case fetchCommonQuestDetail(answerID: Int)
     case updateCommonQuest(answerID: Int, dto: UpdateCommonQuestRequestDTO)
     case deleteCommonQuest(answerID: Int)
+    case postCommonQuestLike(answerID: Int)
 }
 
 extension CommonQuestAPI: EndPoint {
@@ -23,7 +24,7 @@ extension CommonQuestAPI: EndPoint {
         switch self {
         case .fetchCommonQuest, .fetchCommonQuestDetail:
             return "/api/v2/common-quests"
-        case .postCommonQuest, .updateCommonQuest, .deleteCommonQuest:
+        case .postCommonQuest, .updateCommonQuest, .deleteCommonQuest, .postCommonQuestLike:
             return "/api/v1/common-quests"
         }
     }
@@ -36,12 +37,14 @@ extension CommonQuestAPI: EndPoint {
             return ""
         case .updateCommonQuest(let answerID, _), .deleteCommonQuest(let answerID), .fetchCommonQuestDetail(let answerID):
             return "/\(answerID)"
+        case .postCommonQuestLike(let answerID):
+            return "/\(answerID)/likes"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .postCommonQuest:
+        case .postCommonQuest, .postCommonQuestLike:
             return .post
         case .fetchCommonQuest, .fetchCommonQuestDetail:
             return .get
@@ -54,14 +57,15 @@ extension CommonQuestAPI: EndPoint {
     
     var headers: HeaderType {
         switch self {
-        case .postCommonQuest, .fetchCommonQuest, .updateCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail:
+        case .postCommonQuest, .fetchCommonQuest, .updateCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail,
+                .postCommonQuestLike:
             return .withAuth
         }
     }
     
     var parameterEncoding: any ParameterEncoding {
         switch self {
-        case .postCommonQuest, .updateCommonQuest:
+        case .postCommonQuest, .updateCommonQuest, .postCommonQuestLike:
             return JSONEncoding.default
         case .fetchCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail:
             return  URLEncoding.default
@@ -70,7 +74,7 @@ extension CommonQuestAPI: EndPoint {
     
     var queryParameters: [String : String]? {
         switch self {
-        case .postCommonQuest, .updateCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail:
+        case .postCommonQuest, .updateCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail, .postCommonQuestLike:
             return nil
         case .fetchCommonQuest(let date, let cursor):
             if let cursor {
@@ -87,7 +91,7 @@ extension CommonQuestAPI: EndPoint {
         switch self {
         case .postCommonQuest(_, let dto):
             return try? dto.toDictionary()
-        case .fetchCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail:
+        case .fetchCommonQuest, .deleteCommonQuest, .fetchCommonQuestDetail, .postCommonQuestLike:
             return nil
         case .updateCommonQuest(_, let dto):
             return try? dto.toDictionary()

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
@@ -74,4 +74,12 @@ struct DefaultCommonQuestRepository: CommonQuestInterface {
         
         return commonQuestDetail.toEntity(userID: userID)
     }
+    
+    func postCommonQuestLikes(answerID: Int) async throws -> Int {
+        let response = try await network.request(
+            CommonQuestAPI.postCommonQuestLike(answerID: answerID),
+            decodingType: PostCommonQuestLikeResponseDTO.self
+        )
+        return response.likeCount
+    }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/CommonQuestRepository.swift
@@ -75,11 +75,11 @@ struct DefaultCommonQuestRepository: CommonQuestInterface {
         return commonQuestDetail.toEntity(userID: userID)
     }
     
-    func postCommonQuestLikes(answerID: Int) async throws -> Int {
+    func postCommonQuestLikes(answerID: Int) async throws -> CommonQuestLikeEntity {
         let response = try await network.request(
             CommonQuestAPI.postCommonQuestLike(answerID: answerID),
             decodingType: PostCommonQuestLikeResponseDTO.self
         )
-        return response.likeCount
+        return response.toEntity()
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -213,6 +213,10 @@ struct DomainDependencyAssembler: DependencyAssembler {
             return DefaultFetchCommonQuestDetailUseCase(repository: commonQuestRepository)
         }
         
+        DIContainer.shared.register(type: PostCommonQuestLikeUseCase.self) { _ in
+             return DefaultPostCommonQuestLikeUseCase(repository: commonQuestRepository)
+        }
+        
         DIContainer.shared.register(type: FetchNotificationListUseCase.self) { _ in
             return DefaultFetchNotificationListUseCase(repository: notificationRepository)
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/CommonQuestLikeEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/CommonQuestLikeEntity.swift
@@ -1,0 +1,13 @@
+//
+//  CommonQuestLikeEntity.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 6/13/26.
+//
+
+import Foundation
+
+struct CommonQuestLikeEntity {
+    let isLiked: Bool
+    let likeCount: Int 
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/CommonQuestInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/CommonQuestInterface.swift
@@ -13,4 +13,5 @@ protocol CommonQuestInterface {
     func updateCommonQuest(answerID: Int, answer: String) async throws
     func deleteCommonQuest(answerID: Int) async throws
     func fetchCommonQuestDetail(answerID: Int) async throws -> CommonQuestDetailEntity
+    func postCommonQuestLikes(answerID: Int) async throws -> Int
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/CommonQuestInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/CommonQuestInterface.swift
@@ -13,5 +13,5 @@ protocol CommonQuestInterface {
     func updateCommonQuest(answerID: Int, answer: String) async throws
     func deleteCommonQuest(answerID: Int) async throws
     func fetchCommonQuestDetail(answerID: Int) async throws -> CommonQuestDetailEntity
-    func postCommonQuestLikes(answerID: Int) async throws -> Int
+    func postCommonQuestLikes(answerID: Int) async throws -> CommonQuestLikeEntity
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/PostCommonQuestLikeUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/PostCommonQuestLikeUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol PostCommonQuestLikeUseCase {
-    func execute(answerID: Int) async throws -> Int
+    func execute(answerID: Int) async throws -> CommonQuestLikeEntity
 }
 
 struct DefaultPostCommonQuestLikeUseCase: PostCommonQuestLikeUseCase {
@@ -18,7 +18,7 @@ struct DefaultPostCommonQuestLikeUseCase: PostCommonQuestLikeUseCase {
         self.repository = repository
     }
     
-    func execute(answerID: Int) async throws  -> Int {
+    func execute(answerID: Int) async throws  -> CommonQuestLikeEntity {
         return try await repository.postCommonQuestLikes(answerID: answerID)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/PostCommonQuestLikeUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/PostCommonQuestLikeUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  PostCommonQuestLikeUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 6/10/26.
+//
+
+import Foundation
+
+protocol PostCommonQuestLikeUseCase {
+    func execute(answerID: Int) async throws -> Int
+}
+
+struct DefaultPostCommonQuestLikeUseCase: PostCommonQuestLikeUseCase {
+    private let repository: CommonQuestInterface
+    
+    init(repository: CommonQuestInterface) {
+        self.repository = repository
+    }
+    
+    func execute(answerID: Int) async throws  -> Int {
+        return try await repository.postCommonQuestLikes(answerID: answerID)
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Cells/CommonQuestAnswerCell.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Cells/CommonQuestAnswerCell.swift
@@ -94,6 +94,7 @@ extension CommonQuestAnswerCell {
         userNicknameLabel.text = answer.writer
         answerID = answer.answerID
         questContentView.configure(
+            answerID: answer.answerID,
             content: answer.content,
             writtenAt: writtenAt,
             isLiked: answer.isLiked,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Cells/CommonQuestMyAnswerCell.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Cells/CommonQuestMyAnswerCell.swift
@@ -95,6 +95,7 @@ final class CommonQuestMyAnswerCell: UITableViewCell {
 extension CommonQuestMyAnswerCell {
     
     func bind(
+        answerID: Int,
         question: String,
         content: String,
         writtenAt: String,
@@ -104,6 +105,7 @@ extension CommonQuestMyAnswerCell {
     ) {
         questionContentLabel.text = question
         questContentView.configure(
+            answerID: answerID,
             content: content,
             writtenAt: writtenAt,
             isLiked: isLiked,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
@@ -133,7 +133,6 @@ final class QuestContentView: BaseView {
     @objc
     private func likeButtonDidTap() {
         likeButton.isSelected.toggle()
-//        likeCountLabel.text = String(likeCounts)
         delegate?.likeButtonDidTap(answerID: self.answerID)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
@@ -126,13 +126,13 @@ final class QuestContentView: BaseView {
         commentCountLabel.text = String(commentCount)
     }
     
-    func updateUI(likeCount: Int) {
+    func updateUI(likeCount: Int, isLiked: Bool) {
         likeCountLabel.text = String(likeCount)
+        likeButton.isSelected = isLiked
     }
     
     @objc
     private func likeButtonDidTap() {
-        likeButton.isSelected.toggle()
         delegate?.likeButtonDidTap(answerID: self.answerID)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol CommonQuestLikeCommentProtocol: AnyObject {
-    func likeButtonDidTap()
+    func likeButtonDidTap(answerID: Int)
 }
 
 final class QuestContentView: BaseView {
@@ -26,6 +26,7 @@ final class QuestContentView: BaseView {
     
     weak var delegate: CommonQuestLikeCommentProtocol?
     
+    private var answerID: Int = 0
     private var likeCounts: Int = 0
     
     override func setUI() {
@@ -102,6 +103,7 @@ final class QuestContentView: BaseView {
     }
     
     func configure(
+        answerID: Int,
         content: String,
         writtenAt: String? = nil,
         isLiked: Bool,
@@ -109,6 +111,7 @@ final class QuestContentView: BaseView {
         commentCount: Int,
         showAllText: Bool
     ) {
+        self.answerID = answerID
         self.likeCounts = likeCount
         answerContentTextView.do {
             $0.textContainer.maximumNumberOfLines = showAllText ? 0 : 2
@@ -123,11 +126,14 @@ final class QuestContentView: BaseView {
         commentCountLabel.text = String(commentCount)
     }
     
+    func updateUI(likeCount: Int) {
+        likeCountLabel.text = String(likeCount)
+    }
+    
     @objc
     private func likeButtonDidTap() {
         likeButton.isSelected.toggle()
-        likeCounts += likeButton.isSelected ? 1 : -1
-        likeCountLabel.text = String(likeCounts)
-        delegate?.likeButtonDidTap()
+//        likeCountLabel.text = String(likeCounts)
+        delegate?.likeButtonDidTap(answerID: self.answerID)
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/CommonQuestHistoryView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/CommonQuestHistoryView.swift
@@ -165,6 +165,7 @@ extension CommonQuestHistoryView {
 extension CommonQuestHistoryView {
 
     func configure(
+        answerID: Int,
         question: String,
         writtenAt: String,
         profileIcon: UIImage,
@@ -177,6 +178,7 @@ extension CommonQuestHistoryView {
         questionContentLabel.text = question
         dateLabel.text = writtenAt
         questContentView.configure(
+            answerID: answerID,
             content: content,
             isLiked: isLiked,
             likeCount: likeCount,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/CommonQuestHistoryView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/CommonQuestHistoryView.swift
@@ -23,7 +23,7 @@ final class CommonQuestHistoryView: BaseView {
     private let answerView = UIView()
     private let profileIconImageView = UIImageView()
     private let userNicknameLabel = UILabel()
-    private let questContentView = QuestContentView()
+    private(set) var questContentView = QuestContentView()
     private(set) var commentListView = SelfSizingTableView()
     private let commentTextView = CommentTextView()
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
@@ -76,6 +76,7 @@ final class CommonQuestHistoryViewController: BaseViewController {
             $0.separatorStyle = .none
             $0.register(CommentTableViewCell.self)
         }
+        rootView.questContentView.delegate = self
     }
 }
 
@@ -231,6 +232,18 @@ extension CommonQuestHistoryViewController {
                 }
             }
             .store(in: &cancellable)
+        
+        viewModel.output.commonQuestLikeCountPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let result):
+                    self?.rootView.questContentView.updateUI(likeCount: result.likeCount)
+                case .failure(let error):
+                    ByeBooLogger.error(error)
+                }
+            }
+            .store(in: &cancellable)
     }
     
     private func bindData(entity: CommonQuestDetailEntity) {
@@ -287,5 +300,11 @@ extension CommonQuestHistoryViewController: KeyboardHandleProtocol {
             self.rootView.updateLayout(keyboardHeight: height)
             self.rootView.layoutIfNeeded()
         }
+    }
+}
+
+extension CommonQuestHistoryViewController: CommonQuestLikeCommentProtocol {
+    func likeButtonDidTap(answerID: Int) {
+        viewModel.action(.likeButtonDidTap(answerID: answerID))
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
@@ -238,7 +238,8 @@ extension CommonQuestHistoryViewController {
             .sink { [weak self] result in
                 switch result {
                 case .success(let result):
-                    self?.rootView.questContentView.updateUI(likeCount: result.likeCount)
+                    let entity = result.entity
+                    self?.rootView.questContentView.updateUI(likeCount: entity.likeCount, isLiked: entity.isLiked)
                 case .failure(let error):
                     ByeBooLogger.error(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
@@ -238,6 +238,7 @@ extension CommonQuestHistoryViewController {
         self.writerID = answer.writerID
         
         rootView.configure(
+            answerID: answerID,
             question: entity.question,
             writtenAt: ServerDateFormatter.shared.relativeTimeString(from: answer.writtenAt) ?? "", //TODO: ViewModel로 수정
             profileIcon: ProfileIcon.image(for: answer.profileIcon) ?? .relievedBadge,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
@@ -191,6 +191,7 @@ extension CommonQuestMyAnswersViewController: UITableViewDataSource {
         let cell: CommonQuestMyAnswerCell = tableView.dequeueReusableCell(for: indexPath)
         cell.questContentView.delegate = self
         cell.bind(
+            answerID: answer.answerID,
             question: answer.question,
             content: answer.content,
             writtenAt: answer.writtenAt,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
@@ -106,7 +106,12 @@ extension CommonQuestMyAnswersViewController {
             .sink { [weak self] result in
                 switch result {
                 case .success(let result):
-                    self?.updateLikeCount(answerID: result.answerID, likeCount: result.likeCount)
+                    let entity = result.entity
+                    self?.updateLikeCount(
+                        answerID: result.answerID,
+                        likeCount: entity.likeCount,
+                        isLiked: entity.isLiked
+                    )
                 case .failure(let error):
                     ByeBooLogger.error(error)
                 }
@@ -114,7 +119,7 @@ extension CommonQuestMyAnswersViewController {
             .store(in: &cancellable)
     }
     
-    private func updateLikeCount(answerID: Int, likeCount: Int) {
+    private func updateLikeCount(answerID: Int, likeCount: Int, isLiked: Bool) {
         guard let answerIndex = viewModel.indexOfAnswer(answerID: answerID) else {
             return
         }
@@ -124,7 +129,7 @@ extension CommonQuestMyAnswersViewController {
             return
         }
 
-        cell.questContentView.updateUI(likeCount: likeCount)
+        cell.questContentView.updateUI(likeCount: likeCount, isLiked: isLiked)
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
@@ -69,6 +69,7 @@ extension CommonQuestMyAnswersViewController {
     private func bind() {
         bindName()
         bindCommonQuestAnswers()
+        bindLikeCount()
     }
     
     private func bindName() {
@@ -97,6 +98,33 @@ extension CommonQuestMyAnswersViewController {
                 }
             }
             .store(in: &cancellable)
+    }
+    
+    private func bindLikeCount() {
+        viewModel.output.commonQuestLikeCountPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let result):
+                    self?.updateLikeCount(answerID: result.answerID, likeCount: result.likeCount)
+                case .failure(let error):
+                    ByeBooLogger.error(error)
+                }
+            }
+            .store(in: &cancellable)
+    }
+    
+    private func updateLikeCount(answerID: Int, likeCount: Int) {
+        guard let answerIndex = viewModel.indexOfAnswer(answerID: answerID) else {
+            return
+        }
+
+        let indexPath = IndexPath(row: 0, section: answerIndex)
+        guard let cell = rootView.answersTableView.cellForRow(at: indexPath) as? CommonQuestMyAnswerCell else {
+            return
+        }
+
+        cell.questContentView.updateUI(likeCount: likeCount)
     }
 }
 
@@ -204,7 +232,7 @@ extension CommonQuestMyAnswersViewController: UITableViewDataSource {
 }
 
 extension CommonQuestMyAnswersViewController: CommonQuestLikeCommentProtocol {
-    func likeButtonDidTap() {
-        // TODO: like button
+    func likeButtonDidTap(answerID: Int) {
+        viewModel.action(.likeButtonDidTap(answerID: answerID))
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
@@ -86,6 +86,31 @@ extension CommonQuestViewController {
                 }
             }
             .store(in: &cancellable)
+        
+        viewModel.output.commonQuestLikeCountPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let result):
+                    self?.updateLikeCount(answerID: result.answerID, likeCount: result.likeCount)
+                case .failure(let error):
+                    ByeBooLogger.error(error)
+                }
+            }
+            .store(in: &cancellable)
+    }
+
+    private func updateLikeCount(answerID: Int, likeCount: Int) {
+        guard let answerIndex = viewModel.indexOfAnswer(answerID: answerID) else {
+            return
+        }
+
+        let indexPath = IndexPath(row: answerIndex + 1, section: 0)
+        guard let cell = rootView.commonQuestTableView.cellForRow(at: indexPath) as? CommonQuestAnswerCell else {
+            return
+        }
+
+        cell.questContentView.updateUI(likeCount: likeCount)
     }
 }
 
@@ -266,7 +291,8 @@ extension CommonQuestViewController: UITableViewDataSource {
 }
 
 extension CommonQuestViewController: CommonQuestLikeCommentProtocol {
-    func likeButtonDidTap() {
-        // TODO: like button
+    func likeButtonDidTap(answerID: Int) {
+        ByeBooLogger.debug("answerID: \(answerID)")
+        viewModel.action(.likeButtonDidTap(answerID: answerID))
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
@@ -92,7 +92,8 @@ extension CommonQuestViewController {
             .sink { [weak self] result in
                 switch result {
                 case .success(let result):
-                    self?.updateLikeCount(answerID: result.answerID, likeCount: result.likeCount)
+                    let entity = result.entity
+                    self?.updateLikeCount(answerID: result.answerID, likeCount: entity.likeCount, isLiked: entity.isLiked)
                 case .failure(let error):
                     ByeBooLogger.error(error)
                 }
@@ -100,7 +101,7 @@ extension CommonQuestViewController {
             .store(in: &cancellable)
     }
 
-    private func updateLikeCount(answerID: Int, likeCount: Int) {
+    private func updateLikeCount(answerID: Int, likeCount: Int, isLiked: Bool) {
         guard let answerIndex = viewModel.indexOfAnswer(answerID: answerID) else {
             return
         }
@@ -110,7 +111,7 @@ extension CommonQuestViewController {
             return
         }
 
-        cell.questContentView.updateUI(likeCount: likeCount)
+        cell.questContentView.updateUI(likeCount: likeCount, isLiked: isLiked)
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestHistoryViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestHistoryViewModel.swift
@@ -10,20 +10,25 @@ import Foundation
 
 final class CommonQuestHistoryViewModel {
     private let fetchCommonQuestCommentsUseCase: FetchCommonQuestDetailUseCase
+    private let postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
     
     private let fetchCommentListSubject: PassthroughSubject<Result<CommonQuestDetailEntity, ByeBooError>, Never> = .init()
+    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>.init()
     
     private var entity: CommonQuestDetailEntity? = nil
     private var cancellables = Set<AnyCancellable>()
     private(set) var output: Output
     
     init(
-        fetchCommonQuestCommentsUseCase: FetchCommonQuestDetailUseCase
+        fetchCommonQuestCommentsUseCase: FetchCommonQuestDetailUseCase,
+        postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
     ) {
         self.fetchCommonQuestCommentsUseCase = fetchCommonQuestCommentsUseCase
+        self.postCommonQuestLikeUseCase = postCommonQuestLikeUseCase
         
         output = Output(
-            fetchCommonQuestDetailPublisher: fetchCommentListSubject.eraseToAnyPublisher()
+            fetchCommonQuestDetailPublisher: fetchCommentListSubject.eraseToAnyPublisher(),
+            commonQuestLikeCountPublisher: likeCountSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -31,16 +36,20 @@ final class CommonQuestHistoryViewModel {
 extension CommonQuestHistoryViewModel: ViewModelType {
     enum Input {
         case viewWillAppear(answerID: Int)
+        case likeButtonDidTap(answerID: Int)
     }
     
     struct Output {
         let fetchCommonQuestDetailPublisher: AnyPublisher<Result<CommonQuestDetailEntity, ByeBooError>, Never>
+        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
         switch trigger {
         case .viewWillAppear(let answerID):
             fetchCommonQuestComments(answerID: answerID)
+        case .likeButtonDidTap(let answerID):
+            postCommonQuestLike(answerID: answerID)
         }
     }
 }
@@ -69,6 +78,17 @@ extension CommonQuestHistoryViewModel {
                 fetchCommentListSubject.send(.success(entity))
             } catch(let error as ByeBooError) {
                 fetchCommentListSubject.send(.failure(error))
+            }
+        }
+    }
+    
+    private func postCommonQuestLike(answerID: Int) {
+        Task {
+            do {
+                let likeCount = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
+                likeCountSubject.send(.success((answerID: answerID, likeCount: likeCount)))
+            } catch (let error as ByeBooError) {
+                likeCountSubject.send(.failure(error))
             }
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestHistoryViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestHistoryViewModel.swift
@@ -89,8 +89,10 @@ extension CommonQuestHistoryViewModel {
         likeTasks[answerID] = Task {
             do {
                 let entity = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
-                guard !Task.isCancelled else { return }
+                try Task.checkCancellation()
                 likeCountSubject.send(.success((answerID, entity)))
+            } catch is CancellationError {
+                ByeBooLogger.debug("Task 취소됨")
             } catch {
                 guard let error = error as? ByeBooError else {
                     return

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestHistoryViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestHistoryViewModel.swift
@@ -13,10 +13,11 @@ final class CommonQuestHistoryViewModel {
     private let postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
     
     private let fetchCommentListSubject: PassthroughSubject<Result<CommonQuestDetailEntity, ByeBooError>, Never> = .init()
-    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>.init()
+    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>.init()
     
     private var entity: CommonQuestDetailEntity? = nil
     private var cancellables = Set<AnyCancellable>()
+    private var likeTasks: [Int: Task<Void, Never>] = [:]
     private(set) var output: Output
     
     init(
@@ -41,7 +42,7 @@ extension CommonQuestHistoryViewModel: ViewModelType {
     
     struct Output {
         let fetchCommonQuestDetailPublisher: AnyPublisher<Result<CommonQuestDetailEntity, ByeBooError>, Never>
-        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>
+        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -83,13 +84,21 @@ extension CommonQuestHistoryViewModel {
     }
     
     private func postCommonQuestLike(answerID: Int) {
-        Task {
+        likeTasks[answerID]?.cancel()
+
+        likeTasks[answerID] = Task {
             do {
-                let likeCount = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
-                likeCountSubject.send(.success((answerID: answerID, likeCount: likeCount)))
-            } catch (let error as ByeBooError) {
+                let entity = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
+                guard !Task.isCancelled else { return }
+                likeCountSubject.send(.success((answerID, entity)))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                guard !Task.isCancelled else { return }
                 likeCountSubject.send(.failure(error))
             }
+            likeTasks[answerID] = nil
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
@@ -71,12 +71,14 @@ final class CommonQuestMyAnswerViewModel {
     
     private func postCommonQuestLike(answerID: Int) {
         likeTasks[answerID]?.cancel()
-
+        
         likeTasks[answerID] = Task {
             do {
                 let entity = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
-                guard !Task.isCancelled else { return }
+                try Task.checkCancellation()
                 likeCountSubject.send(.success((answerID: answerID, entity)))
+            } catch is CancellationError {
+                ByeBooLogger.debug("Task 취소됨")
             } catch {
                 guard let error = error as? ByeBooError else {
                     return

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
@@ -13,9 +13,12 @@ final class CommonQuestMyAnswerViewModel {
     private let cancellables = Set<AnyCancellable>()
     private let nameSubject = PassthroughSubject<Result<String, ByeBooError>, Never>.init()
     private let answersSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
+    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>.init()
     
     private let getUserNameUseCase: GetUserNameUseCase
     private let fetchCommonQuestMyAnswersUseCase: FetchCommonQuestMyAnswersUseCase
+    private let postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
+    
     
     private(set) var output: Output
     private var commonQuestAnswers: CommonQuestMyAnswersEntity?
@@ -25,13 +28,17 @@ final class CommonQuestMyAnswerViewModel {
     
     init(
         getUserNameUseCase: GetUserNameUseCase,
-        fetchCommonQuestMyAnswersUseCase: FetchCommonQuestMyAnswersUseCase
+        fetchCommonQuestMyAnswersUseCase: FetchCommonQuestMyAnswersUseCase,
+        postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
     ) {
         self.getUserNameUseCase = getUserNameUseCase
         self.fetchCommonQuestMyAnswersUseCase = fetchCommonQuestMyAnswersUseCase
+        self.postCommonQuestLikeUseCase = postCommonQuestLikeUseCase
+        
         self.output = Output(
             namePublisher: nameSubject.eraseToAnyPublisher(),
-            answersPublisher: answersSubject.eraseToAnyPublisher()
+            answersPublisher: answersSubject.eraseToAnyPublisher(),
+            commonQuestLikeCountPublisher: likeCountSubject.eraseToAnyPublisher()
         )
     }
     
@@ -59,6 +66,17 @@ final class CommonQuestMyAnswerViewModel {
             }
         }
     }
+    
+    private func postCommonQuestLike(answerID: Int) {
+        Task {
+            do {
+                let likeCount = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
+                likeCountSubject.send(.success((answerID: answerID, likeCount: likeCount)))
+            } catch (let error as ByeBooError) {
+                likeCountSubject.send(.failure(error))
+            }
+        }
+    }
 }
 
 extension CommonQuestMyAnswerViewModel: ViewModelType {
@@ -66,11 +84,13 @@ extension CommonQuestMyAnswerViewModel: ViewModelType {
     enum Input {
         case viewWillAppear
         case scrollAnswer
+        case likeButtonDidTap(answerID: Int)
     }
     
     struct Output {
         let namePublisher: AnyPublisher<Result<String, ByeBooError>, Never>
         let answersPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
+        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -80,6 +100,8 @@ extension CommonQuestMyAnswerViewModel: ViewModelType {
             fetchUserCommonQuestAnswers()
         case .scrollAnswer:
             fetchUserCommonQuestAnswers(cursor: nextCursor)
+        case .likeButtonDidTap(let answerID):
+            postCommonQuestLike(answerID: answerID)
         }
     }
 }
@@ -88,6 +110,10 @@ extension CommonQuestMyAnswerViewModel {
     
     var answersCount: Int {
         answers.count
+    }
+    
+    func indexOfAnswer(answerID: Int) -> Int? {
+        answers.firstIndex { $0.answerID == answerID }
     }
     
     func getAnswer(at index: Int) -> CommonQuestMyAnswerEntity? {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestMyAnswerViewModel.swift
@@ -13,7 +13,7 @@ final class CommonQuestMyAnswerViewModel {
     private let cancellables = Set<AnyCancellable>()
     private let nameSubject = PassthroughSubject<Result<String, ByeBooError>, Never>.init()
     private let answersSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
-    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>.init()
+    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>.init()
     
     private let getUserNameUseCase: GetUserNameUseCase
     private let fetchCommonQuestMyAnswersUseCase: FetchCommonQuestMyAnswersUseCase
@@ -25,6 +25,8 @@ final class CommonQuestMyAnswerViewModel {
     private var answers: [CommonQuestMyAnswerEntity] = []
     private(set) var hasMorePages = true
     private var nextCursor: Int? = nil
+    
+    private var likeTasks: [Int: Task<Void, Never>] = [:]
     
     init(
         getUserNameUseCase: GetUserNameUseCase,
@@ -68,13 +70,21 @@ final class CommonQuestMyAnswerViewModel {
     }
     
     private func postCommonQuestLike(answerID: Int) {
-        Task {
+        likeTasks[answerID]?.cancel()
+
+        likeTasks[answerID] = Task {
             do {
-                let likeCount = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
-                likeCountSubject.send(.success((answerID: answerID, likeCount: likeCount)))
-            } catch (let error as ByeBooError) {
+                let entity = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
+                guard !Task.isCancelled else { return }
+                likeCountSubject.send(.success((answerID: answerID, entity)))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                guard !Task.isCancelled else { return }
                 likeCountSubject.send(.failure(error))
             }
+            likeTasks[answerID] = nil
         }
     }
 }
@@ -90,7 +100,7 @@ extension CommonQuestMyAnswerViewModel: ViewModelType {
     struct Output {
         let namePublisher: AnyPublisher<Result<String, ByeBooError>, Never>
         let answersPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
-        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>
+        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class CommonQuestViewModel {
     
-    private let cancellables = Set<AnyCancellable>()
+    private var cancellables = Set<AnyCancellable>()
     private let commonQuestSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
     private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>.init()
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -12,7 +12,7 @@ final class CommonQuestViewModel {
     
     private let cancellables = Set<AnyCancellable>()
     private let commonQuestSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
-    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>.init()
+    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>.init()
     
     private let fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase
     private let postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
@@ -24,6 +24,7 @@ final class CommonQuestViewModel {
     private(set) var hasMorePages = true
     private var nextCursor: Int? = nil
     private var currentDate: String = DateFormatter.toAPIDateString(from: .now)
+    private var likeTasks: [Int: Task<Void, Never>] = [:]
     
     init(
         fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase,
@@ -67,13 +68,21 @@ final class CommonQuestViewModel {
     }
     
     private func postCommonQuestLike(answerID: Int) {
-        Task {
+        likeTasks[answerID]?.cancel()
+
+        likeTasks[answerID] = Task {
             do {
-                let likeCount = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
-                likeCountSubject.send(.success((answerID: answerID, likeCount: likeCount)))
-            } catch (let error as ByeBooError) {
+                let entity = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
+                guard !Task.isCancelled else { return }
+                likeCountSubject.send(.success((answerID: answerID, entity)))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                guard !Task.isCancelled else { return }
                 likeCountSubject.send(.failure(error))
             }
+            likeTasks[answerID] = nil
         }
     }
 }
@@ -89,7 +98,7 @@ extension CommonQuestViewModel: ViewModelType {
     
     struct Output {
         let commonQuestPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
-        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>
+        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, entity: CommonQuestLikeEntity), ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -73,8 +73,10 @@ final class CommonQuestViewModel {
         likeTasks[answerID] = Task {
             do {
                 let entity = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
-                guard !Task.isCancelled else { return }
+                try Task.checkCancellation()
                 likeCountSubject.send(.success((answerID: answerID, entity)))
+            } catch is CancellationError {
+                ByeBooLogger.debug("Task 취소됨")
             } catch {
                 guard let error = error as? ByeBooError else {
                     return

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -28,7 +28,7 @@ final class CommonQuestViewModel {
     
     init(
         fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase,
-        postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
+        postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase,
         formatElapsedTimeUseCase: FormatElapsedTimeUseCase
     ) {
         self.fetchCommonQuestByDateUseCase = fetchCommonQuestByDateUseCase

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/CommonQuestViewModel.swift
@@ -12,7 +12,10 @@ final class CommonQuestViewModel {
     
     private let cancellables = Set<AnyCancellable>()
     private let commonQuestSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>.init()
+    private let likeCountSubject = PassthroughSubject<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>.init()
+    
     private let fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase
+    private let postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
     private let formatElapsedTimeUseCase: FormatElapsedTimeUseCase
     
     private(set) var output: Output
@@ -24,12 +27,15 @@ final class CommonQuestViewModel {
     
     init(
         fetchCommonQuestByDateUseCase: FetchCommonQuestByDateUseCase,
+        postCommonQuestLikeUseCase: PostCommonQuestLikeUseCase
         formatElapsedTimeUseCase: FormatElapsedTimeUseCase
     ) {
         self.fetchCommonQuestByDateUseCase = fetchCommonQuestByDateUseCase
+        self.postCommonQuestLikeUseCase = postCommonQuestLikeUseCase
         self.formatElapsedTimeUseCase = formatElapsedTimeUseCase
         self.output = Output(
-            commonQuestPublisher: commonQuestSubject.eraseToAnyPublisher()
+            commonQuestPublisher: commonQuestSubject.eraseToAnyPublisher(),
+            commonQuestLikeCountPublisher: likeCountSubject.eraseToAnyPublisher()
         )
     }
     
@@ -59,6 +65,17 @@ final class CommonQuestViewModel {
             }
         }
     }
+    
+    private func postCommonQuestLike(answerID: Int) {
+        Task {
+            do {
+                let likeCount = try await postCommonQuestLikeUseCase.execute(answerID: answerID)
+                likeCountSubject.send(.success((answerID: answerID, likeCount: likeCount)))
+            } catch (let error as ByeBooError) {
+                likeCountSubject.send(.failure(error))
+            }
+        }
+    }
 }
 
 extension CommonQuestViewModel: ViewModelType {
@@ -67,10 +84,12 @@ extension CommonQuestViewModel: ViewModelType {
         case viewWillAppear
         case moveDateButtonDidTap(selectedDate: String)
         case scrollAnswer
+        case likeButtonDidTap(answerID: Int)
     }
     
     struct Output {
         let commonQuestPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
+        let commonQuestLikeCountPublisher: AnyPublisher<Result<(answerID: Int, likeCount: Int), ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -87,6 +106,8 @@ extension CommonQuestViewModel: ViewModelType {
                 return
             }
             fetchCommonQuestByDate(date: currentDate, cursor: nextCursor)
+        case .likeButtonDidTap(let answerID):
+            postCommonQuestLike(answerID: answerID)
         }
     }
 }
@@ -128,6 +149,10 @@ extension CommonQuestViewModel {
             return nil
         }
         return answers[index].answerID
+    }
+
+    func indexOfAnswer(answerID: Int) -> Int? {
+        answers.firstIndex { $0.answerID == answerID }
     }
     
     func getProfileIcon(at index: Int) -> UIImage? {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -305,14 +305,16 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         
         DIContainer.shared.register(type: CommonQuestMyAnswerViewModel.self) { container in
             guard let getUserNameUseCase = container.resolve(type: GetUserNameUseCase.self),
-                  let fetchCommonQuestMyAnswersUseCase = container.resolve(type: FetchCommonQuestMyAnswersUseCase.self) else  {
+                  let fetchCommonQuestMyAnswersUseCase = container.resolve(type: FetchCommonQuestMyAnswersUseCase.self),
+                  let postCommonQuestLikeUseCase = container.resolve(type: PostCommonQuestLikeUseCase.self) else  {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
             
             return CommonQuestMyAnswerViewModel(
                 getUserNameUseCase: getUserNameUseCase,
-                fetchCommonQuestMyAnswersUseCase: fetchCommonQuestMyAnswersUseCase
+                fetchCommonQuestMyAnswersUseCase: fetchCommonQuestMyAnswersUseCase,
+                postCommonQuestLikeUseCase: postCommonQuestLikeUseCase
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -290,7 +290,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         
         DIContainer.shared.register(type: CommonQuestViewModel.self) { container in
             guard let fetchCommonQuestByDateUseCase = container.resolve(type: FetchCommonQuestByDateUseCase.self),
-                  let postCommonQuestLikeUseCase = container.resolve(type: PostCommonQuestLikeUseCase.self) else {
+                  let postCommonQuestLikeUseCase = container.resolve(type: PostCommonQuestLikeUseCase.self),
                   let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -298,8 +298,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             
             return CommonQuestViewModel(
                 fetchCommonQuestByDateUseCase: fetchCommonQuestByDateUseCase,
+                postCommonQuestLikeUseCase: postCommonQuestLikeUseCase,
                 formatElapsedTimeUseCase: formatElapsedTimeUseCase
-                postCommonQuestLikeUseCase: postCommonQuestLikeUseCase
             )
         }
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -376,13 +376,15 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
                                                                         
         DIContainer.shared.register(type: CommonQuestHistoryViewModel.self) { container in
-            guard let fetchCommonQuestDetailUseCase = container.resolve(type: FetchCommonQuestDetailUseCase.self) else {
+            guard let fetchCommonQuestDetailUseCase = container.resolve(type: FetchCommonQuestDetailUseCase.self),
+                let postCommonQuestLikeUseCase = container.resolve(type: PostCommonQuestLikeUseCase.self) else  {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
                                                                              
             return CommonQuestHistoryViewModel(
-                fetchCommonQuestCommentsUseCase: fetchCommonQuestDetailUseCase
+                fetchCommonQuestCommentsUseCase: fetchCommonQuestDetailUseCase,
+                postCommonQuestLikeUseCase: postCommonQuestLikeUseCase
             )
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -290,6 +290,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         
         DIContainer.shared.register(type: CommonQuestViewModel.self) { container in
             guard let fetchCommonQuestByDateUseCase = container.resolve(type: FetchCommonQuestByDateUseCase.self),
+                  let postCommonQuestLikeUseCase = container.resolve(type: PostCommonQuestLikeUseCase.self) else {
                   let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -298,6 +299,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             return CommonQuestViewModel(
                 fetchCommonQuestByDateUseCase: fetchCommonQuestByDateUseCase,
                 formatElapsedTimeUseCase: formatElapsedTimeUseCase
+                postCommonQuestLikeUseCase: postCommonQuestLikeUseCase
             )
         }
         


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #453

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 공감 API가 사용되는 CommonQuestVC, MyAnswerVC, HistroyVC에 API를 연동했습니다. 
- 이 API의 리스폰스로 likeCount와 isLiked 값이 오는데요! 서버에서 likeCount만 받아서 뷰에 다시 반영하고, isLiked는 클라에서 toggle로 처리하는 것으로 두었습니다. 

|    구현 내용    |   HistoryVC  |  CommonQuestVC   |  MyAnswerVC | 
| :-------------: | :----------: | :----------: |  :----------: |
| GIF | <img width="250" src="https://github.com/user-attachments/assets/087b770a-5b59-4fb6-b8b3-20588a0217f7" /> | <img width="250"  src="https://github.com/user-attachments/assets/2cfd3cab-f445-44de-8e31-748328ce5815" /> |<img width="250" src="https://github.com/user-attachments/assets/3633b1c5-2039-465e-973e-6e4e6c68ebc2" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공통 퀘스트 답변 단위 좋아요 생성 및 결과 반영
  * 히스토리/내 답변/일반 퀘스트 화면에서 답변별 좋아요 상태 표시

* **개선 사항**
  * 좋아요 UI 업데이트를 답변 ID 기준으로 정확히 동기화해 좋아요 수/선택 상태를 갱신
  * 빠른 연속 탭에서도 최신 결과만 반영하며, 답변 목록의 각 셀에도 올바르게 표시됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->