### PR TITLE
Setting/#485 Github Action와 Fastlane을 통한 자동 배포 

### DIFF
--- a/.github/workflows/fastlane_ci.yml
+++ b/.github/workflows/fastlane_ci.yml
@@ -1,0 +1,66 @@
+name: Fastlane CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: [closed]
+
+jobs:
+  fastlane:
+    name: Run Fastlane
+    runs-on: macos-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1 
+
+    - name: Install Bundler
+      run: gem install bundler
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Output Fastlane environment
+      run: bundle exec fastlane env
+
+    - name: Run upload_testflight
+      if: github.event.pull_request.base.ref == 'develop'
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+        FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
+        FASTLANE_ITC_TEAM_ID: ${{ secrets.FASTLANE_ITC_TEAM_ID }}
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+        PRIVATE_REPOSITORY: ${{ secrets.PRIVATE_REPOSITORY }}
+        MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        DISCORD_URL: ${{ secrets.DISCORD_URL }}
+      run: bundle exec fastlane upload_testflight
+
+    - name: Run release_app_store on main
+      if: github.event.pull_request.base.ref == 'main'
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+        FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
+        FASTLANE_ITC_TEAM_ID: ${{ secrets.FASTLANE_ITC_TEAM_ID }}
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+        PRIVATE_REPOSITORY: ${{ secrets.PRIVATE_REPOSITORY }}
+        MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        DISCORD_URL: ${{ secrets.DISCORD_URL }}
+      run: bundle exec fastlane release_app_store

--- a/ByeBoo-iOS/fastlane/Fastfile
+++ b/ByeBoo-iOS/fastlane/Fastfile
@@ -18,6 +18,9 @@ default_platform(:ios)
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "10"
 
+XCODEPROJ = "ByeBoo-iOS.xcodeproj"
+SCHEME = "ByeBoo-iOS"
+
 platform :ios do
 
   def notify_discord_success(lane_name)
@@ -36,17 +39,45 @@ platform :ios do
     )
   end
 
+  def prepare_ci_and_signing
+    setup_ci
+    match(type: "appstore")
+    update_project_team(
+      path: XCODEPROJ,
+      teamid: ENV['TEAM_ID']
+    )
+  end
+
+  def next_build_number
+    latest_build = latest_testflight_build_number(
+      app_identifier: ENV['APP_IDENTIFIER'],
+      initial_build_number: 0
+    )
+    latest_build + 1
+  end
+
+
   desc "Push a new beta build to TestFlight"
   lane :upload_testflight do
     begin
-      increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
-      match(type: "appstore")
+      iprepare_ci_and_signing
+
+      build_number = next_build_number
+      increment_build_number(
+        xcodeproj: XCODEPROJ,
+        build_number: build_number
+      )
+
       build_app(
-        scheme: "ByeBoo-iOS",
+        scheme: SCHEME,
         export_method: "app-store"
       )
-      upload_to_testflight
-      notify_discord_success("TestFlight 업로드")
+
+      upload_to_testflight(
+        skip_waiting_for_build_processing: true
+      )
+
+      notify_discord_success("TestFlight 업로드", build_number)
     rescue => e
       notify_discord_failure("TestFlight 업로드", e.message)
       raise e
@@ -56,19 +87,30 @@ platform :ios do
   desc "Release a new version to the App Store"
   lane :release_app_store do
     begin
-      increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
-      match(type: "appstore")
+      prepare_ci_and_signing
+
+      build_number = next_build_number
+      increment_build_number(
+        xcodeproj: XCODEPROJ,
+        build_number: build_number
+      )
+
       build_app(
-        scheme: "ByeBoo-iOS",
+        scheme: SCHEME,
         export_method: "app-store"
       )
+
       upload_to_app_store(
         skip_screenshots: true,
         skip_metadata: true,
-        submit_for_review: true,
-        force: true
-      )
-      notify_discord_success("App Store 배포")
+        force: true,
+        submit_for_review: true,               # 자동으로 심사 제출 
+        automatic_release: true,               # 심사 통과 후 자동 출시
+        precheck_include_in_app_purchases: false,
+        submission_information: {
+          add_id_info_uses_idfa: false,          # admob 추가 시 true로 변경 
+          export_compliance_uses_encryption: false  
+        }
     rescue => e
       notify_discord_failure("App Store 배포", e.message)
       raise e

--- a/ByeBoo-iOS/fastlane/Fastfile
+++ b/ByeBoo-iOS/fastlane/Fastfile
@@ -19,31 +19,60 @@ ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "10"
 
 platform :ios do
+
+  def notify_discord_success(lane_name)
+    sh(
+      "curl -H 'Content-Type: application/json' " +
+      "-d '{\"content\": \"💟🍎 **#{lane_name}** 성공! 🎉\"}' " +
+      "#{ENV['DISCORD_URL']}"
+    )
+  end
+
+  def notify_discord_failure(lane_name, error_message)
+    sh(
+      "curl -H 'Content-Type: application/json' " +
+      "-d '{\"content\": \"🤔🌀 **#{lane_name}** 실패\\n```#{error_message.to_s.gsub('"', "'").gsub("\n", " ")}```\"}' " +
+      "#{ENV['DISCORD_URL']}"
+    )
+  end
+
   desc "Push a new beta build to TestFlight"
   lane :upload_testflight do
-    increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
-    match(type: "appstore")
-    build_app(
-	scheme: "ByeBoo-iOS",
-	export_method: "app-store"
-	)
-    upload_to_testflight
+    begin
+      increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
+      match(type: "appstore")
+      build_app(
+        scheme: "ByeBoo-iOS",
+        export_method: "app-store"
+      )
+      upload_to_testflight
+      notify_discord_success("TestFlight 업로드")
+    rescue => e
+      notify_discord_failure("TestFlight 업로드", e.message)
+      raise e
+    end
   end
 
   desc "Release a new version to the App Store"
   lane :release_app_store do
-    increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
-    match(type: "appstore")
-    build_app(
-      scheme: "ByeBoo-iOS",
-      export_method: "app-store"
-    )
-    upload_to_app_store(
-      skip_screenshots: true,
-      skip_metadata: true,
-      submit_for_review: true,   
-      force: true                
-    )
+    begin
+      increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
+      match(type: "appstore")
+      build_app(
+        scheme: "ByeBoo-iOS",
+        export_method: "app-store"
+      )
+      upload_to_app_store(
+        skip_screenshots: true,
+        skip_metadata: true,
+        submit_for_review: true,
+        force: true
+      )
+      notify_discord_success("App Store 배포")
+    rescue => e
+      notify_discord_failure("App Store 배포", e.message)
+      raise e
+    end
   end
-end
+
 end

--- a/ByeBoo-iOS/fastlane/Fastfile
+++ b/ByeBoo-iOS/fastlane/Fastfile
@@ -29,4 +29,21 @@ platform :ios do
 	)
     upload_to_testflight
   end
+
+  desc "Release a new version to the App Store"
+  lane :release_app_store do
+    increment_build_number(xcodeproj: "ByeBoo-iOS.xcodeproj")
+    match(type: "appstore")
+    build_app(
+      scheme: "ByeBoo-iOS",
+      export_method: "app-store"
+    )
+    upload_to_app_store(
+      skip_screenshots: true,
+      skip_metadata: true,
+      submit_for_review: true,   
+      force: true                
+    )
+  end
+end
 end


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #485 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Github Action와 Fastlane을 통한 자동 배포를 설정했습니다. 
- Github Action에 관련 시크릿 key를 추가하였습니다. 
- develop PR이 머지되면 TestFlight로, main PR이 머지되면 앱스토어 배포로 되도록 하였습니다. 
- 배포가 끝나면 디스코드 웹훅으로 알림이 오도록 설정했습니다. 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[참고 링크](http://ukseung2.tistory.com/entry/iOS-Fastlane-Github-Action%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%9E%90%EB%8F%99%EB%B0%B0%ED%8F%AC-2)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * TestFlight 배포를 위한 자동화된 빌드 및 업로드 과정이 추가되었습니다.
  * App Store 제출 및 자동 출시를 지원합니다.
  * 배포 성공·실패 상태를 Discord 알림으로 확인할 수 있습니다.

* **개선 사항**
  * 브랜치별로 테스트 배포와 정식 출시 절차가 자동 실행됩니다.
  * 빌드 번호가 TestFlight 업로드 과정에서 자동으로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->