### PR TITLE
Hotfix/#503 크래시 해결

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
+++ b/ByeBoo-iOS/ByeBoo-iOS.xcodeproj/project.pbxproj
@@ -310,7 +310,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ByeBoo-iOS/ByeBoo-Dev.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
@@ -328,7 +328,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -354,7 +354,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z6682N5G5D;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -371,7 +371,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heartz.ByeBoo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/App/SceneDelegate.swift
@@ -46,12 +46,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         NotificationCenter.default.removeObserver(self, name: .navigateLoginViewController, object: nil)
     }
     
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        NotificationCenter.default.post(
-            name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
-    }
+    func sceneDidBecomeActive(_ scene: UIScene) { }
     
     func sceneWillResignActive(_ scene: UIScene) { }
     


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #503

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Firebase Remote config를 어제 분명히 수정해서 게시했는데 계속 1.3.0으로 오고 있어서 이 부분을 다시 1.2.5로 수정했습니다. 
- SceneDelegate와 Splash에서 중복호출되는 옵저버가 있어서 씬델리게이트에 있는 코드를 제거했습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 앱 버전이 1.2.5로 업데이트되었습니다.
  - 빌드 번호가 1로 재설정되었습니다.

- **버그 수정**
  - 앱이 다시 활성화될 때 불필요한 활성화 알림이 발생하지 않도록 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->