### PR TITLE
Refactor/#519 퀘스트 검색 로직 개선

### DIFF
--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/QuestCheckViewController.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewController/QuestCheckViewController.swift
@@ -185,23 +185,14 @@ extension QuestCheckViewController {
     }
     
     private func scrollToStep() {
-        guard let sectionIndex = findCurrentStepSectionIndex(),
-              let step = viewModel.getStep(section: sectionIndex) else { return }
+        let sectionIndex = viewModel.currentQuestIndexPath.section
+        guard let step = viewModel.getStep(section: sectionIndex) else { return }
        
         if isLastStep(stepNumber: step.stepNumber) {
             scrollToBottom()
             return
         }
         scrollToHeader(at: sectionIndex)
-    }
-    
-    private func findCurrentStepSectionIndex() -> Int? {
-        for (sectionIndex, step) in viewModel.steps.enumerated() {
-            if step.quests.contains(where: { $0.questNumber == viewModel.currentStep }) {
-                return sectionIndex
-            }
-        }
-        return nil
     }
     
     private func isLastStep(stepNumber: Int) -> Bool {

--- a/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/ProgressingQuestsViewModel.swift
+++ b/ByeBoo-iOS/ByeBoo-iOS/Presentation/Feature/Quest/ViewModel/ProgressingQuestsViewModel.swift
@@ -26,6 +26,7 @@ final class ProgressingQuestsViewModel {
     
     private(set) var questsEntity: ProgressingQuestsEntity?
     private var timeCancellabels: AnyCancellable?
+    private var questIndexMap: [Int: IndexPath] = [:]
     
     init(
         progressingQuestsUseCase: GetProgressingQuestsUseCase,
@@ -70,7 +71,8 @@ final class ProgressingQuestsViewModel {
             do {
                 let questsEntity = try await progressingQuestsUseCase.execute()
                 self.questsEntity = questsEntity
-                self.setQuestTimer()
+                setQuestTimer()
+                buildQuestIndexMap(from: questsEntity)
                 questsSubject.send(.success(questsEntity))
                 loadingSubject.send(false)
             } catch(let error as ByeBooError) {
@@ -125,6 +127,16 @@ final class ProgressingQuestsViewModel {
     private func formatTime(_ hours: Int, _ minutes: Int) -> String {
         String(format: "%02d:%02d", hours, minutes)
     }
+    
+    private func buildQuestIndexMap(from quests: ProgressingQuestsEntity) {
+        questIndexMap = [:]
+        
+        for (sectionIndex, step) in quests.steps.enumerated() {
+            for (itemIndex, quest) in step.quests.enumerated() {
+                questIndexMap[quest.questNumber] = IndexPath(item: itemIndex, section: sectionIndex)
+            }
+        }
+    }
 }
 
 extension ProgressingQuestsViewModel {
@@ -138,15 +150,7 @@ extension ProgressingQuestsViewModel {
         )
     }
     var currentQuestIndexPath: IndexPath {
-        var indexPath = IndexPath()
-        
-        for (sectionIndex, step) in steps.enumerated() {
-            if let itemIndex = step.quests.firstIndex(where: { $0.questNumber == currentStep }) {
-                indexPath = IndexPath(item: itemIndex, section: sectionIndex)
-                break
-            }
-        }
-        return indexPath
+        questIndexMap[currentStep] ?? IndexPath()
     }
     
     func getStep(section: Int) -> StepEntity? {
@@ -180,13 +184,11 @@ extension ProgressingQuestsViewModel {
     }
     
     func findQuest(questNumber: Int) -> QuestEntity? {
-        for (sectionIndex, step) in steps.enumerated() {
-            if let itemIndex = step.quests.firstIndex(where: { $0.questNumber == questNumber }) {
-                return getQuest(section: sectionIndex, item: itemIndex)
-            }
+        guard let indexPath = questIndexMap[questNumber] else {
+            return nil
         }
         
-        return nil
+        return getQuest(section: indexPath.section, item: indexPath.item)
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #519

## 📄 작업 내용
- `ProgressingQuestsViewModel`의 `currentQuestIndexPath`, `findQuest`가 매번 `steps → quests`를 이중으로 선형 탐색하던 방식을, `questNumber`를 키로 하는 `[Int: IndexPath]` 캐시 조회로 변경했습니다. (탐색 O(n) → O(1))
- `QuestCheckViewController`에 동일한 선형 탐색 로직으로 중복 구현되어 있던 `findCurrentStepSectionIndex()`를 제거하고, `viewModel.currentQuestIndexPath.section`을 사용하도록 정리했습니다.

|    구현 내용    |   개선 전   |   개선 후   |
| :-------------: | :----------: | :----------: |
| 코드 | <img src = "https://github.com/user-attachments/assets/418fe808-e0a1-4876-84ee-dd7292d9b015" width ="500"> | <img src = "https://github.com/user-attachments/assets/251626e7-a164-4482-9c45-01c3576a412c" width ="500"> |

## 💻 주요 코드 설명
`ProgressingQuestsViewModel`
- `buildQuestIndexMap` 메서드에서 `[Int: IndexPath]` 형태의 딕셔너리를 생성합니다. 이때 Int는 `questNumber`을 의미합니다.
```swift
private func buildQuestIndexMap(from quests: ProgressingQuestsEntity) {
    questIndexMap = [:]
    
    for (sectionIndex, step) in quests.steps.enumerated() {
        for (itemIndex, quest) in step.quests.enumerated() {
            questIndexMap[quest.questNumber] = IndexPath(item: itemIndex, section: sectionIndex)
        }
    }
}
```

- 아래는 `questNumber`에 해당하는 퀘스트를 찾는 함수입니다. `indexPath`를 바로 찾아내어 `getQuest` 메서드를 호출할 수 있습니다.
```swift
func findQuest(questNumber: Int) -> QuestEntity? {
    guard let indexPath = questIndexMap[questNumber] else {
        return nil
    }
    
    return getQuest(section: indexPath.section, item: indexPath.item)
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선**
  - 퀘스트 진행 중 현재 단계로 이동하는 처리를 개선했습니다.
  - 퀘스트 조회 및 현재 위치 확인 성능을 향상했습니다.
  - 퀘스트 목록을 불러온 후 현재 퀘스트 위치가 더 효율적으로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->