### PR TITLE
Feat/#491 공통여정 믹스패널

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Home/ViewController/NotificationsViewController.swift
@@ -8,6 +8,8 @@
 import Combine
 import UIKit
 
+import Mixpanel
+
 final class NotificationsViewController: BaseViewController {
     
     private let rootView = NoticesView()
@@ -30,6 +32,8 @@ final class NotificationsViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         viewModel.action(.viewWillAppear)
+        
+        Mixpanel.mainInstance().track(event: AlarmEvents.Name.alarmMain)
     }
     
     override func viewDidLoad() {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
@@ -303,6 +303,8 @@ extension CommonQuestHistoryViewController {
                 case .success(let result):
                     let entity = result.entity
                     self?.rootView.questContentView.updateUI(likeCount: entity.likeCount, isLiked: entity.isLiked)
+                    
+                    Mixpanel.mainInstance().track(event: CommonJourneyEvents.Name.commonJourneyLike)
                 case .failure(let error):
                     ByeBooLogger.error(error)
                 }
@@ -319,6 +321,8 @@ extension CommonQuestHistoryViewController {
                 case .success:
                     ByeBooLogger.debug("댓글 입력 성공")
                     self.scrollToComment()
+                    
+                    Mixpanel.mainInstance().track(event: CommonJourneyEvents.Name.commonJourneyComment)
                 case .failure(let error):
                     ByeBooLogger.debug(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestHistoryViewController.swift
@@ -270,7 +270,7 @@ extension CommonQuestHistoryViewController {
         rootView.configure(
             answerID: answerID,
             question: entity.question,
-            writtenAt: ServerDateFormatter.shared.relativeTimeString(from: answer.writtenAt) ?? "", //TODO: ViewModel로 수정
+            writtenAt: ServerDateFormatter.shared.relativeTimeString(from: answer.writtenAt) ?? "",
             profileIcon: ProfileIcon.image(for: answer.profileIcon) ?? .relievedBadge,
             nickname: answer.writer,
             content: answer.content,

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestMyAnswersViewController.swift
@@ -8,6 +8,8 @@
 import Combine
 import UIKit
 
+import Mixpanel
+
 final class CommonQuestMyAnswersViewController: BaseViewController {
     
     private let rootView = CommonQuestMyAnswersView()
@@ -112,6 +114,8 @@ extension CommonQuestMyAnswersViewController {
                         likeCount: entity.likeCount,
                         isLiked: entity.isLiked
                     )
+                    
+                    Mixpanel.mainInstance().track(event: CommonJourneyEvents.Name.commonJourneyLike)
                 case .failure(let error):
                     ByeBooLogger.error(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestReplyViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestReplyViewController.swift
@@ -8,6 +8,8 @@
 import Combine
 import UIKit
 
+import Mixpanel
+
 final class CommonQuestReplyViewController: BaseViewController {
     
     private let rootView = CommonQuestReplyView()
@@ -106,6 +108,8 @@ extension CommonQuestReplyViewController {
                 case .success:
                     ByeBooLogger.debug("답글 입력 성공")
                     self.scrollToComment()
+                    
+                    Mixpanel.mainInstance().track(event: CommonJourneyEvents.Name.commonJourneyComment)
                 case .failure(let error):
                     ByeBooLogger.debug(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/CommonQuestViewController.swift
@@ -94,6 +94,8 @@ extension CommonQuestViewController {
                 case .success(let result):
                     let entity = result.entity
                     self?.updateLikeCount(answerID: result.answerID, likeCount: entity.likeCount, isLiked: entity.isLiked)
+                    
+                    Mixpanel.mainInstance().track(event: CommonJourneyEvents.Name.commonJourneyLike)
                 case .failure(let error):
                     ByeBooLogger.error(error)
                 }

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Mixpanel/AlarmEvents.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Mixpanel/AlarmEvents.swift
@@ -1,0 +1,14 @@
+//
+//  AlarmEvents.swift
+//  ByeBoo-iOS
+//
+//  Created by 이나연 on 8/18/26.
+//
+
+import Mixpanel
+
+struct AlarmEvents {
+    enum Name {
+        static let alarmMain = "alarm_main"
+    }
+}

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Mixpanel/CommonJourneyEvents.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Mixpanel/CommonJourneyEvents.swift
@@ -13,5 +13,7 @@ struct CommonJourneyEvents {
         static let commonJourneyWriteClick = "common_journey_write_click"
         static let commonJourneyWriteSuccess = "common_journey_write_success"
         static let commonJourneyOthersAnswerPageview = "common_journey_others_answer_pageview"
+        static let commonJourneyComment = "common_journey_comment"
+        static let commonJourneyLike = "common_journey_like"
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #491 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 공통여정 댓글, 좋아요 & 알람 진입 시 믹스패널 이벤트 추가했습니다. 
- 수정 시에는 따로 이벤트 추가하지 않았고, 댓글&답글 작성 시에만 달았습니다. (기획이랑 이야기 완료!!) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 알림 화면 진입과 공통 여정의 좋아요·댓글 활동이 더욱 일관되게 기록됩니다.
  - 공통 퀘스트 답변 및 답글 작성 후 활동 정보 반영이 개선되었습니다.
  - 알림과 공통 여정 관련 주요 사용자 활동을 체계적으로 확인할 수 있도록 기록 항목을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->