### PR TITLE
Fix/#478 댓글 작성 시 공백만 있을 때 완료버튼을 누를 수 없도록 수정

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/CommentTextView.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/View/CommonQuest/Common/CommentTextView.swift
@@ -123,7 +123,7 @@ extension CommentTextView: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
         textCountLabel.text = "\(textView.text.count)/500"
-        let hasText = !textView.text.isEmpty
+        let hasText = !textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         confirmButton.isEnabled = hasText
         confirmButton.applyByeBooFont(style: .body2M16, text: "완료", color: hasText ? .primary300 : .grayscale600)
 


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #478

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 댓글 작성 시 공백만 있을 때 완료버튼을 누를 수 없도록 수정했습니다. 

|    구현 내용      |   IPhone 13 mini   |
| :-------------:  | :----------: |
| GIF | <img width="250"  alt="Simulator Screen Recording - iPhone 13 mini - 2026-07-25 at 02 35 52" src="https://github.com/user-attachments/assets/9cbb3459-e2e2-4988-89bc-f8a3abb6ad6b" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 댓글 입력란에 공백이나 줄바꿈만 입력한 경우 확인 버튼이 활성화되지 않도록 개선했습니다.
  * 실제 내용이 입력된 경우에만 버튼 상태와 글꼴 색상이 활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->