### PR TITLE
Feat/#470 강제 업데이트 구현

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		183EE0E12ED1D10600154F40 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 183EE0E02ED1D10600154F40 /* FirebaseMessaging */; };
 		186847F02ED5567D002827DA /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 186847EF2ED5567D002827DA /* FirebaseCore */; };
 		18A8172D2E154F3D00F68F9F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 18A8172C2E154F3D00F68F9F /* Alamofire */; };
+		514D021B2FF6ADDD0041A4E1 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 514D021A2FF6ADDD0041A4E1 /* FirebaseRemoteConfig */; };
 		515C127F2E159D45001BA2E0 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 515C127E2E159D45001BA2E0 /* Then */; };
 		515C12822E159D77001BA2E0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 515C12812E159D77001BA2E0 /* SnapKit */; };
 		51691DED2E5CB059008CCEC6 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 51691DEC2E5CB059008CCEC6 /* KakaoSDKAuth */; };
@@ -77,6 +78,7 @@
 				CBB032A72E7925FC00C0855E /* Mixpanel in Frameworks */,
 				51691DED2E5CB059008CCEC6 /* KakaoSDKAuth in Frameworks */,
 				CB71A8A32F3B6F9400176B64 /* FirebaseCrashlytics in Frameworks */,
+				514D021B2FF6ADDD0041A4E1 /* FirebaseRemoteConfig in Frameworks */,
 				183EE0E12ED1D10600154F40 /* FirebaseMessaging in Frameworks */,
 				183EE0DB2ED1CB0E00154F40 /* FirebaseAnalytics in Frameworks */,
 			);
@@ -151,6 +153,7 @@
 				183EE0E02ED1D10600154F40 /* FirebaseMessaging */,
 				186847EF2ED5567D002827DA /* FirebaseCore */,
 				CB71A8A22F3B6F9400176B64 /* FirebaseCrashlytics */,
+				514D021A2FF6ADDD0041A4E1 /* FirebaseRemoteConfig */,
 			);
 			productName = "ByeBoo-iOS";
 			productReference = CB41808B2E0925D2001E7BCB /* ByeBoo-iOS.app */;
@@ -670,6 +673,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 18A8172B2E154F3D00F68F9F /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		514D021A2FF6ADDD0041A4E1 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 183EE0D92ED1CB0E00154F40 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 		515C127E2E159D45001BA2E0 /* Then */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
@@ -7,11 +7,7 @@
 
 import FirebaseRemoteConfig
 
-protocol ForceUpdateManager {
-    func checkForUpdate() async -> Bool
-}
-
-final class DefaultForceUpdateManager: ForceUpdateManager {
+final class DefaultForceUpdateRepository: ForceUpdateInterface {
     let remoteConfig = RemoteConfig.remoteConfig()
 
     init() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
@@ -1,0 +1,44 @@
+//
+//  RemoteConfigeManager.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/2/26.
+//
+
+import FirebaseRemoteConfig
+
+protocol ForceUpdateManager {
+    func checkForUpdate() async throws-> Bool
+}
+
+final class DefaultForceUpdateManager: ForceUpdateManager {
+    let remoteConfig = RemoteConfig.remoteConfig()
+
+    init() {
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = 0
+        RemoteConfig.remoteConfig().configSettings = settings
+    }
+
+    func checkForUpdate() async throws -> Bool {
+        do {
+            try await remoteConfig.fetch()
+            try await remoteConfig.activate()
+
+            let minimumVersion = remoteConfig["min_version_code"].stringValue
+            
+            return isUpdateRequired(minimumVersion: minimumVersion)
+        } catch {
+            return false
+        }
+    }
+
+    private var currentAppVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    private func isUpdateRequired(minimumVersion: String) -> Bool {
+        ByeBooLogger.debug("현재버전: \(currentAppVersion), 최소버전: \(minimumVersion)")
+        return currentAppVersion.compare(minimumVersion, options: .numeric) == .orderedAscending
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
@@ -8,7 +8,7 @@
 import FirebaseRemoteConfig
 
 protocol ForceUpdateManager {
-    func checkForUpdate() async throws-> Bool
+    func checkForUpdate() async -> Bool
 }
 
 final class DefaultForceUpdateManager: ForceUpdateManager {
@@ -20,7 +20,7 @@ final class DefaultForceUpdateManager: ForceUpdateManager {
         RemoteConfig.remoteConfig().configSettings = settings
     }
 
-    func checkForUpdate() async throws -> Bool {
+    func checkForUpdate() async -> Bool {
         do {
             try await remoteConfig.fetch()
             try await remoteConfig.activate()

--- a/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Data/Persistence/Service/ForceUpdateManager.swift
@@ -7,13 +7,13 @@
 
 import FirebaseRemoteConfig
 
-final class DefaultForceUpdateRepository: ForceUpdateInterface {
+final class DefaultForceUpdateService: ForceUpdateInterface {
     let remoteConfig = RemoteConfig.remoteConfig()
 
     init() {
         let settings = RemoteConfigSettings()
         settings.minimumFetchInterval = 0
-        RemoteConfig.remoteConfig().configSettings = settings
+        remoteConfig.configSettings = settings
     }
 
     func checkForUpdate() async -> Bool {

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -257,7 +257,7 @@ struct DomainDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: CheckForceUpdateUseCase.self) { _ in
-            return DefaultCheckForceUpdateUsecase(repository: DefaultForceUpdateManager())
+            return DefaultCheckForceUpdateUsecase(repository: DefaultForceUpdateRepository())
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -255,5 +255,9 @@ struct DomainDependencyAssembler: DependencyAssembler {
         DIContainer.shared.register(type: ReadAllNotificationsUseCase.self) { _ in
             return DefaultReadAllNotificationsUseCase(repository: notificationRepository)
         }
+        
+        DIContainer.shared.register(type: CheckForceUpdateUseCase.self) { _ in
+            return DefaultCheckForceUpdateUsecase(repository: DefaultForceUpdateManager())
+        }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/DomainDependencyAssembler.swift
@@ -257,7 +257,7 @@ struct DomainDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: CheckForceUpdateUseCase.self) { _ in
-            return DefaultCheckForceUpdateUsecase(repository: DefaultForceUpdateRepository())
+            return DefaultCheckForceUpdateUseCase(repository: DefaultForceUpdateService())
         }
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/ForeceUpdateInterface.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/Interface/ForeceUpdateInterface.swift
@@ -1,0 +1,10 @@
+//
+//  ForeceUpdateInterface.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/5/26.
+//
+
+protocol ForceUpdateInterface {
+    func checkForUpdate() async -> Bool
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol CheckForceUpdateUseCase {
-    func execute() async throws -> Bool
+    func execute() async -> Bool
 }
 
 struct DefaultCheckForceUpdateUsecase: CheckForceUpdateUseCase {
@@ -19,7 +19,7 @@ struct DefaultCheckForceUpdateUsecase: CheckForceUpdateUseCase {
         self.repository = repository
     }
     
-    func execute() async throws -> Bool {
-        return try await repository.checkForUpdate()
+    func execute() async -> Bool {
+        return await repository.checkForUpdate()
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
@@ -13,9 +13,9 @@ protocol CheckForceUpdateUseCase {
 
 struct DefaultCheckForceUpdateUsecase: CheckForceUpdateUseCase {
     
-    private let repository: ForceUpdateManager
+    private let repository: ForceUpdateInterface
     
-    init(repository: ForceUpdateManager) {
+    init(repository: ForceUpdateInterface) {
         self.repository = repository
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
@@ -11,7 +11,7 @@ protocol CheckForceUpdateUseCase {
     func execute() async -> Bool
 }
 
-struct DefaultCheckForceUpdateUsecase: CheckForceUpdateUseCase {
+struct DefaultCheckForceUpdateUseCase: CheckForceUpdateUseCase {
     
     private let repository: ForceUpdateInterface
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Domain/UseCase/CheckForceUpdateUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  CheckForceUpdateUseCase.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/4/26.
+//
+
+import Foundation
+
+protocol CheckForceUpdateUseCase {
+    func execute() async throws -> Bool
+}
+
+struct DefaultCheckForceUpdateUsecase: CheckForceUpdateUseCase {
+    
+    private let repository: ForceUpdateManager
+    
+    init(repository: ForceUpdateManager) {
+        self.repository = repository
+    }
+    
+    func execute() async throws -> Bool {
+        return try await repository.checkForUpdate()
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/ForceUpdateModalView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Common/Modal/ForceUpdateModalView.swift
@@ -1,0 +1,60 @@
+//
+//  ForceUpdateModalView.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/4/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ForceUpdateModalView: BaseView, ModalProtocol {
+    let actionButton: ByeBooButton = ByeBooButton(titleText: "업데이트 하러 가기", type: .enabled)
+    let dismissButton: ByeBooButton? = nil
+    let modalType: ConfirmModalType?  = nil
+    
+    private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    
+    override func setUI() {
+        addSubviews(titleLabel, descriptionLabel, actionButton)
+    }
+    
+    override func setStyle() {
+        backgroundColor = .grayscale900
+        layer.cornerRadius = 12
+        
+        titleLabel.applyByeBooFont(
+            style: .sub3M18,
+            text: "새로운 업데이트가 있어요",
+            color: .grayscale50
+        )
+        
+        descriptionLabel.applyByeBooFont(
+            style: .body3R16,
+            text: "더 나은 바이부를 만나보세요",
+            color: .grayscale400
+        )
+    }
+    
+    override func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(24.adjustedH)
+            $0.centerX.equalToSuperview()
+        }
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16.adjustedH)
+            $0.centerX.equalToSuperview()
+        }
+        actionButton.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(16.adjustedH)
+            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(24.adjustedW)
+            $0.bottom.equalToSuperview().inset(24.adjustedH)
+            $0.height.equalTo(53.adjustedH)
+        }
+    }
+}
+

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Enum/AppConstants.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Enum/AppConstants.swift
@@ -1,0 +1,11 @@
+//
+//  AppConstants.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 7/4/26.
+//
+
+enum AppConstants {
+    static let appStoreID = "6748205348"
+    static let appStoreURL = "itms-apps://itunes.apple.com/app/id\(appStoreID)"
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
@@ -54,7 +54,8 @@ extension SplashViewController {
     private func bindCheckForceUpdate() {
         viewModel.output.forceUpdatePublisher
             .receive(on: DispatchQueue.main)
-            .sink { result in
+            .sink { [weak self] result in
+                guard let self else { return }
                 switch result {
                 case true:
                     self.presentForceUpdateModal()

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
@@ -9,26 +9,33 @@ import Combine
 import UIKit
 
 final class SplashViewController: BaseViewController {
-    
+
     private let rootView = SplashView()
     private let viewModel: SplashViewModel
     private var cancellables = Set<AnyCancellable>()
-    
+    private var isFirstLaunch = true
+
     init(viewModel: SplashViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         view = rootView
         viewModel.action(.viewDidLoad)
         bind()
-        setAddTarget()
         
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             guard let self = self else { return }
             if self.cancellables.isEmpty {
@@ -39,8 +46,26 @@ final class SplashViewController: BaseViewController {
 }
 
 extension SplashViewController {
-    
     private func bind() {
+        bindCheckForceUpdate()
+        bindAutoLogin()
+    }
+    
+    private func bindCheckForceUpdate() {
+        viewModel.output.forceUpdatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { result in
+                switch result {
+                case true:
+                    self.presentForceUpdateModal()
+                case false:
+                    self.viewModel.action(.tryAutoLogin)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func bindAutoLogin() {
         viewModel.output.autoLoginPublisher
             .receive(on: DispatchQueue.main)
             .sink { result in
@@ -76,6 +101,29 @@ extension SplashViewController {
                 }
             }
             .store(in: &cancellables)
+    }
+    
+    private func presentForceUpdateModal() {
+        let modal = ModalBuilder(
+            modalView: ForceUpdateModalView(),
+            action: openAppstore,
+            rootViewController: self
+        )
+        modal.present()
+    }
+    
+    private func openAppstore() {
+        guard let url = URL(string: AppConstants.appStoreURL) else { return }
+        UIApplication.shared.open(url)
+    }
+    
+    @objc
+    private func appDidBecomeActive() {
+        guard !isFirstLaunch else {
+            isFirstLaunch = false
+            return
+        }
+        viewModel.action(.viewDidLoad)
     }
 }
 

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/SplashViewController.swift
@@ -60,7 +60,7 @@ extension SplashViewController {
                 case true:
                     self.presentForceUpdateModal()
                 case false:
-                    self.viewModel.action(.tryAutoLogin)
+                    ByeBooLogger.debug("강제업데이트 필요 없음")
                 }
             }
             .store(in: &cancellables)

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
@@ -9,22 +9,27 @@ import Combine
 import Foundation
 
 final class SplashViewModel {
-    
+
     private var autoLoginSubject: PassthroughSubject<Result<Void, ByeBooError>, Never> = .init()
-    
+    private var forceUpdateSubject: PassthroughSubject<Bool, Never> = .init()
+
     var output: Output {
         Output(
-            autoLoginPublisher: autoLoginSubject.eraseToAnyPublisher()
+            autoLoginPublisher: autoLoginSubject.eraseToAnyPublisher(),
+            forceUpdatePublisher: forceUpdateSubject.eraseToAnyPublisher()
         )
     }
-    
+
     private var cancellables = Set<AnyCancellable>()
     private let autoLoginUseCase: AutoLoginUseCase
-    
+    private let checkForceUpdateUseCase: CheckForceUpdateUseCase
+
     init(
-        autoLoginUseCase: AutoLoginUseCase
+        autoLoginUseCase: AutoLoginUseCase,
+        checkForceUpdateUseCase: CheckForceUpdateUseCase
     ) {
         self.autoLoginUseCase = autoLoginUseCase
+        self.checkForceUpdateUseCase = checkForceUpdateUseCase
     }
 }
 
@@ -32,15 +37,19 @@ final class SplashViewModel {
 extension SplashViewModel {
     enum Input {
         case viewDidLoad
+        case tryAutoLogin
     }
     
     struct Output {
         let autoLoginPublisher: AnyPublisher<Result<Void, ByeBooError>, Never>
+        let forceUpdatePublisher: AnyPublisher<Bool, Never>
     }
     
     func action(_ trigger: Input) {
         switch trigger {
         case .viewDidLoad:
+            checkForceUpdate()
+        case .tryAutoLogin:
             autoLogin()
         }
     }
@@ -48,6 +57,21 @@ extension SplashViewModel {
 }
 
 extension SplashViewModel {
+    private func checkForceUpdate() {
+        Task {
+            do {
+                if try await checkForceUpdateUseCase.execute() {
+                    forceUpdateSubject.send(true)
+                    ByeBooLogger.debug("강제 업데이트 필요")
+                } else {
+                    forceUpdateSubject.send(false)
+                }
+            } catch {
+                forceUpdateSubject.send(false)
+            }
+        }
+    }
+    
     private func autoLogin()  {
         ByeBooLogger.debug("자동로그인 실행")
         Task {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
@@ -37,7 +37,6 @@ final class SplashViewModel {
 extension SplashViewModel {
     enum Input {
         case viewDidLoad
-        case tryAutoLogin
     }
     
     struct Output {
@@ -49,8 +48,6 @@ extension SplashViewModel {
         switch trigger {
         case .viewDidLoad:
             checkForceUpdate()
-        case .tryAutoLogin:
-            autoLogin()
         }
     }
     
@@ -65,6 +62,7 @@ extension SplashViewModel {
                     ByeBooLogger.debug("강제 업데이트 필요")
                 } else {
                     forceUpdateSubject.send(false)
+                    autoLogin()
                 }
             }
         }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/SplashViewModel.swift
@@ -60,14 +60,12 @@ extension SplashViewModel {
     private func checkForceUpdate() {
         Task {
             do {
-                if try await checkForceUpdateUseCase.execute() {
+                if await checkForceUpdateUseCase.execute() {
                     forceUpdateSubject.send(true)
                     ByeBooLogger.debug("강제 업데이트 필요")
                 } else {
                     forceUpdateSubject.send(false)
                 }
-            } catch {
-                forceUpdateSubject.send(false)
             }
         }
     }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/PresentationDependencyAssembler.swift
@@ -265,14 +265,15 @@ struct PresentationDependencyAssembler: DependencyAssembler {
         }
         
         DIContainer.shared.register(type: SplashViewModel.self) { container in
-            guard let autoLoginUseCase = container.resolve(
-                type: AutoLoginUseCase.self
-            )
-            else {
+            guard let autoLoginUseCase = container.resolve(type: AutoLoginUseCase.self),
+                  let checkForceUpdateUseCase = container.resolve(type: CheckForceUpdateUseCase.self) else {
                 ByeBooLogger.error(ByeBooError.DIFailedError)
                 return
             }
-            return SplashViewModel(autoLoginUseCase: autoLoginUseCase)
+            return SplashViewModel(
+                autoLoginUseCase: autoLoginUseCase,
+                checkForceUpdateUseCase: checkForceUpdateUseCase
+            )
         }
         
         DIContainer.shared.register(type: FinishJourneyViewModel.self) { container in


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #470 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Firebase Remote Config를 이용하여 최소 버전보다 낮을 시 업데이트를 강제하도록 하였습니다. 
- SplashVC에서 앱스토어로 이동하도록 하는 alert이 뜨고 앱스토어로 이동할 수 있도록 구현하였습니다. 
- 모달을 피그마에서 못찾아서 안드 PR보고 쫌쫌따리 맞췄습니당..ㅎㅎ 

|    구현 내용    |   IPhone 17 pro   |   
| :-------------: | :----------: |
| GIF | <img width="250" src="https://github.com/user-attachments/assets/ababe997-00b6-476e-b986-dd8555db590b" /> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### Firebase Remote Config에 min_version_code 매개변수 추가 
<img width="594" height="365" alt="image" src="https://github.com/user-attachments/assets/16c1e7a3-edd1-4415-84f9-15ea103559ae" />

현재 최소버전은 다음 업데이트때 반영될 1.3.0으로 걸어둔 상태입니다! 

### 전체 플로우
1) SplahVC에 진입하면 강제 업데이트 여부를 확인합니다. 
2) 업데이트가 필요하다면 modal을 띄우고 유저가 앱스토어로 이동하게 합니다. 
3) 업데이트가 필요하지 않다면 autoLogin을 실행합니다. 


### ForceUpdateManager
- 버전 비교는 String의 compare 메소드를 이용합니다. 최소 버전보다 낮을 때 true를 리턴합니다. 
```swift
  func checkForUpdate() async -> Bool {  // usecase에서 이 함수를 호출합니다. 
        do {
            try await remoteConfig.fetch()
            try await remoteConfig.activate()

            let minimumVersion = remoteConfig["min_version_code"].stringValue
            
            return isUpdateRequired(minimumVersion: minimumVersion)
        } catch {
            return false
        }
    }

    private var currentAppVersion: String { // 현재 앱 버전을 가져옵니다. 
        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
    }

    private func isUpdateRequired(minimumVersion: String) -> Bool {
        ByeBooLogger.debug("현재버전: \(currentAppVersion), 최소버전: \(minimumVersion)")
        return currentAppVersion.compare(minimumVersion, options: .numeric) == .orderedAscending 
    }
```

의존성 주입 부분에서 고민을 많이 했는데 혹시 더 좋은 방법이 있다면 말씀해주세요 !!!!! 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 요약

* **New Features**
  * 앱 시작 시 원격 설정을 기반으로 강제 업데이트 필요 여부를 확인하고, 필요 시 업데이트 안내 모달을 표시합니다.
  * 모달에서 앱스토어로 바로 이동할 수 있습니다.
* **Bug Fixes**
  * 앱 활성화 시 시작 화면 전환 흐름이 더 안정적으로 동작하도록 개선했습니다.
* **Chores**
  * 강제 업데이트 체크용 유스케이스/리포지토리 구성과 관련 상수·화면 구성을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->