### PR TITLE
Fix/#472 3-2차 스프린트 1차 QA 반영

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/View/LoginView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/View/LoginView.swift
@@ -35,11 +35,13 @@ final class LoginView: BaseView {
         appleLoginButton.do {
             $0.setImage(.appleLoginButton, for: .normal)
             $0.alpha = 0
+            $0.isExclusiveTouch = true
         }
-        
+
         kakaoLoginButton.do {
             $0.setImage(.kakaoLoginButton, for: .normal)
             $0.alpha = 0
+            $0.isExclusiveTouch = true
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewController/LoginViewController.swift
@@ -64,12 +64,14 @@ extension LoginViewController{
     @objc
     private func kakaoLoginButtonDidTap() {
         rootView.kakaoLoginButton.isUserInteractionEnabled = false
+        rootView.appleLoginButton.isUserInteractionEnabled = false
         self.platform = .KAKAO
         viewModel.action(.socialLoginButtonDidTap(platform: .KAKAO))
     }
-    
+
     @objc
     private func appleLoginButtonDidTap() {
+        rootView.kakaoLoginButton.isUserInteractionEnabled = false
         rootView.appleLoginButton.isUserInteractionEnabled = false
         self.platform = .APPLE
         viewModel.action(.socialLoginButtonDidTap(platform: .APPLE))

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Login/ViewModel/LoginViewModel.swift
@@ -23,7 +23,8 @@ final class LoginViewModel: NSObject {
     }
     
     private var cancellables = Set<AnyCancellable>()
-    
+    private var isSocialLoginInProgress = false
+
     private let socialLoginUseCase: SocialLoginUseCase
     private let getIsRegisteredUseCase: GetIsRegisteredUseCase
     private let getUserIDUseCase: GetUserIDUseCase
@@ -60,7 +61,15 @@ extension LoginViewModel {
 
 extension LoginViewModel {
     private func socialLogin(platform: LoginPlatform) {
+        guard !isSocialLoginInProgress else {
+            ByeBooLogger.debug("이미 진행중인 요청 있음")
+            return
+        }
+        isSocialLoginInProgress = true
+
         Task {
+            defer { isSocialLoginInProgress = false }
+
             do {
                 let _ = try await socialLoginUseCase.execute(platform: platform)
                 socialLoginAuthSubject.send(.success(()))

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/QuestContentView.swift
@@ -64,10 +64,15 @@ final class QuestContentView: BaseView {
                 $0.spacing = 4.adjustedW
             }
         }
+        likeContainerView.do {
+            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(likeButtonDidTap))
+            $0.addGestureRecognizer(tapRecognizer)
+            $0.isUserInteractionEnabled = true
+        }
         likeButton.do {
             $0.setImage(.heartOff, for: .normal)
             $0.setImage(.heartOn, for: .selected)
-            $0.addTarget(self, action: #selector(likeButtonDidTap), for: .touchUpInside)
+            $0.isUserInteractionEnabled = false
         }
         commentIcon.do {
             $0.image = .comment


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #472 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 디자인QA 1건을 반영했습니다. 
- 기획 QA에 있는 댓글이 보이지않음 -> 은 아이폰15 시뮬로 확인했는데 저한테 다시 재현이 안돼서 일단 보류했습니다 .. .
- 로그인 중복 방지 작업을 추가적으로 진행했습니다. 


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
### 로그인 중복 방지 개선 
`LoginvViewModel`
- isSocialLoginInProgress 변수를 통해 현재 진행중인 작업이 있는지 판단합니다. 
- defer를 이용해 태스크가 끝날 때 다시 false로 바꿔줍니다. 
```swift
 private func socialLogin(platform: LoginPlatform) {
        guard !isSocialLoginInProgress else {
            ByeBooLogger.debug("이미 진행중인 요청 있음")
            return
        }
        isSocialLoginInProgress = true

        Task {
            defer { isSocialLoginInProgress = false }

            do {
                let _ = try await socialLoginUseCase.execute(platform: platform)
                socialLoginAuthSubject.send(.success(()))
                getIsRegistered()
                getUserID()
            } catch(let error as ByeBooError) {
                ByeBooLogger.error(error)
                socialLoginAuthSubject.send(.failure(error))
            }
        }
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 소셜 로그인 버튼을 빠르게 연속으로 탭해도 로그인 요청이 중복 실행되지 않도록 개선했습니다.
  * 한쪽 소셜 로그인 진행 중 다른 로그인 버튼이 비활성화되도록 변경했습니다.
  * 로그인 버튼의 동시 터치 동작을 방지했습니다.
  * 퀘스트 좋아요 영역의 탭 인식이 더 안정적으로 동작하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->