### PR TITLE
Feat/#459 알림 모두 읽기 API 연동

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Network/EndPoint/NotificationAPI.swift
@@ -13,6 +13,7 @@ enum NotificationAPI {
     case fetchNotificationList
     case fetchUnreadNotification
     case readNotification(notificationID: Int)
+    case readAllNotifications
 }
 
 extension NotificationAPI: EndPoint {
@@ -29,6 +30,8 @@ extension NotificationAPI: EndPoint {
             "/unread/status"
         case .readNotification(let notificationID):
             "/\(notificationID)/read"
+        case .readAllNotifications:
+            "/read-all"
         }
     }
     
@@ -36,14 +39,14 @@ extension NotificationAPI: EndPoint {
         switch self {
         case .fetchNotificationList, .fetchUnreadNotification:
                 .get
-        case .readNotification:
+        case .readNotification, .readAllNotifications:
                 .patch
         }
     }
     
     var headers: HeaderType {
         switch self {
-        case .fetchNotificationList, .fetchUnreadNotification, .readNotification:
+        case .fetchNotificationList, .fetchUnreadNotification, .readNotification, .readAllNotifications:
                 .withAuth
         }
     }
@@ -52,21 +55,21 @@ extension NotificationAPI: EndPoint {
         switch self {
         case .fetchNotificationList, .fetchUnreadNotification:
             JSONEncoding.default
-        case .readNotification:
+        case .readNotification, .readAllNotifications:
             URLEncoding.default
         }
     }
     
     var queryParameters: [String : String]? {
         switch self {
-        case .fetchNotificationList, .fetchUnreadNotification, .readNotification:
+        case .fetchNotificationList, .fetchUnreadNotification, .readNotification, .readAllNotifications:
             nil
         }
     }
     
     var bodyParameters: Parameters? {
         switch self {
-        case .fetchNotificationList, .fetchUnreadNotification, .readNotification:
+        case .fetchNotificationList, .fetchUnreadNotification, .readNotification, .readAllNotifications:
             nil
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Repository/NotificationRepository.swift
@@ -32,4 +32,8 @@ struct DefaultNotificationRepository: NotificationInterface {
     func readNotification(for notificationID: Int) async throws {
         try await networkService.request(NotificationAPI.readNotification(notificationID: notificationID))
     }
+    
+    func readAllNotifications() async throws {
+        try await networkService.request(NotificationAPI.readAllNotifications)
+    }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -232,5 +232,9 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: FetchHasUnreadNotificationUseCase.self) { _ in
             return DefaultFetchHasUnreadNotificationUseCase(repository: notificationRepository)
         }
+        
+        DIContainer.shared.register(type: ReadAllNotificationsUseCase.self) { _ in
+            return DefaultReadAllNotificationsUseCase(repository: notificationRepository)
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
@@ -81,3 +81,17 @@ extension NotificationListEntity {
         )
     }
 }
+
+extension NotificationEntity {
+    func toRead() -> Self {
+        .init(
+            notificationID: notificationID,
+            notificationType: notificationType,
+            title: title,
+            content: content,
+            isRead: true,
+            createdAt: createdAt,
+            landingURL: landingURL
+        )
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Entity/NotificationListEntity.swift
@@ -83,7 +83,7 @@ extension NotificationListEntity {
 }
 
 extension NotificationEntity {
-    func toRead() -> Self {
+    func markAsRead() -> Self {
         .init(
             notificationID: notificationID,
             notificationType: notificationType,

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/NotificationInterface.swift
@@ -9,4 +9,5 @@ protocol NotificationInterface {
     func fetchNotifications() async throws -> NotificationListEntity
     func fetchHasUnreadNotification() async throws -> HasUnreadNotificationEntity
     func readNotification(for notificationID: Int) async throws
+    func readAllNotifications() async throws
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/ReadAllNotificationsUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/ReadAllNotificationsUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  ReadAllNotificationsUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 더스틴 on 6/23/26.
+//
+
+protocol ReadAllNotificationsUseCase {
+    func execute() async throws
+}
+
+struct DefaultReadAllNotificationsUseCase: ReadAllNotificationsUseCase {
+    
+    private let repository: NotificationInterface
+    
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+    
+    func execute() async throws {
+        try await repository.readAllNotifications()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
@@ -72,6 +72,11 @@ extension NotificationsViewController: BackNavigable {
 extension NotificationsViewController: ToastPresentable, ToastErrorHandler {
     
     private func bind() {
+        bindNotificationList()
+        bindAllNotificationsRead()
+    }
+    
+    private func bindNotificationList() {
         viewModel.output.notificationListResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
@@ -85,12 +90,28 @@ extension NotificationsViewController: ToastPresentable, ToastErrorHandler {
             }
             .store(in: &cancellables)
     }
+    
+    private func bindAllNotificationsRead() {
+        viewModel.output.readAllNotificationsResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                switch result {
+                case .success:
+                    self?.rootView.contentView.noticeCardsView.cardTableView.reloadData()
+                case .failure(let error):
+                    self?.handleError(error)
+                }
+            }
+            .store(in: &cancellables)
+    }
 }
 
 extension NotificationsViewController {
     
     @objc
-    private func readAllButtonDidTap() {}
+    private func readAllButtonDidTap() {
+        viewModel.action(.readAllNotificationsDidTap)
+    }
 }
 
 extension NotificationsViewController: UITableViewDataSource {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
@@ -16,19 +16,26 @@ final class NotificationsViewModel {
     private let fetchNotificationListUseCase: FetchNotificationListUseCase
     private let formatElapsedTimeUseCase: FormatElapsedTimeUseCase
     private let readNotificationUseCase: ReadNotificationUseCase
+    private let readAllNotificationsUseCase: ReadAllNotificationsUseCase
     
     private(set) var output: Output
     private var notificationListSubject = PassthroughSubject<Result<NotificationListEntity, ByeBooError>, Never>()
+    private var readAllNotificationsSubject = PassthroughSubject<Result<Void, ByeBooError>, Never>()
     
     init(
         fetchNotificationListUseCase: FetchNotificationListUseCase,
         formatElapsedTimeUseCase: FormatElapsedTimeUseCase,
-        readNotificationUseCase: ReadNotificationUseCase
+        readNotificationUseCase: ReadNotificationUseCase,
+        readAllNotificationsUseCase: ReadAllNotificationsUseCase
     ) {
         self.fetchNotificationListUseCase = fetchNotificationListUseCase
         self.formatElapsedTimeUseCase = formatElapsedTimeUseCase
         self.readNotificationUseCase = readNotificationUseCase
-        self.output = .init(notificationListResult: notificationListSubject.eraseToAnyPublisher())
+        self.readAllNotificationsUseCase = readAllNotificationsUseCase
+        self.output = .init(
+            notificationListResult: notificationListSubject.eraseToAnyPublisher(),
+            readAllNotificationsResult: readAllNotificationsSubject.eraseToAnyPublisher()
+        )
     }
 }
 
@@ -36,10 +43,12 @@ extension NotificationsViewModel: ViewModelType {
     enum Input {
         case viewWillAppear
         case notificationDidTap(at: Int)
+        case readAllNotificationsDidTap
     }
     
     struct Output {
         let notificationListResult: AnyPublisher<Result<NotificationListEntity, ByeBooError>, Never>
+        let readAllNotificationsResult: AnyPublisher<Result<Void, ByeBooError>, Never>
     }
     
     func action(_ trigger: Input) {
@@ -48,6 +57,8 @@ extension NotificationsViewModel: ViewModelType {
             fetchNotificationList()
         case .notificationDidTap(let index):
             readNotification(at: index)
+        case .readAllNotificationsDidTap:
+            readAllNotifications()
         }
     }
 }
@@ -89,6 +100,27 @@ extension NotificationsViewModel {
         }
         
         handleNotification(at: index)
+    }
+    
+    func readAllNotifications() {
+        guard let isAllRead = notifications?.allSatisfy({ $0.isRead }),
+              !isAllRead
+        else {
+            return
+        }
+        
+        Task {
+            do {
+                let _ = try await readAllNotificationsUseCase.execute()
+                self.notifications = notifications?.map { $0.toRead() }
+                readAllNotificationsSubject.send(.success(()))
+            } catch {
+                guard let error = error as? ByeBooError else {
+                    return
+                }
+                readAllNotificationsSubject.send(.failure(error))
+            }
+        }
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewModel/NotificationsViewModel.swift
@@ -112,7 +112,7 @@ extension NotificationsViewModel {
         Task {
             do {
                 let _ = try await readAllNotificationsUseCase.execute()
-                self.notifications = notifications?.map { $0.toRead() }
+                self.notifications = notifications?.map { $0.markAsRead() }
                 readAllNotificationsSubject.send(.success(()))
             } catch {
                 guard let error = error as? ByeBooError else {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -362,7 +362,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: NotificationsViewModel.self) { container in
             guard let fetchNotificationListUseCase = container.resolve(type: FetchNotificationListUseCase.self),
                   let formatElapsedTimeUseCase = container.resolve(type: FormatElapsedTimeUseCase.self),
-                  let readNotificationUseCase = container.resolve(type: ReadNotificationUseCase.self)
+                  let readNotificationUseCase = container.resolve(type: ReadNotificationUseCase.self),
+                  let readAllNotificationsUseCase = container.resolve(type: ReadAllNotificationsUseCase.self)
             else  {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
@@ -371,7 +372,8 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             return NotificationsViewModel(
                 fetchNotificationListUseCase: fetchNotificationListUseCase,
                 formatElapsedTimeUseCase: formatElapsedTimeUseCase,
-                readNotificationUseCase: readNotificationUseCase
+                readNotificationUseCase: readNotificationUseCase,
+                readAllNotificationsUseCase: readAllNotificationsUseCase
             )
         }
                                                                         


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #459 

## 📄 작업 내용
- 알림 모두 읽기 API를 연동했습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| 알림 모두 읽기 | <img src = "https://github.com/user-attachments/assets/6d1d5fab-a776-446d-8864-eb798c2c3621" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명
`NotificationListEntity 파일의 NotificationEntity`
- '알림 모두 읽기' API를 호출하면 **서버 측에서 관리하는 모든 알림의 isRead 속성이 true로** 변합니다.
- 이때 응답 DTO가 없기 때문에 알림 모두 읽기 API 호출 후 **프론트에서 유지하고 있는 알림의 isRead 속성도 true로** 맞춰주어야 합니다.
- 그러나 `NotificationEntity`의 isRead는 상수이고, var로 바꾸면 **'도메인은 불변이다'라는 규칙을 위반**한다고 생각했습다.
- 이에 `NotificationEntity`에 `toRead` 메서드를 구현했고, 이 메서드는 **isRead가 true인 새로운 엔티티 인스턴스를 반환**합니다.
```swift
extension NotificationEntity {
    func toRead() -> Self {
        .init(
            notificationID: notificationID,
            notificationType: notificationType,
            title: title,
            content: content,
            isRead: true,
            createdAt: createdAt,
            landingURL: landingURL
        )
    }
}

// 뷰모델에서의 활용
extension NotificationsViewModel {
    func readAllNotifications() {
        guard let isAllRead = notifications?.allSatisfy({ $0.isRead }),
              !isAllRead
        else {
            return
        }
        
        Task {
            do {
                let _ = try await readAllNotificationsUseCase.execute()
                self.notifications = notifications?.map { $0.toRead() }
                readAllNotificationsSubject.send(.success(()))
            } catch {
                guard let error = error as? ByeBooError else {
                    return
                }
                readAllNotificationsSubject.send(.failure(error))
            }
        }
    }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 알림 화면에 “전체 읽음” 기능을 추가해 모든 알림을 한 번에 읽음 처리할 수 있습니다.
  * “전체 읽음” 버튼 탭 시 즉시 요청을 보내고 결과에 따라 화면이 갱신됩니다.
* **개선**
  * 전체 읽음 처리 후 읽음 상태가 반영되어 알림 목록이 올바르게 재로드됩니다.
  * 성공/오류에 따른 사용자 피드백 흐름이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->