### PR TITLE
Fix/#480 공통여정 답변 상세보기에서 뒤로 가기 클릭 시 공통 여정 탭으로 이동하도록 수정

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
@@ -35,6 +35,14 @@ final class ParentQuestViewController<T: TabItem>: BaseViewController, ToastPres
         tabBar.select(index: selectedIndex)
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        if navigationController?.topViewController === self {
+            selectedIndex = 0
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
@@ -35,14 +35,6 @@ final class ParentQuestViewController<T: TabItem>: BaseViewController, ToastPres
         tabBar.select(index: selectedIndex)
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        if navigationController?.topViewController === self {
-            selectedIndex = 0
-        }
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -55,6 +47,14 @@ final class ParentQuestViewController<T: TabItem>: BaseViewController, ToastPres
             name: .showToastMessage,
             object: nil
         )
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        if navigationController?.topViewController === self {
+            selectedIndex = 0
+        }
     }
     
     override func setView() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/ParentQuestViewController.swift
@@ -114,6 +114,7 @@ extension ParentQuestViewController {
             else {
                 return
             }
+            selectedIndex = index
             show(controllers[index])
         }
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #480 

## 📄 작업 내용
- 공통여정 답변 상세보기에서 뒤로 가기 클릭 시 공통 여정 탭으로 이동하도록 수정

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/2828d6b5-36df-4d23-8efb-a098ff9a6367" width ="250"> | <img src = "" width ="250"> |


## ✅ Testing
- 테스트 목적과 상황
공통 여정 답변 상세보기에서 뒤로 가기 클릭
- 시나리오 진행에 필요한 조건
공통 여정 관련 알림을 탭하여 -> 공통 여정 답변 상세보기로 이동한 후 -> 뒤로 가기를 클릭한다.
홈에서 퀘스트 탭을 클릭하고 -> 공통 여정 탭바를 클릭한 후 -> 공통 여정 답변 상세보기로 이동한 후 -> 뒤로 가기를 클릭한다.
- 시나리오 완료 시 보장하는 결과
공통 여정 답변 상세보기에서 뒤로 가기 클릭 시 공통 여정 탭으로 이동한다.

## 💻 주요 코드 설명
`ParentQuestViewController`
- 퀘스트 탭에서 <나의 여정> 혹은 <공통 여정> 탭을 누르면 ParentQuestViewController의 bind 메서드가 호출됩니다.
- bind 메서드에서는 사용자가 클릭한 탭의 인덱스를 인식하여 올바른 탭을 보여줍니다.
- 이때 bind 메서드에서 selectedIndex를 사용자가 실제로 탭한 인덱스로 초기화하지 않는 것이 문제가 되었습니다.
- 더불어, 퀘스트 탭에서 다른 탭으로 갔다가 다시 퀘스트 탭으로 돌아왔을 때는 <나의 여정>이 선택되어있어야 합니다.
- 이에 따라 아래와 같이 코드를 수정했습니다. (주석 참고)
```swift
final class ParentQuestViewController<T: QuestTabItem> {

    override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated)
        
        // 다른 뷰로의 push가 아닌 다른 탭으로 전환한 경우에만 selectedIndex를 0으로 초기화
        if navigationController?.topViewController === self {
            selectedIndex = 0
        }
    }

    private func bind() {
        tabBar.didTap = { [weak self] index in
            guard let self,
                  index >= 0 && index < controllers.count
            else {
                return
            }
            selectedIndex = index    // 사용자가 탭했을 때 selectedIndex 업데이트
            show(controllers[index])
        }
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 퀘스트 탭을 선택하면 선택 상태가 즉시 올바르게 반영됩니다.
  * 화면을 벗어난 후 다시 진입할 때 기본 탭으로 정상 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->