### PR TITLE
Refactor/#474 3-2차 스프린트 QA 반영

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardsView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/View/Notice/NoticeCardsView.swift
@@ -21,6 +21,7 @@ final class NoticeCardsView: BaseView {
                 bottom: 24.adjustedH,
                 right: 0
             )
+            $0.sectionHeaderTopPadding = 0
         }
     }
     

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
@@ -176,6 +176,6 @@ extension NotificationsViewController: UITableViewDelegate {
         _ tableView: UITableView,
         heightForHeaderInSection section: Int
     ) -> CGFloat {
-        0
+        return section == 0 ? 0 : 24.adjustedH
     }
 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
@@ -35,11 +35,6 @@ final class ParentQuestViewController<T: TabItem>: BaseViewController, ToastPres
         tabBar.select(index: selectedIndex)
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        selectedIndex = 0
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #474 

## 📄 작업 내용
- 공통퀘스트 답변 상세 보기에서 뒤로 가기 시 나의 여정 탭으로 떨어지는 오류가 있어 해결했습니다.
- 알림 탭에서 헤더 뷰(최근 30일까지의 알림 표시 + 모두 읽기 버튼)과 첫 알림 간의 간격을 조정했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 공지 및 알림 목록의 섹션 간 여백과 헤더 표시를 조정해 화면 구성이 더 자연스러워졌습니다.
  * 퀘스트 화면을 다시 열 때 이전에 선택한 탭과 콘텐츠가 유지되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->